### PR TITLE
Fix CVR pipeline missing address file error

### DIFF
--- a/.github/workflows/cvr_enrichment_pipeline.yml
+++ b/.github/workflows/cvr_enrichment_pipeline.yml
@@ -48,6 +48,8 @@ on:
 env:
   BUCKET_NAME: landbrugsdata-raw-data
   PYTHON_VERSION: '3.11'
+  # Shared timestamp for all pipeline steps to ensure consistent file paths
+  PIPELINE_START_TIME: ${{ github.run_started_at }}
 
 jobs:
   # Step 1: CVR Collection (Sequential - must run first)
@@ -299,15 +301,23 @@ jobs:
       
       - name: Create Financial Data Artifact
         run: |
-          # Get the latest financial data from GCS and save as artifact
-          LATEST_DIR=$(gsutil ls gs://landbrugsdata-raw-data/gold/cvr_enrichment_financial/ | tail -1)
-          if [ ! -z "$LATEST_DIR" ]; then
-            FINANCIAL_PATH="${LATEST_DIR}data.parquet"
+          # Convert GitHub's timestamp to the format used by the pipeline
+          PIPELINE_TIMESTAMP=$(date -d "$PIPELINE_START_TIME" -u +"%Y%m%d_%H%M%S")
+          echo "Using pipeline timestamp: $PIPELINE_TIMESTAMP"
+          
+          # Get the financial data from the expected path using the shared timestamp
+          FINANCIAL_PATH="gs://landbrugsdata-raw-data/gold/cvr_enrichment_financial/${PIPELINE_TIMESTAMP}/data.parquet"
+          echo "Looking for financial file at: $FINANCIAL_PATH"
+          
+          if gsutil -q stat "$FINANCIAL_PATH"; then
             gsutil cp "$FINANCIAL_PATH" /tmp/cvr_financial_data.parquet
-            echo "Created financial artifact from: $FINANCIAL_PATH"
+            echo "✅ Created financial artifact from: $FINANCIAL_PATH"
           else
-            echo "No financial data found, creating empty artifact"
+            echo "⚠️ Financial file not found at expected path: $FINANCIAL_PATH"
+            echo "This suggests the financial documents step failed or didn't complete"
+            # Create empty artifact to prevent downstream failures
             touch /tmp/cvr_financial_data.parquet
+            echo "Created empty financial artifact"
           fi
       
       - name: Upload Financial Data Artifact
@@ -379,15 +389,23 @@ jobs:
       
       - name: Create Address Data Artifact
         run: |
-          # Get the latest address data from GCS and save as artifact
-          LATEST_DIR=$(gsutil ls gs://landbrugsdata-raw-data/gold/cvr_enrichment/ | tail -1)
-          if [ ! -z "$LATEST_DIR" ]; then
-            ADDRESS_PATH="${LATEST_DIR}address_geocoding.parquet"
+          # Convert GitHub's timestamp to the format used by the pipeline
+          PIPELINE_TIMESTAMP=$(date -d "$PIPELINE_START_TIME" -u +"%Y%m%d_%H%M%S")
+          echo "Using pipeline timestamp: $PIPELINE_TIMESTAMP"
+          
+          # Get the address data from the expected path using the shared timestamp
+          ADDRESS_PATH="gs://landbrugsdata-raw-data/gold/cvr_enrichment/${PIPELINE_TIMESTAMP}/address_geocoding.parquet"
+          echo "Looking for address file at: $ADDRESS_PATH"
+          
+          if gsutil -q stat "$ADDRESS_PATH"; then
             gsutil cp "$ADDRESS_PATH" /tmp/cvr_address_data.parquet
-            echo "Created address artifact from: $ADDRESS_PATH"
+            echo "✅ Created address artifact from: $ADDRESS_PATH"
           else
-            echo "No address data found, creating empty artifact"
+            echo "⚠️ Address file not found at expected path: $ADDRESS_PATH"
+            echo "This suggests the address geocoding step failed or didn't complete"
+            # Create empty artifact to prevent downstream failures
             touch /tmp/cvr_address_data.parquet
+            echo "Created empty address artifact"
           fi
       
       - name: Upload Address Data Artifact

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/common/base.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/common/base.py
@@ -161,7 +161,19 @@ class BaseSource(Generic[T], ABC):
         self.gcs_access = GCSDataAccess(connection=self.conn)
 
         # Use pipeline start time consistently (not save time)
-        self.pipeline_start_time = datetime.now()
+        # Check if shared timestamp is provided via environment variable (for GitHub Actions)
+        pipeline_start_env = os.getenv('PIPELINE_START_TIME')
+        if pipeline_start_env:
+            try:
+                # Parse GitHub's ISO timestamp format
+                self.pipeline_start_time = datetime.fromisoformat(pipeline_start_env.replace('Z', '+00:00'))
+                logger.info(f"Using shared pipeline start time from environment: {self.pipeline_start_time}")
+            except (ValueError, TypeError) as e:
+                logger.warning(f"Failed to parse PIPELINE_START_TIME environment variable: {e}")
+                self.pipeline_start_time = datetime.now()
+        else:
+            self.pipeline_start_time = datetime.now()
+        
         self.date_pattern = self.pipeline_start_time.strftime("%Y%m%d_%H%M%S")
 
         # Initialize schema managers with shared connection


### PR DESCRIPTION
## Summary
• Fixed timestamp synchronization issue causing "CommandException: No URLs matched" errors
• Ensured all pipeline steps use consistent timestamps for GCS file paths
• Added robust error handling for artifact creation steps

## Root Cause
Each pipeline step was generating its own timestamp, causing:
- Address geocoding step to create files with timestamp `20250812_214000`
- Artifact creation step to look for files with a different timestamp
- Result: `gs://landbrugsdata-raw-data/gold/cvr_enrichment/20250812_214000/address_geocoding.parquet` not found

## Solution
1. **Shared timestamp environment variable**: `PIPELINE_START_TIME: ${{ github.run_started_at }}`
2. **Modified pipeline base class** to use shared timestamp when available
3. **Updated artifact creation steps** to use synchronized timestamp instead of generating new ones
4. **Enhanced error handling** with clear logging and graceful fallbacks

## Test Plan
- [x] Verify workflow file syntax is valid
- [x] Confirm pipeline base class correctly parses environment variable
- [x] Test artifact creation steps use consistent timestamps
- [ ] Run full CVR pipeline to verify fix resolves the original error
- [ ] Verify pipeline works both in GitHub Actions and standalone modes

🤖 Generated with [Claude Code](https://claude.ai/code)