### PR TITLE
fix(cadastral-silver): enable geometry validation by default

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cadastral.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cadastral.py
@@ -559,8 +559,9 @@ class CadastralSilver(BaseSource[CadastralSilverConfig], SilverJobInterface):
             self.log.warning("No valid data found after processing")
             return None
 
-        # Skip expensive geometry validation for cadastral data since coordinates are now fixed
-        skip_validation = os.getenv("CADASTRAL_SKIP_VALIDATION", "true").lower() == "true"
+        # Enable geometry validation by default to fix invalid geometries upstream
+        # Validation includes ST_MakeValid which repairs topology issues before Gold stage
+        skip_validation = os.getenv("CADASTRAL_SKIP_VALIDATION", "false").lower() == "true"
         if skip_validation:
             self.log.info("Skipping geometry validation (CADASTRAL_SKIP_VALIDATION=true)")
             # Just do coordinate transformation without validation


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes TopologyException error in Gold stage field area analysis caused by invalid cadastral geometries bypassing validation.

## 💡 Solution

Changed `CADASTRAL_SKIP_VALIDATION` default from `"true"` to `"false"` in the cadastral Silver pipeline to enable geometry validation by default. Invalid geometries are now repaired using `ST_MakeValid` upstream (Silver layer) rather than causing failures downstream in Gold stage `ST_Intersection` operations.

This aligns cadastral with all other Silver pipelines (agricultural_fields, soil_types, bnbo_status, wetlands, water_projects) which already validate geometries unconditionally.

## ✅ How to Do Self-Test

```bash
# Verify the change enables validation
cd backend/pipelines/unified_pipeline
python -m unified_pipeline.silver.cadastral  # Should now run geometry validation by default

# Check logs confirm ST_MakeValid is applied
# Look for: "Applying geometry validation and coordinate transformation"
```

## 📝 Additional Notes

The topology error occurred at coordinates 54.78°N, 11.97°E during field×property intersection analysis. The invalid cadastral geometry is now fixed in the Silver layer before reaching the Gold analysis stage.