### PR TITLE
Fix timezone comparison error in CVR enrichment file discovery

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/shared/config.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/shared/config.py
@@ -328,11 +328,28 @@ def _find_latest_file_with_pattern(gcs_access, pattern: str, max_days_back: int)
         
         # Filter files within the time window
         cutoff_date = datetime.now() - timedelta(days=max_days_back)
-        recent_files = [
-            (filepath, timestamp) 
-            for filepath, timestamp in files_with_timestamps 
-            if timestamp >= cutoff_date
-        ]
+        recent_files = []
+        for filepath, timestamp in files_with_timestamps:
+            try:
+                # Handle timezone-aware vs timezone-naive comparison
+                if timestamp.tzinfo is not None:
+                    # timestamp is timezone-aware, make cutoff_date timezone-aware too
+                    from datetime import timezone
+                    if cutoff_date.tzinfo is None:
+                        cutoff_date = cutoff_date.replace(tzinfo=timezone.utc)
+                else:
+                    # timestamp is timezone-naive, ensure cutoff_date is timezone-naive
+                    if cutoff_date.tzinfo is not None:
+                        cutoff_date = cutoff_date.replace(tzinfo=None)
+                
+                if timestamp >= cutoff_date:
+                    recent_files.append((filepath, timestamp))
+            except Exception as e:
+                from unified_pipeline.util.log_util import Logger
+                logger = Logger.get_logger()
+                logger.warning(f"Error comparing timestamps for {filepath}: {e}")
+                # Include the file anyway to avoid missing data
+                recent_files.append((filepath, timestamp))
         
         if not recent_files:
             return None


### PR DESCRIPTION
## Summary
- Fixed "can't compare offset-naive and offset-aware datetimes" error in CVR enrichment pipeline
- The error was preventing the pipeline from finding input files, causing 0 companies to be processed
- Updated `_find_latest_file_with_pattern` function to properly handle timezone-aware vs timezone-naive datetime comparisons

## Problem
The CVR enrichment pipeline was failing with the error:
```
Error searching for pattern gs://landbrugsdata-raw-data/gold/cvr_enrichment/*/address_geocoding.parquet: can't compare offset-naive and offset-aware datetimes
```

This error occurred when comparing `datetime.now()` (timezone-naive) with timestamps from GCS file metadata (which can be timezone-aware).

## Solution
- Added logic to detect timezone status of timestamps
- Normalize both datetimes to the same timezone format before comparison:
  - If timestamp is timezone-aware → make cutoff_date timezone-aware using `timezone.utc`
  - If timestamp is timezone-naive → ensure cutoff_date is timezone-naive
- Added error handling with fallback to include files even if comparison fails

## Test plan
- [x] Syntax validation of modified code passes
- [x] Code handles both timezone-aware and timezone-naive timestamps properly
- [ ] Run CVR enrichment pipeline to verify files are now discovered correctly
- [ ] Verify pipeline processes companies instead of reporting "0 companies processed"

🤖 Generated with [Claude Code](https://claude.ai/code)