### PR TITLE
Fix CVR data discrepancy issues in data consolidation step

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/data_consolidation.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/data_consolidation.py
@@ -1131,7 +1131,10 @@ class DataConsolidation(BaseSource[DataConsolidationConfig], GoldJobInterface):
 
         # Calculate summary statistics
         companies_data = consolidated_data.get("companies", {})
-        pnumbers_data = consolidated_data.get("pnumbers", {})
+        # Count P-numbers from merged company data (not from separate pnumbers dict)
+        total_pnumbers = sum(
+            len(company.get("pnumber_data", [])) for company in companies_data.values()
+        )
 
         # Count addresses and geocoded addresses
         total_addresses = 0
@@ -1149,7 +1152,7 @@ class DataConsolidation(BaseSource[DataConsolidationConfig], GoldJobInterface):
         # Create comprehensive summary statistics
         summary_stats = {
             "total_companies": len(companies_data),
-            "total_pnumbers": len(pnumbers_data),
+            "total_pnumbers": total_pnumbers,
             "total_addresses": total_addresses,
             "geocoded_addresses": geocoded_addresses,
             "financial_documents": financial_docs,

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/shared/config.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/shared/config.py
@@ -276,7 +276,7 @@ def _get_latest_input_paths_from_gcs(
             patterns = [
                 f"{base_pattern}/*/company_fetching.parquet",
                 f"{base_pattern}/*/pnumber_fetching.parquet",
-                f"{base_pattern}/*/financial_documents.parquet",
+                f"gs://{bucket}/gold/cvr_enrichment_financial/*/data.parquet",  # Financial docs use different dataset
                 f"{base_pattern}/*/address_geocoding.parquet",
             ]
 


### PR DESCRIPTION
## Summary
Fixed two critical data discrepancy issues in the CVR enrichment pipeline data consolidation step:

• **P-numbers count discrepancy**: Fixed summary calculation bug where 129 P-numbers were processed but final summary showed 0
• **Financial records not found**: Fixed dataset name mismatch causing financial documents data to be missed during consolidation

## Changes Made

### 1. P-Numbers Summary Calculation Fix
**File**: `data_consolidation.py:1134-1137`
- **Problem**: Code tried to count from non-existent `consolidated_data.get("pnumbers", {})` 
- **Solution**: Now correctly counts P-numbers from merged company data structure
- **Impact**: Summary will show correct P-number count (129) instead of 0

### 2. Financial Documents Dataset Mismatch Fix  
**File**: `shared/config.py:279`
- **Problem**: Financial documents saved to `cvr_enrichment_financial` dataset but consolidation looked in `cvr_enrichment`
- **Solution**: Updated file pattern to look in correct dataset location
- **Impact**: Financial documents will now be found and processed during consolidation

## Test Plan
- [x] Syntax validation passes for both modified files
- [x] Changes preserve existing functionality while fixing the bugs
- [ ] Run data consolidation step to verify P-numbers and financial records are correctly counted
- [ ] Verify final summary shows accurate statistics

## Root Cause Analysis
Both issues were in the **data fetching logic** of the consolidation step:
1. **P-numbers**: Bug in summary calculation using wrong data structure
2. **Financial records**: Looking for files in wrong GCS dataset path

🤖 Generated with [Claude Code](https://claude.ai/code)