### PR TITLE
fix(workflow): add workflow_call trigger to cvr_enrichment_pipeline

### DIFF
--- a/.github/workflows/cvr_enrichment_pipeline.yml
+++ b/.github/workflows/cvr_enrichment_pipeline.yml
@@ -40,6 +40,39 @@ on:
           - WARNING
           - ERROR
         default: "INFO"
+  workflow_call:
+    inputs:
+      test_limit:
+        description: "Test limit (number of CVR numbers to process, empty for no limit)"
+        required: false
+        type: string
+      skip_steps:
+        description: "Comma-separated list of steps to skip (collection,company_fetching,data_parsing,data_consolidation,pnumber_fetching,financial_documents,address_geocoding)"
+        required: false
+        type: string
+      run_only_step:
+        description: "Run only a specific step independently (collection,company_fetching,pnumber_fetching,financial_documents,address_geocoding). Note: data_parsing and data_consolidation require full pipeline run."
+        required: false
+        type: string
+        default: "none"
+      log_level:
+        description: "Logging level"
+        type: string
+        required: false
+        default: "INFO"
+    secrets:
+      GCP_SA_KEY:
+        required: true
+      CVR_USERNAME:
+        required: true
+      CVR_PASSWORD:
+        required: true
+      GCS_ACCESS_KEY_ID:
+        required: true
+      GCS_SECRET_ACCESS_KEY:
+        required: true
+      LANDBRUGSDATA_UUID_NAMESPACE:
+        required: true
   schedule:
     # Run monthly on the 1st at 02:00 UTC
     - cron: "0 2 1 * *"


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes workflow validation error in unified_pipeline_weekly.yml that prevented calling cvr_enrichment_pipeline.yml as a reusable workflow.

## 💡 Solution

Added the `workflow_call` trigger to cvr_enrichment_pipeline.yml to make it reusable:
- Declare inputs compatible with workflow_call (converted choice type to string for log_level)
- Specify all required secrets (GCP_SA_KEY, CVR credentials, GCS keys, UUID namespace)
- Allows both manual execution (workflow_dispatch) and caller workflow execution (workflow_call)

## ✅ How to Do Self-Test

The workflow file is now syntactically valid and can be:
1. Triggered manually via GitHub Actions UI using workflow_dispatch
2. Called from other workflows like unified_pipeline_weekly.yml using workflow_call

## 📝 Additional Notes

The linter has automatically validated the YAML syntax. The workflow_call trigger parameters match the workflow_dispatch inputs to maintain API consistency.