### PR TITLE
feat: add property owners SFTP to GCS pipeline

### DIFF
--- a/.github/workflows/property_owners_sftp_transfer.yml
+++ b/.github/workflows/property_owners_sftp_transfer.yml
@@ -1,0 +1,74 @@
+name: Weekly Property Owners SFTP to GCS Transfer
+
+on:
+  schedule:
+    # Run every Monday at 2 AM UTC
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+    # Allow manual triggering for testing
+
+jobs:
+  create-transfer-vm:
+    name: Create Property Owners SFTP Transfer VM
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Create SFTP Transfer VM
+      run: |
+        # Generate unique VM name with timestamp
+        VM_NAME="property-owners-sftp-$(date +%Y%m%d-%H%M%S)"
+        PROJECT_ID="landbrugsdata-1"
+        ZONE="europe-west1-b"
+        
+        echo "Creating SFTP transfer VM: $VM_NAME"
+        
+        # Create the VM with startup script
+        gcloud compute instances create $VM_NAME \
+          --project=$PROJECT_ID \
+          --zone=$ZONE \
+          --machine-type=e2-small \
+          --network-interface=address=sftp-transfer-static-ip,network-tier=PREMIUM,subnet=default \
+          --boot-disk-size=30GB \
+          --boot-disk-type=pd-balanced \
+          --image-family=debian-12 \
+          --image-project=debian-cloud \
+          --scopes=https://www.googleapis.com/auth/cloud-platform \
+          --metadata=enable-oslogin=true \
+          --metadata-from-file=startup-script=backend/pipelines/property_owners_sftp/sftp-transfer-startup.sh \
+          --preemptible \
+          --no-restart-on-failure \
+          --maintenance-policy=TERMINATE
+        
+        echo "✅ VM $VM_NAME created successfully"
+        echo "The VM will automatically:"
+        echo "  1. Install dependencies"
+        echo "  2. Download latest file from SFTP server (property owners data)"
+        echo "  3. Upload to GCS bucket: landbrugsdata-raw-data/bronze/property_owners/"
+        echo "  4. Delete itself when complete"
+        
+        # Optional: Wait a few minutes and check if VM still exists (means it failed)
+        echo "Waiting 5 minutes to check transfer status..."
+        sleep 300
+        
+        if gcloud compute instances describe $VM_NAME --zone=$ZONE --project=$PROJECT_ID >/dev/null 2>&1; then
+          echo "⚠️  VM still exists after 5 minutes - transfer may have failed"
+          echo "Check VM logs: gcloud compute instances get-serial-port-output $VM_NAME --zone=$ZONE --project=$PROJECT_ID"
+        else
+          echo "✅ VM has been deleted - transfer likely completed successfully"
+        fi 

