### PR TITLE
fix(field-analysis): add ST_MakeValid to prevent topology errors

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/bnbo_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/bnbo_prefilter.py
@@ -156,7 +156,7 @@ class BNBOPreFilter(PreFilteringStageBase):
                 )
                 coord_pairs = []
                 for i, (wkt,) in enumerate(sample_wkt[:3]):
-                    self.log.info(f"   Raw WKT {i+1}: {wkt}")
+                    self.log.info(f"   Raw WKT {i + 1}: {wkt}")
                     # Extract coordinates from "POINT(x y)" format
                     if wkt and "POINT(" in wkt:
                         coords_str = wkt.replace("POINT(", "").replace(")", "")
@@ -166,17 +166,17 @@ class BNBOPreFilter(PreFilteringStageBase):
                                 first_val, second_val = float(coord_parts[0]), float(coord_parts[1])
                                 coord_pairs.append((first_val, second_val))
                                 self.log.info(
-                                    f"   BNBO {i+1}: POINT({first_val:.6f} {second_val:.6f})"
+                                    f"   BNBO {i + 1}: POINT({first_val:.6f} {second_val:.6f})"
                                 )
                             else:
                                 self.log.warning(
-                                    f"   BNBO {i+1}: Invalid coordinate format: {coords_str}"
+                                    f"   BNBO {i + 1}: Invalid coordinate format: {coords_str}"
                                 )
                         except Exception as parse_e:
-                            self.log.warning(f"   BNBO {i+1}: Parse error: {parse_e}")
+                            self.log.warning(f"   BNBO {i + 1}: Parse error: {parse_e}")
                             continue
                     else:
-                        self.log.warning(f"   BNBO {i+1}: Not a POINT geometry: {wkt}")
+                        self.log.warning(f"   BNBO {i + 1}: Not a POINT geometry: {wkt}")
 
                 if coord_pairs:
                     self.log.info(
@@ -238,11 +238,12 @@ class BNBOPreFilter(PreFilteringStageBase):
         # Handle different geometry formats (WKT string, WKB binary, or already parsed geometry)
         # Use simpler approach: since we know geometry is GEOMETRY type, use it directly
         try:
+            self.log.info("Applying ST_MakeValid to ensure BNBO geometry validity...")
             self.conn.execute("""
                 CREATE OR REPLACE TABLE bnbo_status_full AS
                 SELECT
                     status_category,
-                    UNNEST(ST_Dump(geometry)).geom as geometry
+                    ST_MakeValid(UNNEST(ST_Dump(geometry)).geom) as geometry
                 FROM bnbo_status_raw
                 WHERE geometry IS NOT NULL
             """)
@@ -251,11 +252,12 @@ class BNBOPreFilter(PreFilteringStageBase):
             self.log.info("🔄 Trying with type-safe CASE statement...")
 
             # Fallback: Use type-safe approach with explicit type checking
+            self.log.info("Applying ST_MakeValid in fallback case...")
             self.conn.execute("""
                 CREATE OR REPLACE TABLE bnbo_status_full AS
                 SELECT
                     status_category,
-                    UNNEST(ST_Dump(
+                    ST_MakeValid(UNNEST(ST_Dump(
                         CASE
                             WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
                                 ST_GeomFromText(geometry)
@@ -264,7 +266,7 @@ class BNBOPreFilter(PreFilteringStageBase):
                             ELSE
                                 geometry
                         END
-                    )).geom as geometry
+                    )).geom) as geometry
                 FROM bnbo_status_raw
                 WHERE geometry IS NOT NULL
             """)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/properties_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/properties_prefilter.py
@@ -32,17 +32,20 @@ class PropertiesPreFilter(PreFilteringStageBase):
         self.log.info("Loading full cadastral dataset (6.5M properties)...")
         self._load_silver_dataset("cadastral", "properties_raw")
 
-        # Add memory optimization and basic geometry validation
-        self.log.info("Preparing properties dataset with memory optimization...")
+        # Add memory optimization and geometry validation with ST_MakeValid
+        self.log.info(
+            "Preparing properties dataset with memory optimization and geometry repair..."
+        )
         self.conn.execute("""
             CREATE OR REPLACE TABLE properties_full AS
             SELECT
                 bfe_number,
-                geometry
+                ST_MakeValid(geometry) as geometry
             FROM properties_raw
             WHERE geometry IS NOT NULL
               AND bfe_number IS NOT NULL
         """)
+        self.log.info("✅ Applied ST_MakeValid to repair any invalid cadastral geometries")
 
         # Log dataset sizes and validate data integrity
         properties_count = self.conn.execute("SELECT COUNT(*) FROM properties_full").fetchone()[0]
@@ -65,7 +68,7 @@ class PropertiesPreFilter(PreFilteringStageBase):
                 )
                 coord_pairs = []
                 for i, (wkt,) in enumerate(sample_wkt[:3]):
