### PR TITLE
revert: remove ST_FlipCoordinates from stage 4 area calculations

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage4/consolidate_two_tables.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage4/consolidate_two_tables.py
@@ -143,15 +143,15 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
             CREATE OR REPLACE TABLE bnbo_field_aggregates AS
             SELECT
                 field_uuid,
-                SUM(ST_Area_Spheroid(ST_FlipCoordinates(field_bnbo_geometry)) as field_bnbo_total_m2,
+                SUM(ST_Area_Spheroid(field_bnbo_geometry)) as field_bnbo_total_m2,
                 COUNT(DISTINCT status_category) as bnbo_status_count,
                 STRING_AGG(DISTINCT status_category, ', ' ORDER BY status_category)
                     as bnbo_status_categories,
                 SUM(CASE WHEN status_category = 'Action Required'
-                    THEN ST_Area_Spheroid(ST_FlipCoordinates(field_bnbo_geometry)) ELSE 0 END) / 10000.0
+                    THEN ST_Area_Spheroid(field_bnbo_geometry) ELSE 0 END) / 10000.0
                     as bnbo_action_required_hectares,
                 SUM(CASE WHEN status_category = 'Completed'
-                    THEN ST_Area_Spheroid(ST_FlipCoordinates(field_bnbo_geometry)) ELSE 0 END) / 10000.0
+                    THEN ST_Area_Spheroid(field_bnbo_geometry) ELSE 0 END) / 10000.0
                     as bnbo_completed_hectares
             FROM field_bnbo_intersections
             GROUP BY field_uuid
@@ -162,13 +162,13 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
             CREATE OR REPLACE TABLE bnbo_water_field_aggregates AS
             SELECT
                 field_uuid,
-                SUM(ST_Area_Spheroid(ST_FlipCoordinates(field_bnbo_water_geometry))
+                SUM(ST_Area_Spheroid(field_bnbo_water_geometry))
                     as field_bnbo_water_covered_m2,
                 SUM(CASE WHEN status_category = 'Action Required'
-                    THEN ST_Area_Spheroid(ST_FlipCoordinates(field_bnbo_water_geometry)) ELSE 0 END) / 10000.0
+                    THEN ST_Area_Spheroid(field_bnbo_water_geometry) ELSE 0 END) / 10000.0
                     as bnbo_action_required_water_covered_hectares,
                 SUM(CASE WHEN status_category = 'Completed'
-                    THEN ST_Area_Spheroid(ST_FlipCoordinates(field_bnbo_water_geometry)) ELSE 0 END) / 10000.0
+                    THEN ST_Area_Spheroid(field_bnbo_water_geometry) ELSE 0 END) / 10000.0
                     as bnbo_completed_water_covered_hectares
             FROM field_bnbo_water_intersections
             GROUP BY field_uuid
@@ -181,7 +181,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
             SELECT
                 field_uuid,
                 -- Simple area sum - overlaps already resolved in wetlands_dissolved silver layer