--- a/backend/pipelines/property_owners_sftp/sftp-transfer-startup.sh
+++ b/backend/pipelines/property_owners_sftp/sftp-transfer-startup.sh
@@ -1,0 +1,474 @@
+#!/bin/bash
+
+# Startup script for SFTP to GCS transfer VM
+# This script runs when the VM starts, performs the transfer, and DELETION IS CURRENTLY DISABLED FOR DEBUGGING
+
+set -e
+
+# Log everything
+exec > >(tee /var/log/sftp-transfer.log) 2>&1
+echo "Starting SFTP to GCS transfer at $(date)"
+sync # Try to flush initial log
+
+# Install required packages
+apt-get update
+apt-get install -y python3-pip python3-venv git dnsutils iputils-ping
+
+# Create virtual environment
+python3 -m venv /opt/transfer-env
+source /opt/transfer-env/bin/activate
+
+# Install required Python packages
+pip install google-cloud-storage google-cloud-secret-manager paramiko
+
+# Create the transfer script
+cat > /opt/transfer_script.py << 'EOF'
+#!/usr/bin/env python3
+
+import os
+import tempfile
+import logging
+import paramiko
+from datetime import datetime
+from pathlib import Path
+from google.cloud import storage, secretmanager
+import subprocess
+import sys
+import traceback # Added for more detailed error logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Handler to flush logs immediately
+class FlushFileHandler(logging.FileHandler):
+    def emit(self, record):
+        super().emit(record)
+        self.flush()
+
+# If you want to log to a file within the python script as well (optional)
+# file_handler = FlushFileHandler('/var/log/python_transfer_details.log')
+# formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+# file_handler.setFormatter(formatter)
+# logger.addHandler(file_handler)
+
+def flush_logs():
+    """Ensure stdout and stderr are flushed."""
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+class SFTPToGCSTransfer:
+    def __init__(self):
+        self.project_id = "landbrugsdata-1"
+        self.bucket_name = "landbrugsdata-raw-data"
+        self.storage_client = storage.Client()
+        self.secret_client = secretmanager.SecretManagerServiceClient()
+        logger.info("SFTPToGCSTransfer class initialized.")
+        flush_logs()
+
+    def get_secret(self, secret_name):
+        logger.debug(f"Attempting to get secret: {secret_name}")
+        flush_logs()
+        name = f"projects/{self.project_id}/secrets/{secret_name}/versions/latest"
+        try:
+            response = self.secret_client.access_secret_version(name=name)
+            secret_value = response.payload.data.decode('UTF-8').strip()
+            logger.debug(f"Successfully retrieved secret: {secret_name}")
+            flush_logs()
+            return secret_value
+        except Exception as e:
+            logger.error(f"Failed to retrieve secret: {secret_name}. Error: {e}")
+            logger.error(traceback.format_exc())
+            flush_logs()
+            raise
+
+    def get_sftp_client(self):
+        logger.info("Attempting to create SFTP client...")
+        flush_logs()
+        try:
+            host = self.get_secret("datafordeler-sftp-host")
+            username = self.get_secret("datafordeler-sftp-username")
+            private_key_data = self.get_secret("ssh-brugerdatafordeleren")
+            
+            ssh = paramiko.SSHClient()
+            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            
+            import socket
+            import time
+            
+            def resolve_hostname_with_retry(hostname, max_attempts=5, delay=10):
+                logger.info(f"Starting DNS resolution for {hostname}.")
+                flush_logs()
+                for attempt in range(1, max_attempts + 1):
+                    try:
+                        logger.debug(f"DNS RESOLUTION ATTEMPT {attempt}/{max_attempts} for {hostname}")
+                        flush_logs()
+                        
+                        # Test system DNS tools first
+                        try:
+                            logger.debug("Testing with getent...")
+                            flush_logs()
+                            result = subprocess.run(['getent', 'hosts', hostname], 
+                                                  capture_output=True, text=True, timeout=10)
+                            if result.returncode == 0:
+                                logger.debug(f"getent result: {result.stdout.strip()}")
+                            else:
+                                logger.warning(f"getent failed for {hostname}: {result.stderr}")
+                            flush_logs()
+                        except Exception as e:
+                            logger.warning(f"getent test failed for {hostname}: {e}")
+                            flush_logs()
+                        
+                        try:
+                            logger.debug("Testing with nslookup...")
+                            flush_logs()
+                            result = subprocess.run(['nslookup', hostname], 
+                                                  capture_output=True, text=True, timeout=10)
+                            if result.returncode == 0 and result.stdout:
+                                logger.debug(f"nslookup stdout for {hostname}: {result.stdout.strip()}")
+                            elif result.stderr:
+                                logger.warning(f"nslookup stderr for {hostname}: {result.stderr.strip()}")
+                            flush_logs()
+                        except Exception as e:
+                            logger.warning(f"nslookup test failed for {hostname}: {e}")
+                            flush_logs()
+                        
+                        logger.debug(f"Attempting Python DNS resolution for {hostname}")
+                        flush_logs()
+                        try:
+                            logger.debug("Trying socket.getaddrinfo...")
+                            flush_logs()
+                            result = socket.getaddrinfo(hostname, None, socket.AF_INET)
+                            ip = result[0][4][0]
+                            logger.info(f"DNS resolution successful: {hostname} -> {ip}")
+                            flush_logs()
+                            return ip
+                        except Exception as e:
+                            logger.warning(f"getaddrinfo failed for {hostname}: {e}")
+                            flush_logs()
+                        
+                    except socket.gaierror as e:
+                        logger.warning(f"DNS resolution attempt {attempt} for {hostname} failed with gaierror: {e}")
+                        logger.warning(f"Error details: errno={getattr(e, 'errno', 'unknown')}")
+                        
+                        if attempt < max_attempts:
+                            logger.info(f"Waiting {delay} seconds before DNS retry for {hostname} (attempt {attempt+1}/{max_attempts})...")
+                            flush_logs()
+                            time.sleep(delay)
+                        else:
+                            logger.error(f"All DNS resolution attempts failed for {hostname}")
+                            flush_logs()
+                            raise
+                    except Exception as e:
+                        logger.error(f"Unexpected error in DNS resolution attempt {attempt}: {e}")
+                        logger.error(f"Error type: {type(e).__name__}")
+                        logger.error(f"Traceback: {traceback.format_exc()}")
+                        flush_logs()
+                        if attempt < max_attempts:
+                            logger.info(f"Waiting {delay} seconds before retry...")
+                            flush_logs()
+                            time.sleep(delay)
+                        else:
+                            logger.error(f"All DNS resolution attempts failed for {hostname}")
+                            flush_logs()
+                            raise
+            
+            host_ip = resolve_hostname_with_retry(host)
+            
+            try:
+                logger.info(f"Testing TCP connection to {host_ip}:22...")
+                flush_logs()
+                sock = socket.create_connection((host_ip, 22), timeout=30)
+                sock.close()
+                logger.info("TCP connection successful")
+                flush_logs()
+            except Exception as e:
+                logger.error(f"TCP connection failed: {e}")
+                logger.error(traceback.format_exc())
+                flush_logs()
+                raise
+            
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.key') as key_file:
+                key_file.write(private_key_data)
+                if not private_key_data.endswith('\n'):
+                    key_file.write('\n')
+                key_file.flush()
+                key_file_path = key_file.name # Store for logging
+                logger.debug(f"Private key written to temporary file: {key_file_path}")
+                flush_logs()
+
+                try:
+                    logger.debug(f"Loading RSA private key from temporary file...")
+                    flush_logs()
+                    private_key = paramiko.RSAKey.from_private_key_file(key_file_path)
+                    logger.debug("RSA key loaded successfully")
+                    flush_logs()
+                    
+                    logger.info(f"Attempting SSH connection to {host_ip} (user: {username})...")
+                    flush_logs()
+                    ssh.connect(
+                        hostname=host_ip, port=22, username=username, pkey=private_key,
+                        timeout=60, banner_timeout=30, auth_timeout=30,
+                        disabled_algorithms={'pubkeys': [], 'kex': [], 'keys': [], 'ciphers': [], 'macs': []},
+                        allow_agent=False, look_for_keys=False
+                    )
+                    # logger.info(f"SSH connection established successfully. Server version: {ssh.get_transport().server_version}, Client version: {ssh.get_transport().local_version}")
+                    # Attempting a more robust way to get server banner, or just a generic success message
+                    banner = ssh.get_transport().get_banner()
+                    if banner:
+                        logger.info(f"SSH connection established successfully. Server banner: {banner.strip()}")
+                    else:
+                        logger.info("SSH connection established successfully.")
+                    flush_logs()
+                    
+                    sftp = ssh.open_sftp()
+                    # logger.info(f"SFTP session opened successfully. Server SFTP version: {sftp.protocol.version}")
+                    logger.info("SFTP session opened successfully.") # Simplified logging
+                    flush_logs()
+                    return sftp
+                except Exception as e:
+                    logger.error(f"SSH/SFTP connection failed: {e}")
+                    logger.error(traceback.format_exc())
+                    flush_logs()
+                    raise
+                finally:
+                    logger.info(f"Deleting temporary key file: {key_file_path}")
+                    flush_logs()
+                    os.unlink(key_file_path)
+                    
+        except Exception as e:
+            logger.error(f"Failed to connect to SFTP: {e}")
+            logger.error(traceback.format_exc())
+            flush_logs()
+            raise
+    
+    def find_latest_file(self, sftp):
+        logger.info("Finding latest .zip file on SFTP server...")
+        flush_logs()
+        latest_file = None
+        latest_time = None
+        
+        try:
+            for entry in sftp.listdir_attr('.'): # Check current directory
+                logger.debug(f"SFTP entry: {entry.filename}, mtime: {entry.st_mtime}, longname: {entry.longname}")
+                flush_logs()
+                if not entry.longname.startswith('d') and entry.filename.endswith('.zip'):
+                    if latest_time is None or entry.st_mtime > latest_time:
+                        latest_file = entry.filename
+                        latest_time = entry.st_mtime
+                        logger.debug(f"New latest candidate: {latest_file} (mtime: {latest_time})")
+                        flush_logs()
+            
+            if latest_file is None:
+                logger.error("No .zip files found on SFTP server in current directory.")
+                flush_logs()
+                raise FileNotFoundError("No .zip files found on SFTP server")
+                
+            logger.info(f"Found latest file: {latest_file}")
+            flush_logs()
+            return latest_file
+        except Exception as e:
+            logger.error(f"Error finding latest file on SFTP server: {e}")
+            logger.error(traceback.format_exc())
+            flush_logs()
+            raise
+
+    def transfer_file(self):
+        logger.info("Starting file transfer process...")
+        flush_logs()
+        sftp = None
+        try:
+            logger.info("Connecting to SFTP server for transfer...")
+            flush_logs()
+            sftp = self.get_sftp_client()
+            
+            latest_file = self.find_latest_file(sftp)
+            
+            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+            gcs_filename = f"bronze/property_owners/{timestamp}_{latest_file}"
+            
+            bucket = self.storage_client.bucket(self.bucket_name)
+            blob = bucket.blob(gcs_filename)
+            
+            logger.info(f"Target GCS path: gs://{self.bucket_name}/{gcs_filename}")
+            flush_logs()
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                local_path = Path(tmpdir) / latest_file
+                logger.debug(f"Temporary local path for download: {local_path}")
+                flush_logs()
+
+                # SFTP Download
+                try:
+                    logger.info(f"Attempting SFTP download: {latest_file}...")
+                    flush_logs()
+                    sftp.get(latest_file, str(local_path))
+                    logger.info(f"SFTP download of {latest_file} complete. Local file size: {local_path.stat().st_size} bytes.")
+                    flush_logs()
+                except Exception as e:
+                    logger.error(f"SFTP download of {latest_file} failed: {e}")
+                    logger.error(traceback.format_exc())
+                    flush_logs()
+                    raise # Re-raise to be caught by outer try/except
+
+                # GCS Upload
+                try:
+                    logger.info(f"Attempting GCS upload for {latest_file} to {gcs_filename}...")
+                    flush_logs()
+                    blob.upload_from_filename(str(local_path))
+                    logger.info(f"GCS upload complete for {gcs_filename}.")
+                    flush_logs()
+                except Exception as e:
+                    logger.error(f"GCS upload of {local_path} failed: {e}")
+                    logger.error(traceback.format_exc())
+                    flush_logs()
+                    raise # Re-raise to be caught by outer try/except
+
+            logger.info("File transfer process completed successfully.")
+            flush_logs()
+
+        except Exception as e:
+            logger.error(f"Overall transfer_file process failed: {e}")
+            logger.error(traceback.format_exc()) # Log full traceback
+            flush_logs()
+            # Do not re-raise here if we want the script to attempt cleanup/VM deletion
+            # However, for debugging, re-raising might be useful if not deleting VM
+            raise # Re-raise for now as VM deletion is disabled
+        finally:
+            if sftp:
+                try:
+                    logger.info("Closing SFTP connection...")
+                    flush_logs()
+                    sftp.close()
+                    if sftp.sock: # If transport is open
+                        sftp.sock.close()
+                    logger.info("SFTP connection closed.")
+                    flush_logs()
+                except Exception as e:
+                    logger.warning(f"Error closing SFTP connection: {e}")
+                    logger.error(traceback.format_exc())
+                    flush_logs()
+
+def main_transfer_and_shutdown():
+    logger.info("=== Starting main_transfer_and_shutdown ===")
+    flush_logs()
+    transfer_instance = None
+    success = False
+    try:
+        transfer_instance = SFTPToGCSTransfer()
+        transfer_instance.transfer_file()
+        logger.info("Transfer process initiated and returned from transfer_file method.")
+        flush_logs()
+        # Assuming if transfer_file doesn't raise an exception, it's a success for now
+        # More robust success checking might be needed (e.g., check GCS object existence)
+        success = True # Mark as success if no exceptions from transfer_file
+    except Exception as e:
+        logger.error(f"An error occurred in main_transfer_and_shutdown: {e}")
+        logger.error(traceback.format_exc())
+        flush_logs()
+        # success remains False
+    finally:
+        logger.info(f"Transfer success status: {success}")
+        logger.info("--- DEBUG: VM Deletion is currently disabled ---")
+        flush_logs()
+        # delete_vm() # DEBUG: Temporarily commented out
+        # if success:
+        #    logger.info("Transfer successful, preparing to delete VM.")
+        #    delete_vm()
+        # else:
+        #    logger.error("Transfer failed, VM will NOT be deleted due to errors (or if deletion is disabled).")
+        
+    logger.info("=== main_transfer_and_shutdown finished ===")
+    flush_logs()
+
+if __name__ == "__main__":
+    # Add DNS debug before actual script run
+    logger.info("=== Initial DNS DEBUG (Pre-Transfer) ===")
+    flush_logs()
+    # subprocess.run(["echo", "Testing DNS resolution for ftp2.datafordeler.dk..."], check=False) # Removed
+    # subprocess.run(["echo", "System time: $(date)"], check=False) # Removed
+    # subprocess.run(["echo", "Uptime: $(uptime)"], check=False) # Removed
+    # subprocess.run(["echo", "--- nslookup test ---"], check=False) # Removed
+    # subprocess.run(["nslookup", "ftp2.datafordeler.dk"], check=False) # Removed
+    # subprocess.run(["echo", "--- dig test ---"], check=False) # Removed
+    # subprocess.run(["dig", "ftp2.datafordeler.dk"], check=False) # Removed
+    # subprocess.run(["echo", "--- ping test ---\\"], check=False) # Removed
+    # ping_result = subprocess.run(["ping", "-c", "2", "-W", "5", "ftp2.datafordeler.dk"], capture_output=True, text=True) # Removed
+    # logger.info(f"Ping stdout: {ping_result.stdout}") # Removed
+    # logger.info(f"Ping stderr: {ping_result.stderr}") # Removed
+    # if ping_result.returncode != 0: # Removed
+    #    logger.warning(f"ping failed with code {ping_result.returncode}") # Removed
+    # subprocess.run(["echo", "--- getent test ---"], check=False) # Removed
+    # subprocess.run(["getent", "hosts", "ftp2.datafordeler.dk"], check=False) # Removed
+    
+    logger.info("Performing a quick Python socket test for DNS...")
+    python_socket_test_command = '''import socket, time; \
+print(f"Pre-transfer DNS check at {time.time()}:"); \
+try: \
+    ip = socket.gethostbyname(\'ftp2.datafordeler.dk\'); \
+    print(f"Python socket.gethostbyname(\'ftp2.datafordeler.dk\') SUCCESS: {ip}"); \
+    addr_info = socket.getaddrinfo(\'ftp2.datafordeler.dk\', None, socket.AF_INET); \
+    print(f"Python socket.getaddrinfo(\'ftp2.datafordeler.dk\') SUCCESS: {addr_info[0][4][0]}"); \
+except Exception as e: \
+    print(f"Pre-transfer DNS check FAILED: {e}")'''
+    subprocess.run(["python3", "-c", python_socket_test_command], check=False)
+    
+    # subprocess.run(["echo", "--- Python socket test ---"], check=False) # Combined above
+    # Fixed f-string issue by constructing the command string carefully
+    # python_socket_test_command = '''import socket, time; \
+# print(f"Testing at {time.time()}"); \
+# print(f"Python socket.gethostbyname SUCCESS: {socket.gethostbyname(\\'ftp2.datafordeler.dk\\')}"); \
+# print(f"Python socket.getaddrinfo SUCCESS: {socket.getaddrinfo(\\'ftp2.datafordeler.dk\\', None, socket.AF_INET)[0][4][0]}")'''
+    # subprocess.run(["python3", "-c", python_socket_test_command], check=False) # Combined above
+    # subprocess.run(["echo", "--- systemd-resolved status ---"], check=False) # Removed
+    # subprocess.run(["systemctl", "status", "systemd-resolved.service", "--no-pager"], check=False) # Removed
+    # subprocess.run(["echo", "--- /etc/resolv.conf ---"], check=False) # Removed
+    # subprocess.run(["cat", "/etc/resolv.conf"], check=False) # Removed
+    logger.info("=== END Initial DNS DEBUG ===")
+    flush_logs()
+    # sync # Try to flush logs before python script <-- This was the misplaced sync
+
+    logger.info("Running SFTP to GCS transfer...")
+    flush_logs()
+    
+    main_transfer_and_shutdown()
+    logger.info("Python script /opt/transfer_script.py finished.")
+    flush_logs()
+    # sync # Try to flush logs after python script
+
+EOF
+
+chmod +x /opt/transfer_script.py
+
+# Get current VM name and zone for self-deletion
+VM_NAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name)
+ZONE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone | awk -F/ '{print $NF}')
+PROJECT_ID=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
+
+# Function to delete the VM
+delete_vm() {
+  echo "Attempting to delete VM: $VM_NAME in zone: $ZONE project: $PROJECT_ID"
+  sync
+  gcloud compute instances delete "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --quiet
+  echo "gcloud delete command executed for $VM_NAME. Check console for status."
+  # echo "DEBUG: VM Deletion is currently disabled. Would have deleted $VM_NAME."
+  sync
+}
+
+# Run the transfer script
+echo "Executing /opt/transfer_script.py..."
+sync # Try to flush logs before python script - MOVED HERE
+python3 /opt/transfer_script.py || (echo "Python script failed with an error." && echo "ERROR: Python script failed. VM deletion still disabled for debugging." >&2)
+
+echo "SFTP to GCS transfer script finished its course at $(date)."
+
+# DEBUG: VM Deletion is currently disabled
+#echo "INFO: VM Deletion is currently DISABLED. You will need to manually delete this VM: $(hostname)"
+echo "VM will self-delete in 1 minute to allow log inspection if needed."
+sleep 60
+delete_vm
+
+# Final sync before potential shutdown (though shutdown is disabled)
+sync
+echo "Script finished."
+exit 0 


