### PR TITLE
fix(workflow): add default value for source input in unified_pipeline_weekly

### DIFF
--- a/.github/workflows/unified_pipeline_weekly.yml
+++ b/.github/workflows/unified_pipeline_weekly.yml
@@ -12,6 +12,7 @@ on:
         description: "Specific weekly source to run (optional - runs all weekly sources if not specified)"
         required: false
         type: choice
+        default: "all_weekly"
         options:
           - "all_weekly"
           - "cvr_enrichment"


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes job skipping in unified_pipeline_weekly.yml when triggered manually without selecting a source value.

## 💡 Solution

Added `default: "all_weekly"` to the source input parameter:
- When workflow is triggered manually without explicit source selection, it now defaults to running all weekly sources
- Prevents empty/null input value from causing conditional evaluation to false
- Maintains backward compatibility with explicit source selection

## ✅ How to Do Self-Test

1. Trigger the workflow manually via GitHub Actions UI without selecting any source
2. Verify that CVR Enrichment jobs run instead of being skipped
3. Test explicit source selection still works correctly

## 📝 Additional Notes

Root cause: The conditional `if: ${{ github.event.inputs.source == 'cvr_enrichment' || github.event.inputs.source == 'all_weekly' || github.event_name == 'schedule' }}` evaluates to false when source is empty, causing all CVR enrichment jobs to be skipped.