### PR TITLE
fix(pipeline): use CTE for BLOB to VARCHAR cast in CVR parser

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cvr_data_parser.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cvr_data_parser.py
@@ -308,20 +308,30 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
         self.log.info("Parsing companies data from raw JSON...")
 
         # Create companies table with comprehensive parsing
+        # Use CTE to cast BLOB to VARCHAR first to avoid DuckDB type issues
         self.conn.execute(f"""
             CREATE OR REPLACE TABLE {companies_table} AS
+            WITH raw_data_with_varchar AS (
+                SELECT
+                    cvr_number,
+                    CAST(raw_json AS VARCHAR) as raw_json_str,
+                    raw_json,
+                    fetch_timestamp
+                FROM {raw_data_table}
+                WHERE raw_json IS NOT NULL
+            )
             SELECT
                 cvr_number,
                 company_uuid(cvr_number) as company_uuid,
-                json_extract_string(raw_json::VARCHAR, '$.company_name') as company_name,
-                json_extract_string(raw_json::VARCHAR, '$.company_type_description')
+                json_extract_string(raw_json_str, '$.company_name') as company_name,
+                json_extract_string(raw_json_str, '$.company_type_description')
                     as company_type_description,
-                json_extract_string(raw_json::VARCHAR, '$.status') as status,
-                json_extract_string(raw_json::VARCHAR, '$.founded_date') as founded_date,
-                json_extract_string(raw_json::VARCHAR, '$.dissolution_date') as dissolution_date,
-                json_extract(raw_json::VARCHAR, '$.advertisement_protection')::BOOLEAN
+                json_extract_string(raw_json_str, '$.status') as status,
+                json_extract_string(raw_json_str, '$.founded_date') as founded_date,
+                json_extract_string(raw_json_str, '$.dissolution_date') as dissolution_date,
+                json_extract(raw_json_str, '$.advertisement_protection')::BOOLEAN
                     as advertisement_protection,
-                json_extract(raw_json::VARCHAR, '$.pnumber_count')::INTEGER as pnumber_count,
+                json_extract(raw_json_str, '$.pnumber_count')::INTEGER as pnumber_count,
                 -- Address fields (will be populated by Address Geocoding step)
                 NULL::VARCHAR as current_full_address,
                 NULL::VARCHAR as current_street_name,
@@ -340,14 +350,14 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
                 NULL::BOOLEAN as dawa_enriched,
                 -- Extract industry information
                 CASE
-                    WHEN json_array_length(json_extract(raw_json::VARCHAR, '$.industries')) > 0 THEN
-                        json_extract_string(json_extract(raw_json::VARCHAR, '$.industries[0]'),
+                    WHEN json_array_length(json_extract(raw_json_str, '$.industries')) > 0 THEN
+                        json_extract_string(json_extract(raw_json_str, '$.industries[0]'),
                                           '$.industry_code')
                     ELSE NULL
                 END as primary_industry_code,
                 CASE
-                    WHEN json_array_length(json_extract(raw_json::VARCHAR, '$.industries')) > 0 THEN
-                        json_extract_string(json_extract(raw_json::VARCHAR, '$.industries[0]'),
+                    WHEN json_array_length(json_extract(raw_json_str, '$.industries')) > 0 THEN
+                        json_extract_string(json_extract(raw_json_str, '$.industries[0]'),
                                           '$.industry_description')
                     ELSE NULL
                 END as primary_industry_description,
@@ -355,8 +365,7 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
                 {self._get_agricultural_classification_sql()} as is_agricultural_company,
                 raw_json as company_data_json,
                 fetch_timestamp as processing_timestamp
-            FROM {raw_data_table}
-            WHERE raw_json IS NOT NULL
+            FROM raw_data_with_varchar
         """)
 
         # Get count and log result
@@ -372,12 +381,17 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
     def _get_agricultural_classification_sql(self) -> str:
         """Get SQL for agricultural company classification."""
         # Extract industry code for readability
