### PR TITLE
fix(backend): resolve 500 error in pesticide CVR search

### DIFF
--- a/backend/api/supabase/functions/pesticide-analysis/index.ts
+++ b/backend/api/supabase/functions/pesticide-analysis/index.ts
@@ -89,12 +89,12 @@ serve(async (req) => {
     const supabase = createClient(supabaseUrl, supabaseKey);
 
     // Use the RPC function instead of direct table query to get properly aggregated data
-    const { data: rawCompanies, error: companiesError } = await supabase.rpc(
+    const { data: rawCompanies, error: companiesError} = await supabase.rpc(
       "get_pesticide_companies",
       {
         p_years: params.years && params.years.length > 0 ? params.years : null,
         p_geography: params.geography !== "country" ? params.geography : null,
-        p_cvr: params.cvr ? BigInt(params.cvr) : null,
+        p_cvr: params.cvr ? parseInt(params.cvr) : null,
         p_pesticide_type: params.type || "total",
         p_sort_by: params.sortBy || "total_belastning",
         p_sort_order: params.sortOrder || "desc",
@@ -111,7 +111,7 @@ serve(async (req) => {
       {
         p_years: params.years && params.years.length > 0 ? params.years : null,
         p_geography: params.geography !== "country" ? params.geography : null,
-        p_cvr: params.cvr ? BigInt(params.cvr) : null,
+        p_cvr: params.cvr ? parseInt(params.cvr) : null,
       }
     );
 


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes pesticide analysis CVR search returning 500 error on https://www.landbruget.dk/pesticidanalyse

## 💡 Solution
The pesticide-analysis Edge Function was using `BigInt()` to convert CVR parameters before passing them to Supabase RPC functions. BigInt objects cannot be serialized to JSON, causing a runtime error when executing the RPC calls.

Changed from `BigInt(params.cvr)` to `parseInt(params.cvr)` in both RPC calls:
- `get_pesticide_companies()` call at line 97
- `get_pesticide_metadata()` call at line 114

This ensures CVR numbers are properly serialized as integers for the RPC function parameters.

## ✅ How to Do Self-Test
1. Visit https://www.landbruget.dk/pesticidanalyse
2. Enter a valid CVR number (e.g., 31373077)
3. Verify the search returns companies without a 500 error
4. Click on a company to verify the details panel loads correctly

## 📝 Additional Notes
The fix is minimal and focused - only changing the type conversion method for CVR parameters to ensure JSON serializability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)