### PR TITLE
Fix "Analyser" submenu is hidden by year selector

### DIFF
--- a/frontend/src/components/layout/templates/navbar.tsx
+++ b/frontend/src/components/layout/templates/navbar.tsx
@@ -38,7 +38,7 @@ function DesktopNav() {
           Analyser
           <ChevronDownIcon className="ml-1 h-4 w-4" aria-hidden="true" />
         </MenuButton>
-        <MenuItems className="ring-opacity-5 bg-card border-border absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md border py-1 shadow-lg focus:outline-none">
+        <MenuItems className="ring-opacity-5 bg-card border-border absolute right-0 z-40 mt-2 w-48 origin-top-right rounded-md border py-1 shadow-lg focus:outline-none">
           {analyserLinks.map(({ href, label }) => (
             <MenuItem key={href}>
               <Link


### PR DESCRIPTION
## 🛠️ Issue Fix
The “Analyser” dropdown menu is hidden behind the year selector for the map.

No issue linked

## 💡 Solution
Increase z-index to 40. The year selector has z-index 30.

## ✅ How to Do Self-Test
Start test server, go to http://localhost:3001/markanalyse, and click on “Analyser”.

## 📷 Screenshots
Before the fix:
<img width="478" height="342" alt="image" src="https://github.com/user-attachments/assets/856fbc37-56a7-4039-aa9d-8f2c06102e74" />
