### PR TITLE
Fix BBR buildings pipeline to accept 'both' source option - Add 'both…

### DIFF
--- a/backend/pipelines/bbr_buildings/main.py
+++ b/backend/pipelines/bbr_buildings/main.py
@@ -31,7 +31,7 @@ def main():
 
     parser.add_argument(
         "--source",
-        choices=["inspire_bbr", "geodanmark_wfs"],
+        choices=["inspire_bbr", "geodanmark_wfs", "both"],
         help="Data source for bronze layer (required for bronze layer)",
     )
 
@@ -100,6 +100,20 @@ def run_bronze_layer(args: argparse.Namespace, settings: Settings, logger: loggi
     elif args.source == "geodanmark_wfs":
         fetcher = GeoDanmarkWFSFetcher(settings, logger)
         fetcher.fetch_samples(output_dir)
+
+    elif args.source == "both":
+        # Run both sources sequentially
+        logger.info("Running both data sources...")
+
+        # First run INSPIRE BBR
+        logger.info("Fetching INSPIRE BBR data...")
+        inspire_fetcher = InspireBBRFetcher(settings, logger)
+        inspire_fetcher.fetch_data(output_dir, sample_size=args.sample_size)
+
+        # Then run GeoDanmark WFS
+        logger.info("Fetching GeoDanmark WFS data...")
+        geodanmark_fetcher = GeoDanmarkWFSFetcher(settings, logger)
+        geodanmark_fetcher.fetch_samples(output_dir)
 
     logger.info("Bronze layer processing completed successfully")
 


### PR DESCRIPTION
…' as valid choice for --source argument - Implement sequential execution of both inspire_bbr and geodanmark_wfs when --source both is specified - Fixes GitHub workflow error when running with source: both option

## 🛠️ Issue Fix
<!-- Describe the issue this PR fixes -->
Fixes #[ISSUE_NUMBER]
<!-- If there's no issue, you can write "No issue linked" -->

## 💡 Solution
<!-- Briefly describe the solution or changes introduced in this PR -->
- [ ] Explain what was changed and why
- [ ] Mention any relevant decisions or trade-offs

## ✅ How to Do Self-Test
<!-- Provide instructions for how to test the changes, can be copied from README -->

## 📷 Screenshots (if applicable)
<!-- Add any relevant screenshots for UI changes -->

## 📝 Additional Notes
<!-- Add any other context or information reviewers should know -->
