### PR TITLE
fix(pipeline): increase CVR parser memory limit to 6GB

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cvr_data_parser.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cvr_data_parser.py
@@ -112,14 +112,16 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
         self.log.info("🔧 Applying CVR data parser memory optimizations...")
 
         # Conservative memory settings for parsing
-        self.conn.execute("SET memory_limit = '4GB'")
-        self.conn.execute("SET max_memory = '4GB'")
+        self.conn.execute("SET memory_limit = '6GB'")
+        self.conn.execute("SET max_memory = '6GB'")
         self.conn.execute("SET threads = 2")
         self.conn.execute("SET temp_directory = '/tmp'")
+        self.conn.execute("SET preserve_insertion_order = false")
 
         self.log.info("✅ CVR data parser memory optimizations applied")
-        self.log.info("   • Memory limit: 4GB")
+        self.log.info("   • Memory limit: 6GB")
         self.log.info("   • Threads: 2")
+        self.log.info("   • Preserve insertion order: false")
         self.log.info("   • Processing: Batch-based with immediate cleanup")
 
     def _setup_uuid_functions(self):


### PR DESCRIPTION
## 🛠️ Issue Fix

After fixing the BLOB type errors (PRs #521, #522), the CVR parser now fails with Out of Memory error at 3.7GB/3.7GB.

**Error:**
```
Out of Memory Error: failed to allocate data of size 16.0 MiB (3.7 GiB/3.7 GiB used)
```

## 💡 Solution

The CTE-based VARCHAR conversion approach uses more memory than the inline casts (because it materializes the conversion). Increase memory limit and optimize memory usage.

**Changes:**
- Increase `memory_limit` from 4GB → 6GB
- Increase `max_memory` from 4GB → 6GB  
- Set `preserve_insertion_order = false` (reduces memory overhead)

## ✅ Test

```bash
cd backend/pipelines/unified_pipeline
python -u -m unified_pipeline run -s cvr_enrichment -j data_parsing
```

Should parse all ~58K CVR companies without OOM errors.

## 📊 Progress

- ✅ Fixed BLOB errors in `raw_json` (PR #521)
- ✅ Fixed BLOB errors in `crypto_hash()` (PR #522)
- ✅ Increased memory limit for CTE approach (this PR)