### PR TITLE
feat(dmi-pipeline): add progress logging to monthly data fetching

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/dmi.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/dmi.py
@@ -224,10 +224,23 @@ class DMIBronze(BaseSource[DMIBronzeConfig], BronzeJobInterface):
 
             all_features: list = []
             cur_start = datetime(start_time.year, start_time.month, 1)
+
+            # Calculate total months for progress tracking
+            total_months = (
+                (end_time.year - start_time.year) * 12 + (end_time.month - start_time.month) + 1
+            )
+            month_counter = 0
+
             while cur_start < end_time:
                 cur_end = _add_one_month(cur_start) - timedelta(seconds=1)
                 if cur_end > end_time:
                     cur_end = end_time
+
+                month_counter += 1
+                self.log.info(
+                    f"  [{parameter_id}] Fetching {cur_start:%Y-%m} "
+                    f"({month_counter}/{total_months}, {month_counter * 100 // total_months}%)"
+                )
 
                 monthly_data = await self.api_client.fetch_grid_data(
                     session, parameter_id, cur_start, cur_end
@@ -235,6 +248,14 @@ class DMIBronze(BaseSource[DMIBronzeConfig], BronzeJobInterface):
 
                 if monthly_data.get("features"):
                     all_features.extend(monthly_data["features"])
+                    self.log.info(
+                        f"  [{parameter_id}] ✓ {cur_start:%Y-%m}: {len(monthly_data['features'])} features "
+                        f"(total: {len(all_features)})"
+                    )
+                else:
+                    self.log.warning(
+                        f"  [{parameter_id}] ⚠ {cur_start:%Y-%m}: No features returned"
+                    )
 
                 cur_start = _add_one_month(cur_start)
 


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- Added real-time progress logging while fetching DMI monthly climate data
- Displays progress indicator with percentage for each parameter (e.g., 1/181, 0%)
- Shows feature count per month and running total to track data accumulation
- Includes status indicators: ✓ for successful months, ⚠ for missing data

## ✅ How to Do Self-Test
```bash
cd backend && source venv/bin/activate
cd pipelines/unified_pipeline && python main.py
# Monitor logs for progress indicators like: [pot_evaporation_makkink] Fetching 2011-01 (1/181, 0%)
```

## 📝 Additional Notes
This improves observability during the long 180+ month DMI data fetch cycle, preventing the appearance of the pipeline being frozen.