### PR DESCRIPTION
## 🛠️ Issue Fix
bronze for #289, needs to clean up separately
No issue linked
<!-- If there's no issue, you can write "No issue linked" -->

## 💡 Solution
<!-- Briefly describe the solution or changes introduced in this PR -->
This PR introduces a new automated pipeline to transfer property owner data weekly from an external SFTP server to Google Cloud Storage (GCS).
- **What was changed and why:**
    - A new GitHub Actions workflow (`.github/workflows/property_owners_sftp_transfer.yml`) was created to:
        - Schedule a weekly run (Mondays at 2 AM UTC).
        - Allow manual triggering via `workflow_dispatch`.
        - Create a temporary Google Compute Engine (GCE) VM using a static IP (`sftp-transfer-static-ip`) in `europe-west1-b`.
        - The VM is configured to be preemptible and use an `e2-small` machine type with a 30GB `pd-balanced` boot disk.
    - A new startup script (`backend/pipelines/property_owners_sftp/sftp-transfer-startup.sh`) was created and is executed by the GCE VM. This script:
        - Installs necessary dependencies (Python, pip, gcloud, Paramiko, Google Cloud libraries).
        - Securely retrieves SFTP credentials and the SSH private key from Google Secret Manager.
        - Connects to the SFTP server (`ftp2.datafordeler.dk`).
        - Identifies the latest `.zip` file in the SFTP server's root directory.
        - Downloads the file to the VM.
        - Uploads the file to GCS at `gs://landbrugsdata-raw-data/bronze/property_owners/` with a timestamped filename.
        - Includes robust logging to `/var/log/sftp-transfer.log` on the VM.
        - Contains comprehensive DNS resolution and connectivity checks.
        - Automatically deletes the GCE VM upon completion (successful or failed transfer), after a 60-second delay to allow for log inspection if needed.
