### PR TITLE
Add PLANTE_IT API credentials to unified pipeline workflows

### DIFF
--- a/.github/workflows/unified_pipeline.yml
+++ b/.github/workflows/unified_pipeline.yml
@@ -79,6 +79,8 @@ jobs:
       DATAFORDELER_PASSWORD: ${{ secrets.DATAFORDELER_PASSWORD }}
       GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
       DMI_GOV_CLOUD_API_KEY: ${{ secrets.DMI_GOV_CLOUD_API_KEY }}
+      PLANTE_IT_USERNAME: ${{ secrets.PLANTE_IT_USERNAME }}
+      PLANTE_IT_PASSWORD: ${{ secrets.PLANTE_IT_PASSWORD }}
       SAVE_LOCAL: false
     steps:
       - name: Checkout code
@@ -237,6 +239,8 @@ jobs:
     env:
       ENVIRONMENT: production
       GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
+      PLANTE_IT_USERNAME: ${{ secrets.PLANTE_IT_USERNAME }}
+      PLANTE_IT_PASSWORD: ${{ secrets.PLANTE_IT_PASSWORD }}
       SAVE_LOCAL: false
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
• Add PLANTE_IT_USERNAME and PLANTE_IT_PASSWORD environment variables to unified pipeline workflows
• Fixes pesticide compliance pipeline failures due to missing API credentials in GitHub Actions
• Ensures both main pipeline job and pesticide-processing matrix job have access to Plante IT API

## Test plan
- [ ] Verify GitHub secrets PLANTE_IT_USERNAME and PLANTE_IT_PASSWORD are configured
- [ ] Run pesticide_compliance pipeline to confirm credentials are accessible
- [ ] Validate that PlanteITAPI initialization no longer fails with credential errors

🤖 Generated with [Claude Code](https://claude.ai/code)