### PR TITLE
Revert "Align area ranking calculation with the other rankings"

### DIFF
--- a/backend/api/supabase/functions/homepage-rankings/index.ts
+++ b/backend/api/supabase/functions/homepage-rankings/index.ts
@@ -257,14 +257,14 @@ serve(async (req) => {
             "Virksomheder med det største samlede landbrugsareal i 2025",
           unit: "hektar",
           company_count: landAreaCount || 0,
-          items: landAreaData.map((item, index) => {
+          items: landAreaData.map((item) => {
             const company = companyMap.get(item.company_id);
             return {
               company_id: item.company_id,
               cvr_number: company?.cvr_number?.toString() || "N/A",
               company_name: company?.company_name || "Ukendt virksomhed",
               municipality: company?.municipality || "Ukendt kommune",
-              rank: index + 1,
+              rank: item.rank_dk_total_area,
               value: item.total_area_ha,
               formatted_value: `${item.total_area_ha.toFixed(1)} ha`,
               year: item.year,

--- a/supabase/functions/homepage-rankings/index.ts
+++ b/supabase/functions/homepage-rankings/index.ts
@@ -246,14 +246,14 @@ serve(async (req) => {
             "Virksomheder med det største samlede landbrugsareal i 2025",
           unit: "hektar",
           company_count: landAreaCount || 0,
-          items: landAreaData.map((item, index) => {
+          items: landAreaData.map((item) => {
             const company = companyMap.get(item.company_id);
             return {
               company_id: item.company_id,
               cvr_number: company?.cvr_number?.toString() || "N/A",
               company_name: company?.company_name || "Ukendt virksomhed",
               municipality: company?.municipality || "Ukendt kommune",
-              rank: index + 1,
+              rank: item.rank_dk_total_area,
               value: item.total_area_ha,
               formatted_value: `${item.total_area_ha.toFixed(1)} ha`,
               year: item.year,


### PR DESCRIPTION
This reverts commit 9f0a00a3dc3e42f23510aca2e3121966c8a04888.

The fix that this was meant to do did not work.