-        industry_code_expr = "json_extract_string(json_extract(raw_json::VARCHAR, '$.industries[0]'), '$.industry_code')"
-        is_current_expr = "json_extract(json_extract(raw_json::VARCHAR, '$.industries[0]'), '$.is_current')::BOOLEAN"
+        # Note: Expects raw_json_str (VARCHAR) to be available in the query context
+        industry_code_expr = (
+            "json_extract_string(json_extract(raw_json_str, '$.industries[0]'), '$.industry_code')"
+        )
+        is_current_expr = (
+            "json_extract(json_extract(raw_json_str, '$.industries[0]'), '$.is_current')::BOOLEAN"
+        )
 
         return f"""
             CASE
-                WHEN json_array_length(json_extract(raw_json::VARCHAR, '$.industries')) > 0 THEN
+                WHEN json_array_length(json_extract(raw_json_str, '$.industries')) > 0 THEN
                     CASE
                         WHEN {industry_code_expr} IS NOT NULL
                         AND {is_current_expr} = true
@@ -437,31 +451,40 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
         # Create persons table with leadership extraction
         self.conn.execute(f"""
             CREATE OR REPLACE TABLE {persons_table} AS
-            WITH leadership_flattened AS (
+            WITH raw_data_with_varchar AS (
                 SELECT
                     cvr_number,
-                    idx as leadership_idx
+                    CAST(raw_json AS VARCHAR) as raw_json_str,
+                    raw_json,
+                    fetch_timestamp
                 FROM {raw_data_table}
+            ),
+            leadership_flattened AS (
+                SELECT
+                    cvr_number,
+                    raw_json_str,
+                    fetch_timestamp,
+                    idx as leadership_idx
+                FROM raw_data_with_varchar
                 CROSS JOIN unnest(generate_series(0::BIGINT, (
-                    json_array_length(json_extract(raw_json::VARCHAR, '$.leadership')) - 1
+                    json_array_length(json_extract(raw_json_str, '$.leadership')) - 1
                 )::BIGINT)) as t(idx)
-                WHERE json_array_length(json_extract(raw_json::VARCHAR, '$.leadership')) > 0
+                WHERE json_array_length(json_extract(raw_json_str, '$.leadership')) > 0
             )
             SELECT
                 uuid() as person_uuid,
-                lf.cvr_number,
-                company_uuid(lf.cvr_number) as company_uuid,
-                lf.leadership_idx,
+                cvr_number,
+                company_uuid(cvr_number) as company_uuid,
+                leadership_idx,
                 'leadership' as relation_type,
                 json_extract_string(
-                    json_extract(rd.raw_json::VARCHAR, '$.leadership[' || lf.leadership_idx || ']'),
+                    json_extract(raw_json_str, '$.leadership[' || leadership_idx || ']'),
                     '$.relation_type'
                 ) as person_relation_type,
-                json_extract(rd.raw_json::VARCHAR, '$.leadership[' || lf.leadership_idx || ']')
+                json_extract(raw_json_str, '$.leadership[' || leadership_idx || ']')
                     as person_data_json,
-                rd.fetch_timestamp as processing_timestamp
-            FROM leadership_flattened lf
-            JOIN {raw_data_table} rd ON lf.cvr_number = rd.cvr_number
+                fetch_timestamp as processing_timestamp
+            FROM leadership_flattened
         """)
 
         # Get count and log result
@@ -480,42 +503,51 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
         # Create employment table with temporal data extraction
         self.conn.execute(f"""
             CREATE OR REPLACE TABLE {employment_table} AS
-            WITH employment_flattened AS (
+            WITH raw_data_with_varchar AS (
                 SELECT
                     cvr_number,
-                    idx as employment_idx
+                    CAST(raw_json AS VARCHAR) as raw_json_str,
+                    raw_json,
+                    fetch_timestamp
                 FROM {raw_data_table}
+            ),
+            employment_flattened AS (
+                SELECT
+                    cvr_number,
+                    raw_json_str,
+                    fetch_timestamp,
+                    idx as employment_idx
+                FROM raw_data_with_varchar
                 CROSS JOIN unnest(generate_series(0::BIGINT, (
-                    json_array_length(json_extract(raw_json::VARCHAR, '$.employment')) - 1
+                    json_array_length(json_extract(raw_json_str, '$.employment')) - 1
                 )::BIGINT)) as t(idx)
-                WHERE json_array_length(json_extract(raw_json::VARCHAR, '$.employment')) > 0
+                WHERE json_array_length(json_extract(raw_json_str, '$.employment')) > 0
             )
             SELECT
                 uuid() as employment_uuid,
-                ef.cvr_number,
-                company_uuid(ef.cvr_number) as company_uuid,
-                ef.employment_idx,
+                cvr_number,
+                company_uuid(cvr_number) as company_uuid,
+                employment_idx,
                 json_extract(
-                    json_extract(rd.raw_json::VARCHAR, '$.employment[' || ef.employment_idx || ']'),
+                    json_extract(raw_json_str, '$.employment[' || employment_idx || ']'),
                     '$.employee_count'
                 )::INTEGER as employee_count,
                 json_extract_string(
-                    json_extract(rd.raw_json::VARCHAR, '$.employment[' || ef.employment_idx || ']'),
+                    json_extract(raw_json_str, '$.employment[' || employment_idx || ']'),
                     '$.period_start'
                 ) as period_start,
                 json_extract_string(
-                    json_extract(rd.raw_json::VARCHAR, '$.employment[' || ef.employment_idx || ']'),
+                    json_extract(raw_json_str, '$.employment[' || employment_idx || ']'),
                     '$.period_end'
                 ) as period_end,
                 json_extract(
-                    json_extract(rd.raw_json::VARCHAR, '$.employment[' || ef.employment_idx || ']'),
+                    json_extract(raw_json_str, '$.employment[' || employment_idx || ']'),
                     '$.is_current'
                 )::BOOLEAN as is_current,
-                json_extract(rd.raw_json::VARCHAR, '$.employment[' || ef.employment_idx || ']')
+                json_extract(raw_json_str, '$.employment[' || employment_idx || ']')
                     as employment_data_json,
-                rd.fetch_timestamp as processing_timestamp
-            FROM employment_flattened ef
-            JOIN {raw_data_table} rd ON ef.cvr_number = rd.cvr_number
+                fetch_timestamp as processing_timestamp
+            FROM employment_flattened
         """)
 
         # Get count and log result


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes the CVR data parsing pipeline failure that persisted after PR #519. The inline `::VARCHAR` casts weren't sufficient because DuckDB still treated the column as BLOB type.

## 💡 Solution

Use CTEs (Common Table Expressions) to explicitly `CAST(raw_json AS VARCHAR)` **before** any JSON operations, creating a `raw_json_str` column that all JSON functions operate on.

**Key changes:**
- Wrap all queries with `raw_data_with_varchar` CTE using `CAST(raw_json AS VARCHAR)`
- Update all JSON operations to use `raw_json_str` instead of `raw_json`
- Apply to `_parse_companies_data()`, `_parse_persons_data()`, `_parse_employment_data()`
- Update `_get_agricultural_classification_sql()` to expect `raw_json_str` in context

**Why this works:** By casting in a CTE first, DuckDB materializes the VARCHAR type before it reaches JSON functions, preventing BLOB type from propagating through the query and causing the `substr(BLOB, ...)` error.

## ✅ How to Test

Run the CVR enrichment pipeline data_parsing step:
```bash
cd backend/pipelines/unified_pipeline
python -u -m unified_pipeline run -s cvr_enrichment -j data_parsing
```

Should complete successfully and parse all company, person, and employment records without BLOB type errors.