### PR TITLE
Fix ValidationException import error in field area analysis

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/base.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/base.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 from unified_pipeline.common.base import BaseJobConfig, BaseSource
 from unified_pipeline.util.log_util import Logger
 
-from .area_validation import FieldAreaValidator, ValidationException
+from .area_validation import FieldAreaValidator, ValidationError
 from .config import CONFIG
 
 


### PR DESCRIPTION
## Summary
• Fixed import error where `ValidationException` was being imported but the actual class name is `ValidationError`
• Updated import statement in `base.py` to match the correct class name defined in `area_validation.py:617`
• CVR pipeline now runs successfully without import errors

## Test plan
- [x] Verified the correct class name exists in `area_validation.py`
- [x] Updated the import statement in `base.py`
- [x] Tested CVR pipeline runs successfully without import errors
- [x] No other references to `ValidationException` found in codebase

🤖 Generated with [Claude Code](https://claude.ai/code)