- **Relevant decisions or trade-offs:**
    - Using a GCE VM with a startup script provides a managed and isolated environment for the transfer.
    - Self-deletion of the VM minimizes costs.
    - Storing credentials in Secret Manager enhances security.
    - The GCS path `bronze/property_owners/` was chosen to align with data lake conventions.
    - Logging was initially verbose for debugging and then reduced for production.

## ✅ How to Do Self-Test
<!-- Provide instructions for how to test the changes, can be copied from README -->
1.  **Trigger Manually:** Go to the "Actions" tab in the GitHub repository.
2.  Find the "Weekly Property Owners SFTP to GCS Transfer" workflow.
3.  Click "Run workflow" and then "Run workflow" again (using the `main` branch, or this PR branch once merged/if testing branch directly).
4.  **Monitor Workflow:** Observe the GitHub Actions logs for the VM creation step.
5.  **Monitor GCS Bucket:** After a few minutes (approx. 5-10 minutes for VM startup, script execution, and upload), check the `gs://landbrugsdata-raw-data/bronze/property_owners/` GCS path for a new timestamped `.zip` file.
6.  **Verify VM Deletion (Optional but Recommended):**
    - During the 5-minute wait in the GitHub Action, or shortly after, you can check the Google Cloud Console (Compute Engine > VM Instances for project `landbrugsdata-1` in zone `europe-west1-b`) to see the temporary VM (e.g., `property-owners-sftp-YYYYMMDD-HHMMSS`).
    - The GitHub Action itself will report if the VM still exists after its 5-minute check.
    - The VM's own startup script is designed to self-delete after its operations and a 60-second delay. So, even if the GitHub Action's check is slightly off, the VM should disappear on its own. If it doesn't, the startup script logs (`/var/log/sftp-transfer.log` on the VM, accessible via SSH if it's still running) would indicate why.

## 📷 Screenshots (if applicable)
<!-- Add any relevant screenshots for UI changes -->
N/A

## 📝 Additional Notes
<!-- Add any other context or information reviewers should know -->
