### PR TITLE
fix(pipeline): cast crypto_hash BLOB to VARCHAR in company_uuid

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cvr_data_parser.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cvr_data_parser.py
@@ -129,6 +129,7 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
             raise ValueError("LANDBRUGSDATA_UUID_NAMESPACE environment variable is required")
 
         # Create company UUID function using namespace from environment
+        # Cast crypto_hash BLOB result to VARCHAR to avoid substr() type errors
         self.conn.execute(f"""
             CREATE OR REPLACE FUNCTION company_uuid(cvr_number) AS (
                 SELECT CASE
@@ -137,16 +138,16 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
                                                '^[1-9][0-9]{{7}}$')
                     THEN NULL
                     ELSE CONCAT(
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                               TRIM(CAST(cvr_number AS VARCHAR)))), 1, 8), '-',
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                               TRIM(CAST(cvr_number AS VARCHAR)))), 9, 4), '-',
-                        '5', SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                                      TRIM(CAST(cvr_number AS VARCHAR)))), 13, 3), '-',
-                        CONCAT('8', SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                                               TRIM(CAST(cvr_number AS VARCHAR)))), 17, 3)), '-',
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                               TRIM(CAST(cvr_number AS VARCHAR)))), 21, 12)
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                               TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 1, 8), '-',
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                               TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 9, 4), '-',
+                        '5', SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                                      TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 13, 3), '-',
+                        CONCAT('8', SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                                               TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 17, 3)), '-',
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                               TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 21, 12)
                     )
                 END
             )


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes the remaining BLOB error in CVR data parsing. After fixing raw_json handling in PR #521, the pipeline still failed because the `company_uuid()` function also has BLOB issues.

**Error:**
```
Binder Error: No function matches 'substr(BLOB, INTEGER_LITERAL, INTEGER_LITERAL)'
LINE 14: company_uuid(cvr_number) as company_uuid,
```

## 💡 Solution

Cast `crypto_hash('md5', ...)` results to VARCHAR before using SUBSTR.

`crypto_hash()` returns BLOB type, which causes SUBSTR() to fail. This fix wraps every `crypto_hash()` call with `CAST(... AS VARCHAR)` in the `company_uuid()` UDF.

**Changes:**
- Updated all 5 `SUBSTR(crypto_hash(...))` calls to `SUBSTR(CAST(crypto_hash(...) AS VARCHAR))`
- Applied in the `company_uuid()` function definition

## ✅ Test

```bash
cd backend/pipelines/unified_pipeline  
python -u -m unified_pipeline run -s cvr_enrichment -j data_parsing
```

Should now successfully parse all CVR data without any BLOB type errors.