### PR TITLE
Fix has_financial_metrics column error in CVR data consolidation

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/data_consolidation.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/data_consolidation.py
@@ -382,15 +382,27 @@ class DataConsolidation(BaseSource[DataConsolidationConfig], GoldJobInterface):
             self.gcs_access.create_table_from_gcs(table_name, input_path)
             
             # Work with the actual financial data structure as saved by the financial documents step
+            # The parquet file contains raw financial metrics, so we compute has_financial_metrics
             result = self.conn.execute(
                 f"""
                 SELECT 
                     cvr_number,
                     COALESCE(document_count, 0) as document_count,
-                    has_financial_metrics
+                    CASE 
+                        WHEN total_assets IS NOT NULL 
+                          OR cash_and_cash_equivalents IS NOT NULL 
+                          OR other_finance_income IS NOT NULL 
+                          OR liabilities_other_than_provisions IS NOT NULL
+                        THEN true 
+                        ELSE false 
+                    END as has_financial_metrics
                 FROM {table_name}
                 WHERE cvr_number IS NOT NULL
-                  AND (document_count > 0 OR has_financial_metrics = true)
+                  AND (document_count > 0 OR 
+                       total_assets IS NOT NULL OR 
+                       cash_and_cash_equivalents IS NOT NULL OR 
+                       other_finance_income IS NOT NULL OR 
+                       liabilities_other_than_provisions IS NOT NULL)
             """
             ).fetchall()
             


### PR DESCRIPTION
## Summary
- Fixed "Referenced column 'has_financial_metrics' not found" error in CVR data consolidation
- The error occurred because the code expected a pre-computed `has_financial_metrics` column that doesn't exist in GCS parquet files
- Modified the SQL query to compute `has_financial_metrics` on-the-fly from available financial metric columns

## Changes
- Updated `data_consolidation.py` to use a CASE statement that checks if any financial metric columns (`total_assets`, `cash_and_cash_equivalents`, etc.) contain non-null values
- This eliminates the dependency on a missing computed column and uses the actual raw financial data structure

## Test plan
- [x] Code compiles without errors
- [x] Ruff linting passes for modified sections
- [ ] Run CVR data consolidation pipeline to verify the fix resolves the column error
- [ ] Verify that companies with financial metrics are properly identified

🤖 Generated with [Claude Code](https://claude.ai/code)