### PR TITLE
fix(workflows): correct GCS paths for silver data availability checks

### DIFF
--- a/.github/workflows/field_area_analysis_multi_stage.yml
+++ b/.github/workflows/field_area_analysis_multi_stage.yml
@@ -83,8 +83,8 @@ jobs:
             echo "soil_types_available=false" >> $GITHUB_OUTPUT
           fi
 
-          # Check bnbo (drinking water protection areas)
-          if gsutil ls "gs://${{ secrets.GCS_BUCKET }}/silver/bnbo/" &>/dev/null; then
+          # Check bnbo (drinking water protection areas - dissolved geometries)
+          if gsutil ls "gs://${{ secrets.GCS_BUCKET }}/silver/bnbo_status_dissolved/" &>/dev/null; then
             echo "  ✅ bnbo: Available"
             echo "bnbo_available=true" >> $GITHUB_OUTPUT
           else
@@ -92,8 +92,8 @@ jobs:
             echo "bnbo_available=false" >> $GITHUB_OUTPUT
           fi
 
-          # Check properties (cadastral data)
-          if gsutil ls "gs://${{ secrets.GCS_BUCKET }}/silver/bfe_ejerlav/" &>/dev/null; then
+          # Check properties (merged cadastral + property owners from gold layer)
+          if gsutil ls "gs://${{ secrets.GCS_BUCKET }}/gold/property_cadastral_merged/" &>/dev/null; then
             echo "  ✅ properties: Available"
             echo "properties_available=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## 🛠️ Issue Fix
Field area analysis workflow was skipping BNBO and properties prefiltering due to incorrect GCS path checks.

## 💡 Solution
Fixed two incorrect GCS path references in the silver data availability verification step:
- BNBO check: `silver/bnbo/` → `silver/bnbo_status_dissolved/` (uses dissolved geometries optimized for spatial analysis)
- Properties check: `silver/bfe_ejerlav/` → `gold/property_cadastral_merged/` (merged dataset combining property owners and cadastral data)

Both datasets now correctly resolve to existing GCS locations, allowing prefiltering stages to run as intended.

## ✅ How to Do Self-Test
The workflow will now correctly detect available datasets in GCS and run the prefiltering operations instead of skipping them. Verify by checking that the `verify-silver-data` job outputs `bnbo_available=true` and `properties_available=true`.

## 📝 Additional Notes
Data lineage verified in GCS:
- BNBO: bronze/bnbo_status → silver/bnbo_status + bnbo_status_dissolved
- Properties: silver/property_owners + cadastral → gold/property_cadastral_merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)