### PR TITLE
fix(workflows): correct YAML indentation for github-script action

### DIFF
--- a/.github/workflows/parquet_to_supabase_migration.yml
+++ b/.github/workflows/parquet_to_supabase_migration.yml
@@ -462,16 +462,16 @@ jobs:
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         with:
-        script: |
-          const fs = require('fs');
-          const summary = fs.readFileSync('migration_summary.md', 'utf8');
+          script: |
+            const fs = require('fs');
+            const summary = fs.readFileSync('migration_summary.md', 'utf8');
 
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: summary
-          });
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: summary
+            });
 
   cleanup:
     name: Cleanup


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes YAML syntax error in parquet_to_supabase_migration.yml workflow

## 💡 Solution
Fixed missing 2-space indentation for `script:` parameter in the github-script action. The workflow was failing validation with:
```
(Line: 464, Col: 14): Unexpected value '', (Line: 465, Col: 9): Unexpected value 'script'
```

**Change**: Added proper indentation to `script:` parameter and its contents in the "Comment on PR" step.

## ✅ How to Do Self-Test
1. View the workflow file in GitHub - should no longer show syntax errors
2. Trigger parquet_to_supabase_migration workflow manually - should start without "workflow file issue"
3. GitHub Actions should accept the workflow syntax on PR merge

## 📝 Additional Notes
This is a follow-up fix to PR #497. The original PR was squash-merged but this indentation issue was introduced during the fixes and needs correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>