### PR TITLE
fix(workflows): add bash shell for fvm_wfs matrix generation

### DIFF
--- a/.github/workflows/fvm_wfs_matrix_download.yml
+++ b/.github/workflows/fvm_wfs_matrix_download.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - name: Generate matrix
         id: set-matrix
+        shell: bash
         run: |
           # Define all layer configurations
           if [ "${{ github.event.inputs.layer_types }}" = "all" ]; then


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes GitHub Actions workflow failure in `fvm_wfs_matrix_download.yml` caused by shell syntax errors.

## 💡 Solution
- Added `shell: bash` directive to the "Generate matrix" step
- The matrix generation step uses bash-specific array syntax (`+=()` operations) that fails under the default `sh` shell on Linux runners
- This simple one-line fix ensures the workflow uses bash instead of sh for proper syntax support

## ✅ How to Do Self-Test
Push this branch to trigger the workflow manually via the GitHub Actions dashboard. The matrix generation step should now execute without syntax errors.

## 📝 Additional Notes
The error message was: "syntax error near unexpected token `('" which occurs when bash array operations are run under `/bin/sh` instead of `/bin/bash`.