### PR TITLE
fix(workflows): escape JSON in curl payloads for workflow dispatch

### DIFF
--- a/.github/workflows/unified_pipeline_monthly.yml
+++ b/.github/workflows/unified_pipeline_monthly.yml
@@ -214,7 +214,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/fvm_wfs_matrix_download.yml/dispatches" \
-              -d '{"ref":"${{ github.ref }}","inputs":{"stage":"all","layer_types":"all","years":"all"}}')
+              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"stage\":\"all\",\"layer_types\":\"all\",\"years\":\"all\"}}")
 
             if [ "$HTTP_CODE" = "204" ]; then
               echo "✅ FVM WFS matrix workflow triggered successfully (HTTP $HTTP_CODE)"
@@ -231,7 +231,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/drive_pipeline.yml/dispatches" \
-              -d '{"ref":"${{ github.ref }}","inputs":{"log_level":"INFO","max_workers":"4"}}')
+              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"log_level\":\"INFO\",\"max_workers\":\"4\"}}")
 
             if [ "$HTTP_CODE" = "204" ]; then
               echo "✅ Google Drive pipeline triggered successfully (HTTP $HTTP_CODE)"
@@ -248,7 +248,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/bbr_buildings_pipeline.yml/dispatches" \
-              -d '{"ref":"${{ github.ref }}","inputs":{"layer":"both","sample_size":"0","log_level":"INFO"}}')
+              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"layer\":\"both\",\"sample_size\":\"0\",\"log_level\":\"INFO\"}}")
 
             if [ "$HTTP_CODE" = "204" ]; then
               echo "✅ BBR Buildings pipeline triggered successfully (HTTP $HTTP_CODE)"
@@ -428,7 +428,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/field_area_analysis_multi_stage.yml/dispatches" \
-              -d '{"ref":"${{ github.ref }}","inputs":{"stage":"all","agricultural_fields_year":"both"}}'
+              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"stage\":\"all\",\"agricultural_fields_year\":\"both\"}}"
             echo "✅ Field Area Analysis matrix workflow triggered successfully"
           elif [ "${{ matrix.source }}" = "fvm_wfs" ]; then
             # FVM WFS - trigger the dedicated matrix workflow
@@ -438,7 +438,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/fvm_wfs_matrix_download.yml/dispatches" \
-              -d '{"ref":"${{ github.ref }}","inputs":{"stage":"all","layer_types":"all","years":"all"}}')
+              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"stage\":\"all\",\"layer_types\":\"all\",\"years\":\"all\"}}")
 
             if [ "$HTTP_CODE" = "204" ]; then
               echo "✅ FVM WFS matrix workflow triggered successfully (HTTP $HTTP_CODE)"


### PR DESCRIPTION
## Summary

Fixed bash syntax error in the monthly unified pipeline workflow that was causing the fvm_wfs pipeline to fail with "syntax error near unexpected token `('" on line 82.

The issue was caused by mixing single quotes with GitHub Actions variable expansion (`${{ github.ref }}`) in curl JSON payloads. When the ref contains `refs/heads/branch-name`, bash fails to parse the command correctly.

## Changes

Changed all curl `-d` payloads from single quotes with embedded variables:
```bash
-d '{"ref":"${{ github.ref }}","inputs":{...}}'
```

To double quotes with escaped JSON:
```bash
-d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{...}}"
```

This allows proper GitHub Actions variable expansion while maintaining valid JSON syntax.

## Fixed Workflows

- fvm_wfs matrix dispatch (2 occurrences)
- drive_data dispatch  
- bbr_buildings dispatch
- field_area_analysis dispatch

## Testing

The fix will be validated when the monthly pipeline runs next or when manually triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)