-                    self.log.info(f"   Raw WKT {i+1}: {wkt}")
+                    self.log.info(f"   Raw WKT {i + 1}: {wkt}")
                     # Extract coordinates from "POINT(x y)" format
                     if wkt and "POINT(" in wkt:
                         coords_str = wkt.replace("POINT(", "").replace(")", "")
@@ -75,17 +78,17 @@ class PropertiesPreFilter(PreFilteringStageBase):
                                 first_val, second_val = float(coord_parts[0]), float(coord_parts[1])
                                 coord_pairs.append((first_val, second_val))
                                 self.log.info(
-                                    f"   Property {i+1}: POINT({first_val:.6f} {second_val:.6f})"
+                                    f"   Property {i + 1}: POINT({first_val:.6f} {second_val:.6f})"
                                 )
                             else:
                                 self.log.warning(
-                                    f"   Property {i+1}: Invalid coordinate format: {coords_str}"
+                                    f"   Property {i + 1}: Invalid coordinate format: {coords_str}"
                                 )
                         except Exception as parse_e:
-                            self.log.warning(f"   Property {i+1}: Parse error: {parse_e}")
+                            self.log.warning(f"   Property {i + 1}: Parse error: {parse_e}")
                             continue
                     else:
-                        self.log.warning(f"   Property {i+1}: Not a POINT geometry: {wkt}")
+                        self.log.warning(f"   Property {i + 1}: Not a POINT geometry: {wkt}")
 
                 if coord_pairs:
                     self.log.info(

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/soil_types_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/soil_types_prefilter.py
@@ -164,7 +164,7 @@ class SoilTypesPreFilter(PreFilteringStageBase):
                 )
                 coord_pairs = []
                 for i, (wkt,) in enumerate(sample_wkt[:3]):
-                    self.log.info(f"   Raw WKT {i+1}: {wkt}")
+                    self.log.info(f"   Raw WKT {i + 1}: {wkt}")
                     # Extract coordinates from "POINT(x y)" format
                     if wkt and "POINT(" in wkt:
                         coords_str = wkt.replace("POINT(", "").replace(")", "")
@@ -174,17 +174,17 @@ class SoilTypesPreFilter(PreFilteringStageBase):
                                 first_val, second_val = float(coord_parts[0]), float(coord_parts[1])
                                 coord_pairs.append((first_val, second_val))
                                 self.log.info(
-                                    f"   Soil {i+1}: POINT({first_val:.6f} {second_val:.6f})"
+                                    f"   Soil {i + 1}: POINT({first_val:.6f} {second_val:.6f})"
                                 )
                             else:
                                 self.log.warning(
-                                    f"   Soil {i+1}: Invalid coordinate format: {coords_str}"
+                                    f"   Soil {i + 1}: Invalid coordinate format: {coords_str}"
                                 )
                         except Exception as parse_e:
-                            self.log.warning(f"   Soil {i+1}: Parse error: {parse_e}")
+                            self.log.warning(f"   Soil {i + 1}: Parse error: {parse_e}")
                             continue
                     else:
-                        self.log.warning(f"   Soil {i+1}: Not a POINT geometry: {wkt}")
+                        self.log.warning(f"   Soil {i + 1}: Not a POINT geometry: {wkt}")
 
                 if coord_pairs:
                     self.log.info(
@@ -251,12 +251,13 @@ class SoilTypesPreFilter(PreFilteringStageBase):
         # Handle different geometry formats (WKT string, WKB binary, or already parsed geometry)
         # Use simpler approach: since we know geometry is GEOMETRY type, use it directly
         try:
+            self.log.info("Applying ST_MakeValid to ensure soil types geometry validity...")
             self.conn.execute("""
                 CREATE OR REPLACE TABLE soil_types_full AS
                 SELECT
                     soil_code,
                     soil_description,  -- Only meaningful soil data (8 Danish soil types)
-                    UNNEST(ST_Dump(geometry)).geom as geometry
+                    ST_MakeValid(UNNEST(ST_Dump(geometry)).geom) as geometry
                 FROM soil_types_raw
                 WHERE geometry IS NOT NULL
             """)
@@ -265,12 +266,13 @@ class SoilTypesPreFilter(PreFilteringStageBase):
             self.log.info("🔄 Trying with type-safe CASE statement...")
 
             # Fallback: Use type-safe approach with explicit type checking
+            self.log.info("Applying ST_MakeValid in fallback case...")
             self.conn.execute("""
                 CREATE OR REPLACE TABLE soil_types_full AS
                 SELECT
                     soil_code,
                     soil_description,  -- Only meaningful soil data (8 Danish soil types)
-                    UNNEST(ST_Dump(
+                    ST_MakeValid(UNNEST(ST_Dump(
                         CASE
                             WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
                                 ST_GeomFromText(geometry)
@@ -279,7 +281,7 @@ class SoilTypesPreFilter(PreFilteringStageBase):
                             ELSE
                                 geometry
                         END
-                    )).geom as geometry
+                    )).geom) as geometry
                 FROM soil_types_raw
                 WHERE geometry IS NOT NULL
             """)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/water_projects_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/water_projects_prefilter.py
@@ -163,7 +163,7 @@ class WaterProjectsPreFilter(PreFilteringStageBase):
                 )
                 coord_pairs = []
                 for i, (wkt,) in enumerate(sample_wkt[:3]):
-                    self.log.info(f"   Raw WKT {i+1}: {wkt}")
+                    self.log.info(f"   Raw WKT {i + 1}: {wkt}")
                     # Extract coordinates from "POINT(x y)" format
                     if wkt and "POINT(" in wkt:
                         coords_str = wkt.replace("POINT(", "").replace(")", "")
@@ -173,19 +173,19 @@ class WaterProjectsPreFilter(PreFilteringStageBase):
                                 first_val, second_val = float(coord_parts[0]), float(coord_parts[1])
                                 coord_pairs.append((first_val, second_val))
                                 self.log.info(
-                                    f"   Water Project {i+1}: "
+                                    f"   Water Project {i + 1}: "
                                     f"POINT({first_val:.6f} {second_val:.6f})"
                                 )
                             else:
                                 self.log.warning(
-                                    f"   Water Project {i+1}: "
+                                    f"   Water Project {i + 1}: "
                                     f"Invalid coordinate format: {coords_str}"
                                 )
                         except Exception as parse_e:
-                            self.log.warning(f"   Water Project {i+1}: Parse error: {parse_e}")
+                            self.log.warning(f"   Water Project {i + 1}: Parse error: {parse_e}")
                             continue
                     else:
-                        self.log.warning(f"   Water Project {i+1}: Not a POINT geometry: {wkt}")
+                        self.log.warning(f"   Water Project {i + 1}: Not a POINT geometry: {wkt}")
 
                 if coord_pairs:
                     self.log.info(
@@ -251,11 +251,12 @@ class WaterProjectsPreFilter(PreFilteringStageBase):
         # Handle different geometry formats (WKT string, WKB binary, or already parsed geometry)
         # Use simpler approach: since we know geometry is GEOMETRY type, use it directly
         try:
+            self.log.info("Applying ST_MakeValid to ensure water projects geometry validity...")
             self.conn.execute("""
                 CREATE OR REPLACE TABLE water_projects_full AS
                 SELECT
                     project_id,
-                    UNNEST(ST_Dump(geometry)).geom as geometry
+                    ST_MakeValid(UNNEST(ST_Dump(geometry)).geom) as geometry
                 FROM water_projects_raw
                 WHERE geometry IS NOT NULL
             """)
@@ -264,11 +265,12 @@ class WaterProjectsPreFilter(PreFilteringStageBase):
             self.log.info("🔄 Trying with type-safe CASE statement...")
 
             # Fallback: Use type-safe approach with explicit type checking
+            self.log.info("Applying ST_MakeValid in fallback case...")
             self.conn.execute("""
                 CREATE OR REPLACE TABLE water_projects_full AS
                 SELECT
                     project_id,
-                    UNNEST(ST_Dump(
+                    ST_MakeValid(UNNEST(ST_Dump(
                         CASE
                             WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
                                 ST_GeomFromText(geometry)
@@ -277,7 +279,7 @@ class WaterProjectsPreFilter(PreFilteringStageBase):
                             ELSE
                                 geometry
                         END
-                    )).geom as geometry
+                    )).geom) as geometry
                 FROM water_projects_raw
                 WHERE geometry IS NOT NULL
             """)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/wetlands_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/wetlands_prefilter.py
@@ -122,8 +122,7 @@ class WetlandsPreFilter(PreFilteringStageBase):
         if coord_validation:
             min_x, max_x, min_y, max_y = coord_validation
             self.log.info(
-                f"📍 Coordinate bounds: X({min_x:.2f}, {max_x:.2f}), "
-                f"Y({min_y:.2f}, {max_y:.2f})"
+                f"📍 Coordinate bounds: X({min_x:.2f}, {max_x:.2f}), Y({min_y:.2f}, {max_y:.2f})"
             )
 
             # Check if coordinates are in expected ranges for Denmark
@@ -134,8 +133,7 @@ class WetlandsPreFilter(PreFilteringStageBase):
                 )
             elif min_x >= 440000 and max_x <= 900000 and min_y >= 6040000 and max_y <= 6420000:
                 self.log.info(
-                    "✅ Coordinates appear to be in UTM Zone 32N (EPSG:25832) - "
-                    "Denmark bounds OK"
+                    "✅ Coordinates appear to be in UTM Zone 32N (EPSG:25832) - Denmark bounds OK"
                 )
             else:
                 self.log.warning("⚠️ Coordinates outside expected Denmark bounds!")
@@ -165,7 +163,7 @@ class WetlandsPreFilter(PreFilteringStageBase):
                 )
                 coord_pairs = []
                 for i, (wkt,) in enumerate(sample_wkt[:3]):
-                    self.log.info(f"   Raw WKT {i+1}: {wkt}")
+                    self.log.info(f"   Raw WKT {i + 1}: {wkt}")
                     # Extract coordinates from "POINT(x y)" format
                     if wkt and "POINT(" in wkt:
                         coords_str = wkt.replace("POINT(", "").replace(")", "")
@@ -175,17 +173,17 @@ class WetlandsPreFilter(PreFilteringStageBase):
                                 first_val, second_val = float(coord_parts[0]), float(coord_parts[1])
                                 coord_pairs.append((first_val, second_val))
                                 self.log.info(
-                                    f"   Wetland {i+1}: POINT({first_val:.6f} {second_val:.6f})"
+                                    f"   Wetland {i + 1}: POINT({first_val:.6f} {second_val:.6f})"
                                 )
                             else:
                                 self.log.warning(
-                                    f"   Wetland {i+1}: Invalid coordinate format: {coords_str}"
+                                    f"   Wetland {i + 1}: Invalid coordinate format: {coords_str}"
                                 )
                         except Exception as parse_e:
-                            self.log.warning(f"   Wetland {i+1}: Parse error: {parse_e}")
+                            self.log.warning(f"   Wetland {i + 1}: Parse error: {parse_e}")
                             continue
                     else:
