### PR TITLE
Fix H3 PFAS pipeline pesticide disaggregation data lookup for Y+1 pattern

### DIFF
--- a/backend/pipelines/h3_pfas_exposure_pipeline/src/h3_pfas_exposure/gold/data_loader.py
+++ b/backend/pipelines/h3_pfas_exposure_pipeline/src/h3_pfas_exposure/gold/data_loader.py
@@ -102,6 +102,23 @@ class H3DataLoader:
                 )
                 return sorted(files)[-1]  # Latest by timestamp
 
+        # Special handling for pesticide_disaggregation with Y+1 pattern
+        if not files and dataset == "pesticide_disaggregation":
+            # Try unified pipeline Y+1 format: pesticide_disaggregation_YYYY_YYYY+1/timestamp/pesticide_disaggregation_YYYY_YYYY+1.parquet
+            self.log.warning(
+                f"No unified format files found for {dataset} {year}, trying Y+1 pattern format"
+            )
+            y_plus_1_pattern = (
+                f"gs://{self.config.bucket}/gold/{dataset}_{year}_{year + 1}/*/{dataset}_{year}_{year + 1}.parquet"
+            )
+            files = self.gcs_access.list_files(y_plus_1_pattern)
+
+            if files:
+                self.log.info(
+                    f"Found Y+1 pattern format files for {dataset} {year}: {len(files)} files"
+                )
+                return sorted(files)[-1]  # Latest by timestamp
+
         if not files:
             # Fallback to legacy format for backward compatibility
             self.log.warning(


### PR DESCRIPTION
## Summary

- Fix H3 PFAS pipeline to correctly locate pesticide disaggregation data using the unified pipeline's Y+1 naming convention
- Add support for `pesticide_disaggregation_YYYY_YYYY+1` path pattern in data loader
- Resolves "No pesticide disaggregation data found" error when running H3 PFAS analysis

## Problem

The H3 PFAS exposure pipeline was failing to find pesticide disaggregation data for 2021, throwing:
```
ERROR | No pesticide disaggregation data found for year 2021
```

## Root Cause

The unified pipeline saves pesticide disaggregation data with a year range naming convention:
- Pattern: `pesticide_disaggregation_{year}_{year+1}`  
- Example: `pesticide_disaggregation_2021_2022` for 2021 analysis data

However, the H3 PFAS data loader was only checking for single year patterns like `pesticide_disaggregation_2021`.

## Solution

Added a new pattern check specifically for pesticide disaggregation data in `_get_latest_gold_path()`:

```python
# Special handling for pesticide_disaggregation with Y+1 pattern
if not files and dataset == "pesticide_disaggregation":
    y_plus_1_pattern = (
        f"gs://{self.config.bucket}/gold/{dataset}_{year}_{year + 1}/*/{dataset}_{year}_{year + 1}.parquet"
    )
```

This matches the actual unified pipeline output format: 
`gs://landbrugsdata-raw-data/gold/pesticide_disaggregation_2021_2022/*/pesticide_disaggregation_2021_2022.parquet`

## Test Plan

- [x] Verified H3 PFAS pipeline now successfully finds and loads pesticide disaggregation data for 2021
- [x] Pipeline proceeds through data loading and begins H3 grid processing 
- [x] No breaking changes to existing data loading patterns (maintains backward compatibility)

🤖 Generated with [Claude Code](https://claude.ai/code)