### PR TITLE
Fix SilverJobInterface import error in fertiliser.py

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/fertiliser.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/fertiliser.py
@@ -18,8 +18,7 @@ from typing import Dict, List, Optional, Any
 
 import duckdb
 
-from ..base.silver_base import SilverJobInterface  
-from ..common.base import BaseJobConfig, ConnectionManager
+from ..common.base import BaseJobConfig, ConnectionManager, SilverJobInterface
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Fix ImportError for SilverJobInterface in fertiliser.py by importing from the correct module path
- Change import from `unified_pipeline.base.silver_base` to `unified_pipeline.common.base`
- Aligns with the pattern used in other silver layer modules like cvr_silver.py

## Test plan
- [x] Verify the import error is resolved
- [x] Confirm other silver modules follow the same import pattern
- [ ] Run the unified pipeline to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)