-                SUM(ST_Area_Spheroid(ST_FlipCoordinates(field_wetland_geometry)) as field_wetland_total_m2
+                SUM(ST_Area_Spheroid(field_wetland_geometry)) as field_wetland_total_m2
             FROM field_wetland_intersections
             GROUP BY field_uuid
         """)
@@ -192,7 +192,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
             CREATE OR REPLACE TABLE wetland_water_field_aggregates AS
             SELECT
                 field_uuid,
-                SUM(ST_Area_Spheroid(ST_FlipCoordinates(field_wetland_water_geometry))
+                SUM(ST_Area_Spheroid(field_wetland_water_geometry))
                     as field_wetland_water_covered_m2
             FROM field_wetland_water_intersections
             GROUP BY field_uuid
@@ -236,7 +236,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                 f.block_id,
                 f.cvr_number,
                 f.year,
-                ST_Area_Spheroid(ST_FlipCoordinates(f.geometry)) as field_area_m2,
+                ST_Area_Spheroid(f.geometry) as field_area_m2,
 
                 -- BNBO Analysis (using pre-aggregated data)
                 COALESCE(ba.field_bnbo_total_m2, 0) as field_bnbo_total_m2,
@@ -250,11 +250,11 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                             COALESCE(ba.field_bnbo_total_m2, 0),
                             CASE
                                 WHEN COALESCE(ba.field_bnbo_total_m2, 0) -
-                                     ST_Area_Spheroid(ST_FlipCoordinates(f.geometry)) <= 0.1
-                                THEN ST_Area_Spheroid(ST_FlipCoordinates(f.geometry))
+                                     ST_Area_Spheroid(f.geometry) <= 0.1
+                                THEN ST_Area_Spheroid(f.geometry)
                                 ELSE COALESCE(ba.field_bnbo_total_m2, 0)
                             END
-                        ) / ST_Area_Spheroid(ST_FlipCoordinates(f.geometry))
+                        ) / ST_Area_Spheroid(f.geometry)
                     ) * 100.0
                     ELSE 0
                 END as field_bnbo_coverage_pct,
@@ -298,11 +298,11 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                             COALESCE(wa.field_wetland_total_m2, 0),
                             CASE
                                 WHEN COALESCE(wa.field_wetland_total_m2, 0) -
-                                     ST_Area_Spheroid(ST_FlipCoordinates(f.geometry)) <= 0.1
-                                THEN ST_Area_Spheroid(ST_FlipCoordinates(f.geometry))
+                                     ST_Area_Spheroid(f.geometry) <= 0.1
+                                THEN ST_Area_Spheroid(f.geometry)
                                 ELSE COALESCE(wa.field_wetland_total_m2, 0)
                             END
-                        ) / ST_Area_Spheroid(ST_FlipCoordinates(f.geometry))
+                        ) / ST_Area_Spheroid(f.geometry)
                     ) * 100.0
                     ELSE 0
                 END as field_wetland_coverage_pct,
@@ -331,7 +331,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                 CASE
                     WHEN COALESCE(sa.field_soil_total_m2, 0) > 0
                     THEN (COALESCE(sa.field_soil_total_m2, 0) /
-                          ST_Area_Spheroid(ST_FlipCoordinates(f.geometry)) * 100.0
+                          ST_Area_Spheroid(f.geometry)) * 100.0
                     ELSE 0
                 END as field_soil_coverage_pct,
                 COALESCE(sa.soil_type_count, 0) as soil_type_count,
@@ -366,15 +366,15 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
             SELECT
                 field_uuid,
                 bfe_number,
-                SUM(ST_Area_Spheroid(ST_FlipCoordinates(property_bnbo_geometry)) as property_bnbo_total_m2,
+                SUM(ST_Area_Spheroid(property_bnbo_geometry)) as property_bnbo_total_m2,
                 COUNT(DISTINCT status_category) as property_bnbo_status_count,
                 STRING_AGG(DISTINCT status_category, ', ' ORDER BY status_category)
                     as property_bnbo_status_categories,
                 SUM(CASE WHEN status_category = 'Action Required'
-                    THEN ST_Area_Spheroid(ST_FlipCoordinates(property_bnbo_geometry)) ELSE 0 END) / 10000.0
+                    THEN ST_Area_Spheroid(property_bnbo_geometry) ELSE 0 END) / 10000.0
                     as property_bnbo_action_required_hectares,
                 SUM(CASE WHEN status_category = 'Completed'
-                    THEN ST_Area_Spheroid(ST_FlipCoordinates(property_bnbo_geometry)) ELSE 0 END) / 10000.0
+                    THEN ST_Area_Spheroid(property_bnbo_geometry) ELSE 0 END) / 10000.0
                     as property_bnbo_completed_hectares
             FROM property_bnbo_intersections
             GROUP BY field_uuid, bfe_number
@@ -386,13 +386,13 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
             SELECT
                 field_uuid,
                 bfe_number,
-                SUM(ST_Area_Spheroid(ST_FlipCoordinates(property_bnbo_water_geometry))
+                SUM(ST_Area_Spheroid(property_bnbo_water_geometry))
                     as property_bnbo_water_covered_m2,
                 SUM(CASE WHEN status_category = 'Action Required'
-                    THEN ST_Area_Spheroid(ST_FlipCoordinates(property_bnbo_water_geometry)) ELSE 0 END) / 10000.0
+                    THEN ST_Area_Spheroid(property_bnbo_water_geometry) ELSE 0 END) / 10000.0
                     as property_bnbo_action_required_water_covered_hectares,
                 SUM(CASE WHEN status_category = 'Completed'
-                    THEN ST_Area_Spheroid(ST_FlipCoordinates(property_bnbo_water_geometry)) ELSE 0 END) / 10000.0
+                    THEN ST_Area_Spheroid(property_bnbo_water_geometry) ELSE 0 END) / 10000.0
                     as property_bnbo_completed_water_covered_hectares
             FROM property_bnbo_water_intersections
             GROUP BY field_uuid, bfe_number
@@ -404,7 +404,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
             SELECT
                 field_uuid,
                 bfe_number,
-                SUM(ST_Area_Spheroid(ST_FlipCoordinates(property_wetland_geometry)) as property_wetland_total_m2
+                SUM(ST_Area_Spheroid(property_wetland_geometry)) as property_wetland_total_m2
             FROM property_wetland_intersections
             GROUP BY field_uuid, bfe_number
         """)
@@ -415,7 +415,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
             SELECT
                 field_uuid,
                 bfe_number,
-                SUM(ST_Area_Spheroid(ST_FlipCoordinates(property_wetland_water_geometry))
+                SUM(ST_Area_Spheroid(property_wetland_water_geometry))
                     as property_wetland_water_covered_m2
             FROM property_wetland_water_intersections
             GROUP BY field_uuid, bfe_number
@@ -433,7 +433,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                 fp.block_id,
                 fp.cvr_number,
                 fp.year,
-                ST_Area_Spheroid(ST_FlipCoordinates(fp.intersection_geometry)) as property_intersection_area_m2,
+                ST_Area_Spheroid(fp.intersection_geometry) as property_intersection_area_m2,
 
                 -- Environmental data from pre-aggregated tables
                 COALESCE(pba.property_bnbo_total_m2, 0) as property_bnbo_total_m2,


### PR DESCRIPTION
## Summary

Reverts commit 5fa785bc (PR #527) which incorrectly added `ST_FlipCoordinates` to all `ST_Area_Spheroid` calls.

### Analysis of Actual Data

Downloaded and analyzed parquet files from GCS:
- `field_analysis_field_bnbo_intersections_2025/data.parquet`
- `agricultural_fields_2025/data.parquet`

**Findings:**
1. Data coordinates ARE stored reversed (lat in X, lon in Y)
2. But official Danish government `area_ha` matches **DIRECT** calculation (1.4% error)
3. With `ST_FlipCoordinates`, the error is **79%** - almost double the correct values

### Example Comparison

| Field | Official (ha) | Direct calc (ha) | Flipped calc (ha) |
|-------|---------------|------------------|-------------------|
| 7-9   | 0.4900        | 0.4970 (1.4% err)| 0.8772 (79% err)  |
| 17-2  | 0.2000        | 0.2006 (0.3% err)| 0.3530 (77% err)  |

### Conclusion

Adding `ST_FlipCoordinates` would **break** all area calculations, producing values nearly double what they should be.

The CI check requiring `ST_FlipCoordinates` needs to be fixed separately - it's enforcing incorrect behavior for this data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)