### PR TITLE
fix(property-owners): inline UUID generation to fix 4-month pipeline failure

### DIFF
--- a/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
+++ b/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
@@ -97,18 +97,57 @@ from pyproj import Transformer, CRS
 from datetime import datetime
 from pathlib import Path
 from google.cloud import storage, secretmanager
-
-# Import UUID utilities
-try:
-    from backend.pipelines.unified_pipeline.src.unified_pipeline.common.uuid_utils import LandbrugsdataUUID
-except ImportError:
-    # Fallback for different import paths
-    import sys
-    sys.path.append('/home/landbrugsdata/backend/pipelines/unified_pipeline/src')
-    from unified_pipeline.common.uuid_utils import LandbrugsdataUUID
 import subprocess
 import sys
 import traceback
+import hashlib
+
+# Inlined UUID generation to avoid repository dependency
+class LandbrugsdataUUID:
+    """
+    Inlined UUID generation for property_owners pipeline.
+    Uses MD5-based UUID5 format to match the centralized uuid_utils.
+    """
+    _namespace = None
+
+    @classmethod
+    def _get_namespace(cls):
+        """Get the UUID namespace from environment variable."""
+        if cls._namespace is None:
+            namespace_str = os.getenv("LANDBRUGSDATA_UUID_NAMESPACE")
+            if not namespace_str:
+                raise ValueError(
+                    "LANDBRUGSDATA_UUID_NAMESPACE environment variable is required"
+                )
+            cls._namespace = namespace_str
+        return cls._namespace
+
+    @classmethod
+    def generate_deterministic_uuid(cls, entity_type, identifier):
+        """
+        Generate deterministic UUID for any entity type with custom identifier.
+
+        Args:
+            entity_type: Type of entity (e.g., 'cpr', 'company', etc.)
+            identifier: Unique identifier string for this entity
+
+        Returns:
+            UUID string
+        """
+        if not identifier:
+            raise ValueError("Identifier cannot be empty")
+
+        # Use MD5-based UUID generation to match DuckDB implementation
+        namespace_str = str(cls._get_namespace())
+        input_str = f"{namespace_str}{entity_type}-{identifier}"
+        md5_hash = hashlib.md5(input_str.encode()).hexdigest()
+
+        # Format as UUID5 (version 5, variant 10)
+        uuid_str = (
+            f"{md5_hash[0:8]}-{md5_hash[8:12]}-5{md5_hash[12:15]}-"
+            f"8{md5_hash[15:18]}-{md5_hash[18:30]}"
+        )
+        return uuid_str
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Problem

The property_owners SFTP pipeline has been **failing for 4 months** (since September 1, 2025). Investigation revealed:

- ❌ Last successful run: **August 25, 2025**
- ❌ Continuous failures: **Sept 1, 2025 → Present** (17+ consecutive failures)
- ❌ Root cause: VM startup script tried to import `LandbrugsdataUUID` from repository that doesn't exist on the VM

### Failure Pattern

1. GitHub Actions creates VM with startup script
2. Startup script tries to import `LandbrugsdataUUID` from `backend/pipelines/unified_pipeline/...`
3. Import fails (no repo on fresh VM) → Python script crashes immediately
4. GitHub Actions waits 60 minutes (timeout added in Sept 2 commit to prevent cost overruns)
5. Force deletes VM with no output files

### Evidence

- GCS buckets empty: No bronze or silver property_owners data
- VM timeout logs show no Python processes running
- Only 3.4GB disk used (no data downloaded/processed)

## Solution

**Inline the UUID generation logic** directly in the startup script to eliminate external dependencies.

### Changes

- ✅ Removed problematic import statements (lines 102-108)
- ✅ Added inlined `LandbrugsdataUUID` class with `generate_deterministic_uuid` method
- ✅ Uses identical MD5-based UUID5 algorithm as centralized `uuid_utils`
- ✅ No changes to business logic or UUID format (maintains consistency)

### Implementation

```python
class LandbrugsdataUUID:
    """Inlined UUID generation - no repository dependency"""
    
    @classmethod
    def generate_deterministic_uuid(cls, entity_type, identifier):
        namespace_str = str(cls._get_namespace())
        input_str = f"{namespace_str}{entity_type}-{identifier}"
        md5_hash = hashlib.md5(input_str.encode()).hexdigest()
        
        # Format as UUID5 (version 5, variant 10)
        uuid_str = (
            f"{md5_hash[0:8]}-{md5_hash[8:12]}-5{md5_hash[12:15]}-"
            f"8{md5_hash[15:18]}-{md5_hash[18:30]}"
        )
        return uuid_str
```

## Impact

- ✅ Fixes 4 months of pipeline failures
- ✅ Expected processing time: 18-20 minutes (well within 60-minute timeout)
- ✅ Restores privacy-transformed property ownership data pipeline
- ✅ Enables weekly automated updates

## Testing Plan

After merge:
1. Manually trigger workflow: `gh workflow run property_owners_sftp_transfer_pipeline.yml`
2. Monitor VM execution in GCP Console
3. Verify output files in GCS:
   - `gs://landbrugsdata-raw-data/bronze/property_owners/` (ZIP backup)
   - `gs://landbrugsdata-raw-data/silver/property_owners/YYYYMMDD_HHMMSS/data.parquet`
4. Verify VM self-deletes after successful processing

## Files Changed

- `backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh`

## Related Issues

Fixes the issue discovered during pipeline health check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)