-                        self.log.warning(f"   Wetland {i+1}: Not a POINT geometry: {wkt}")
+                        self.log.warning(f"   Wetland {i + 1}: Not a POINT geometry: {wkt}")
 
                 if coord_pairs:
                     self.log.info(
@@ -250,11 +248,12 @@ class WetlandsPreFilter(PreFilteringStageBase):
         # Handle different geometry formats (WKT string, WKB binary, or already parsed geometry)
         # Use simpler approach: since we know geometry is GEOMETRY type, use it directly
         try:
+            self.log.info("Applying ST_MakeValid to ensure wetlands geometry validity...")
             self.conn.execute("""
                 CREATE OR REPLACE TABLE wetlands_full AS
                 SELECT
                     toerv_pct,
-                    UNNEST(ST_Dump(geometry)).geom as geometry
+                    ST_MakeValid(UNNEST(ST_Dump(geometry)).geom) as geometry
                 FROM wetlands_raw
                 WHERE geometry IS NOT NULL
             """)
@@ -263,11 +262,12 @@ class WetlandsPreFilter(PreFilteringStageBase):
             self.log.info("🔄 Trying with type-safe CASE statement...")
 
             # Fallback: Use type-safe approach with explicit type checking
+            self.log.info("Applying ST_MakeValid in fallback case...")
             self.conn.execute("""
                 CREATE OR REPLACE TABLE wetlands_full AS
                 SELECT
                     toerv_pct,
-                    UNNEST(ST_Dump(
+                    ST_MakeValid(UNNEST(ST_Dump(
                         CASE
                             WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
                                 ST_GeomFromText(geometry)
@@ -276,7 +276,7 @@ class WetlandsPreFilter(PreFilteringStageBase):
                             ELSE
                                 geometry
                         END
-                    )).geom as geometry
+                    )).geom) as geometry
                 FROM wetlands_raw
                 WHERE geometry IS NOT NULL
             """)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/fields_properties.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/fields_properties.py
@@ -48,6 +48,7 @@ class FieldsPropertiesIntersection(FieldAnalysisStageBase):
         self.conn.execute("SET threads=4")  # Can use more threads due to smaller dataset
 
         self.log.info("Preparing fields as BUILD side (spatial index will be created)...")
+        self.log.info("Applying ST_MakeValid to ensure geometry validity...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE agricultural_fields AS
             SELECT
@@ -55,18 +56,19 @@ class FieldsPropertiesIntersection(FieldAnalysisStageBase):
                 block_id,
                 cvr_number,
                 year,
-                geometry,
+                ST_MakeValid(geometry) as geometry,
                 field_uuid,
-                ST_Area_Spheroid(geometry) as field_area_m2
+                ST_Area_Spheroid(ST_MakeValid(geometry)) as field_area_m2
             FROM agricultural_fields_full
         """)
 
         self.log.info("Preparing pre-filtered properties as PROBE side...")
+        self.log.info("Applying ST_MakeValid to ensure property geometry validity...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE properties AS
             SELECT
                 bfe_number,
-                geometry,
+                ST_MakeValid(geometry) as geometry,
                 property_area_m2
             FROM properties_full
         """)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/fields_soil_types.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/fields_soil_types.py
@@ -39,6 +39,7 @@ class FieldsSoilTypesIntersection(FieldAnalysisStageBase):
 
         # Keep agricultural fields as original multipolygons for consistency with other stages
         self.log.info("Preparing agricultural fields (keeping original multipolygons)...")
+        self.log.info("Applying ST_MakeValid to ensure geometry validity...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE agricultural_fields AS
             SELECT
@@ -47,8 +48,8 @@ class FieldsSoilTypesIntersection(FieldAnalysisStageBase):
                 cvr_number,
                 year,
                 field_uuid,
-                geometry,
-                ST_Area_Spheroid(geometry) as field_area_m2
+                ST_MakeValid(geometry) as geometry,
+                ST_Area_Spheroid(ST_MakeValid(geometry)) as field_area_m2
             FROM agricultural_fields_raw
         """)
 
@@ -63,12 +64,13 @@ class FieldsSoilTypesIntersection(FieldAnalysisStageBase):
 
         # OPTIMIZATION: Decompose soil types with ST_Dump for optimal spatial indexing
         self.log.info("Decomposing soil types with ST_Dump for optimal spatial indexing...")
+        self.log.info("Applying ST_MakeValid to ensure soil type geometry validity...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE soil_types AS
             SELECT
                 soil_description,  -- Only keep useful Danish soil type classification
-                UNNEST(ST_Dump(geometry)).geom as geometry,
-                ST_Area_Spheroid(UNNEST(ST_Dump(geometry)).geom) as soil_area_m2
+                ST_MakeValid(UNNEST(ST_Dump(geometry)).geom) as geometry,
+                ST_Area_Spheroid(ST_MakeValid(UNNEST(ST_Dump(geometry)).geom)) as soil_area_m2
             FROM soil_types_raw
         """)
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/water_projects_bnbo.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/water_projects_bnbo.py
@@ -50,12 +50,13 @@ class WaterProjectsBNBOIntersection(FieldAnalysisStageBase):
         # Use ST_Dump for multipolygon decomposition and add unique IDs
         self.log.info("Decomposing BNBO polygons with ST_Dump and adding unique IDs...")
 
-        # Step 1: Decompose multipolygons with ST_Dump
+        # Step 1: Decompose multipolygons with ST_Dump and validate geometry
+        self.log.info("Applying ST_MakeValid to ensure BNBO geometry validity...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE bnbo_status_decomposed AS
             SELECT
                 status_category,
-                UNNEST(ST_Dump(geometry)).geom as geometry
+                ST_MakeValid(UNNEST(ST_Dump(geometry)).geom) as geometry
             FROM bnbo_status_raw
         """)
 
@@ -75,11 +76,12 @@ class WaterProjectsBNBOIntersection(FieldAnalysisStageBase):
         # Clean up temporary table
         self.conn.execute("DROP TABLE IF EXISTS bnbo_status_decomposed")
 
+        self.log.info("Applying ST_MakeValid to ensure water projects geometry validity...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE water_projects AS
             SELECT
                 project_id,
-                UNNEST(ST_Dump(geometry)).geom as geometry
+                ST_MakeValid(UNNEST(ST_Dump(geometry)).geom) as geometry
             FROM water_projects_raw
         """)
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/water_projects_wetlands.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/water_projects_wetlands.py
@@ -68,11 +68,12 @@ class WaterProjectsWetlandsIntersection(FieldAnalysisStageBase):
         # Wetlands = larger dataset (1.6M) as probe side for comprehensive coverage
 
         self.log.info("Decomposing water projects with ST_Dump for optimal spatial indexing...")
+        self.log.info("Applying ST_MakeValid to ensure water projects geometry validity...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE water_projects AS
             SELECT
                 project_id,
-                UNNEST(ST_Dump(geometry)).geom as geometry
+                ST_MakeValid(UNNEST(ST_Dump(geometry)).geom) as geometry
             FROM water_projects_raw
         """)
 
@@ -91,13 +92,14 @@ class WaterProjectsWetlandsIntersection(FieldAnalysisStageBase):
                 "Stage 1: wetlands_raw missing wetland_key; ensure Stage 0 produced it"
             )
 
+        self.log.info("Applying ST_MakeValid to ensure wetlands geometry validity...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE wetlands AS
             SELECT
                 wetland_key, -- Deterministic fragment key for stable joins
                 wetland_id,  -- Legacy numeric ID retained for compatibility
                 toerv_pct,   -- Keep wetland type for analysis
-                geometry     -- Already decomposed by Stage 0 ST_Dump
+                ST_MakeValid(geometry) as geometry  -- Already decomposed by Stage 0 ST_Dump
             FROM wetlands_raw
         """)
 


### PR DESCRIPTION
## 🛠️ Issue Fix
TopologyException errors during spatial intersection operations in the field area analysis pipeline (e.g., at coordinates 54.858038778262781 11.941576330527756).

## 💡 Solution
Added `ST_MakeValid()` geometry validation to all geometry operations across Stage 0 pre-filtering (5 files) and Stage 1 intersection analysis (4 files). Geometries are now validated immediately after loading from Silver datasets and before any spatial operations (ST_Intersection, ST_Intersects, etc.), ensuring topology validity upstream where issues should be fixed.

**Changed files:**
- Stage 0: properties_prefilter, bnbo_prefilter, soil_types_prefilter, water_projects_prefilter, wetlands_prefilter
- Stage 1: fields_properties, fields_soil_types, water_projects_bnbo, water_projects_wetlands

## ✅ How to Do Self-Test
```bash
# Run the unified pipeline to verify topology fixes work:
cd backend/pipelines/unified_pipeline
python main.py

# Confirm pipeline completes without TopologyException errors
```

## 📝 Additional Notes
This addresses invalid geometries in cadastral, agricultural fields, BNBO, wetlands, water projects, and soil types datasets. The fix follows the principle of repairing geometry issues upstream (at the Silver/Gold boundary) rather than downstream, improving overall data quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)