### PR TITLE
fix(edge-function): correct Deno import specifiers in search function

### DIFF
--- a/backend/api/supabase/functions/search/deno.json
+++ b/backend/api/supabase/functions/search/deno.json
@@ -5,7 +5,7 @@
     "strict": true
   },
   "imports": {
-    "std/": "https://deno.land/std@0.168.0/",
+    "std/http/server": "https://deno.land/std@0.168.0/http/server.ts",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
   }
 }

--- a/backend/api/supabase/functions/search/index.ts
+++ b/backend/api/supabase/functions/search/index.ts
@@ -1,5 +1,5 @@
-import { serve } from "std/http/server.ts";
-import { createClient } from "@supabase/supabase-js";
+import { serve } from 'std/http/server';
+import { createClient } from '@supabase/supabase-js';
 
 // --- Types ---
 interface SearchResult {


### PR DESCRIPTION
## Summary
- Fixed Edge Function deployment failure in the `search` function
- Corrected Deno import specifiers to match the import map
- Aligned with import patterns used in other working Edge Functions

## Problem
The `search` Edge Function was failing to deploy with the error:
```
Relative import path "@supabase/supabase-js" not prefixed with / or ./ or ../
at file:///home/runner/work/landbruget.dk/landbruget.dk/backend/api/supabase/functions/search/index.ts:2:30
```

## Root Cause
- Import statement used `"std/http/server.ts"` (with file extension)
- But `deno.json` mapped `"std/"` (prefix) instead of the exact path
- Deno couldn't resolve the import because of the mismatch

## Solution
1. Changed import from `"std/http/server.ts"` to `'std/http/server'` (no extension)
2. Updated `deno.json` to map the exact import path: `"std/http/server": "https://deno.land/std@0.168.0/http/server.ts"`
3. Also standardized quote style to match other functions (single quotes)

## Test Plan
- [ ] Verify Edge Function deploys successfully in CI
- [ ] Confirm other Edge Functions continue to deploy
- [ ] Test search functionality in production after deploy

## References
- Failed deployment: https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/20968350080
- Similar working function: `company-basic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)