### PR TITLE
fix(property-owners): pass LANDBRUGSDATA_UUID_NAMESPACE to VM

### DIFF
--- a/.github/workflows/property_owners_sftp_transfer_pipeline.yml
+++ b/.github/workflows/property_owners_sftp_transfer_pipeline.yml
@@ -73,7 +73,7 @@ jobs:
             --image-family=debian-12 \
             --image-project=debian-cloud \
             --scopes=https://www.googleapis.com/auth/cloud-platform \
-            --metadata=enable-oslogin=true \
+            --metadata=enable-oslogin=true,LANDBRUGSDATA_UUID_NAMESPACE=${{ secrets.LANDBRUGSDATA_UUID_NAMESPACE }} \
             --metadata-from-file=startup-script=backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh \
             --maintenance-policy=MIGRATE
 

--- a/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
+++ b/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
@@ -850,6 +850,15 @@ VM_NAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/comp
 ZONE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone | awk -F/ '{print $NF}')
 PROJECT_ID=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
 
+# Get UUID namespace from instance metadata and export for Python script
+LANDBRUGSDATA_UUID_NAMESPACE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/LANDBRUGSDATA_UUID_NAMESPACE 2>/dev/null || echo "")
+if [ -z "$LANDBRUGSDATA_UUID_NAMESPACE" ]; then
+  log_with_timestamp "ERROR: LANDBRUGSDATA_UUID_NAMESPACE not found in VM metadata"
+  exit 1
+fi
+export LANDBRUGSDATA_UUID_NAMESPACE
+log_with_timestamp "✅ LANDBRUGSDATA_UUID_NAMESPACE loaded from VM metadata"
+
 # Function to delete the VM
 delete_vm() {
   log_with_timestamp "Attempting to delete VM: $VM_NAME in zone: $ZONE project: $PROJECT_ID"


### PR DESCRIPTION
## Problem

After merging the first fix (#491), the pipeline progressed much further but still failed with:
```
ValueError: LANDBRUGSDATA_UUID_NAMESPACE environment variable is required
```

The environment variable was defined in the GitHub Actions workflow but wasn't being passed to the VM instance.

## Root Cause

The `LANDBRUGSDATA_UUID_NAMESPACE` was set at the workflow level but VMs don't inherit environment variables from the GitHub Actions runner. The variable needs to be:
1. Passed as VM metadata during instance creation
2. Fetched from instance metadata and exported in the startup script

## Solution

### Workflow Changes (.github/workflows/property_owners_sftp_transfer_pipeline.yml:76)
```yaml
--metadata=enable-oslogin=true,LANDBRUGSDATA_UUID_NAMESPACE=${{ secrets.LANDBRUGSDATA_UUID_NAMESPACE }}
```

### Startup Script Changes (backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh:853-860)
```bash
# Get UUID namespace from instance metadata and export for Python script
LANDBRUGSDATA_UUID_NAMESPACE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/LANDBRUGSDATA_UUID_NAMESPACE 2>/dev/null || echo "")
if [ -z "$LANDBRUGSDATA_UUID_NAMESPACE" ]; then
  log_with_timestamp "ERROR: LANDBRUGSDATA_UUID_NAMESPACE not found in VM metadata"
  exit 1
fi
export LANDBRUGSDATA_UUID_NAMESPACE
log_with_timestamp "✅ LANDBRUGSDATA_UUID_NAMESPACE loaded from VM metadata"
```

## Testing Progress

From the first test run (20464515805):
- ✅ VM created successfully
- ✅ Dependencies installed (Python, ijson, pyarrow, etc.)
- ✅ SFTP connection established
- ✅ File downloaded: `testigen_20251222120023.zip` (1.1 GB in 50 seconds)
- ✅ JSON extracted: 11.8 GB
- ❌ Failed at UUID generation (missing environment variable)

With this fix, the pipeline should complete successfully.

## Related

- Follows #491 (inlined UUID generation fix)
- Together these fix 4 months of pipeline failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)