### PR TITLE
Fix datetime timezone comparison error in H3 PFAS analysis

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/util/gcs_access.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/util/gcs_access.py
@@ -858,8 +858,8 @@ class GCSDataAccess:
 
                 # Handle different mtime types from gcsfs
                 if isinstance(mtime, datetime.datetime):
-                    # mtime is already a datetime object
-                    timestamp = mtime
+                    # mtime is already a datetime object, normalize to timezone-naive
+                    timestamp = mtime.replace(tzinfo=None) if mtime.tzinfo else mtime
                 elif isinstance(mtime, (int, float)) and mtime > 0:
                     # mtime is a numeric timestamp
                     timestamp = datetime.datetime.fromtimestamp(mtime)
@@ -870,7 +870,7 @@ class GCSDataAccess:
                 files_with_timestamps.append((f"gs://{file_path}", timestamp))
             except Exception as e:
                 self.log.warning(f"Could not get timestamp for {file_path}: {e}")
-                # Fall back to current time if timestamp unavailable
+                # Fall back to current time if timestamp unavailable (timezone-naive)
                 files_with_timestamps.append((f"gs://{file_path}", datetime.datetime.now()))
 
         return files_with_timestamps


### PR DESCRIPTION
## Summary
Fixes the datetime timezone comparison error that was preventing H3 PFAS exposure analysis from finding results, causing the cumulative analysis to fail with "can't compare offset-naive and offset-aware datetimes" error.

## Problem
The H3 PFAS exposure analysis was failing during file discovery in the cumulative analysis step. The error occurred when comparing:
- `recent_threshold` (timezone-naive datetime from `datetime.now()`)
- File timestamps from GCS (potentially timezone-aware datetime objects)

This prevented the analysis from finding any H3 pesticide data files, resulting in empty results and pipeline failure.

## Solution
Modified `list_files_with_timestamps()` in `gcs_access.py` to normalize all datetime objects to timezone-naive:
- Convert timezone-aware datetime objects to timezone-naive using `mtime.replace(tzinfo=None)`
- Maintain timezone-naive datetime objects as-is
- Ensure consistent datetime comparison throughout the system

## Changes
- **File**: `backend/pipelines/unified_pipeline/src/unified_pipeline/util/gcs_access.py`
- **Lines**: 861-862, 873
- **Impact**: Fixes timezone comparison without breaking existing functionality

## Test Plan
- [x] Verified datetime comparison logic works correctly
- [x] Confirmed fix doesn't break existing timezone-naive datetime handling
- [x] Tested with mixed timezone-aware and timezone-naive datetime scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)