### PR TITLE
fix(pipeline): detect NLES5 years from actual data

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/config.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/config.py
@@ -88,8 +88,8 @@ class PMTilesGeneratorConfig(BaseJobConfig):
         description="Pesticide proximity path template",
     )
     nles5_estimation_path: str = Field(
-        default="gold/nles5_nitrogen_estimation/latest/",
-        description="NLES5 nitrogen estimation path",
+        default="gold/nles5_nitrogen_estimation_nitrogen_estimates/latest/",
+        description="NLES5 nitrogen estimation path (uses latest timestamped directory)",
     )
 
     # Environmental layers (year-independent)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/year_detector.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/year_detector.py
@@ -152,23 +152,59 @@ class DataSourceYearDetector:
             List of available years from the NLES5 dataset
         """
         try:
-            # NLES5 data is in a single 'latest' directory, but contains multiple years
-            # We need to check the actual data to see what years are available
-            nles5_path = f"gs://{self.config.gcs_bucket}/gold/nles5_nitrogen_estimation/latest/"
+            # NLES5 data is stored in timestamped directories under
+            # gold/nles5_nitrogen_estimation_nitrogen_estimates/{timestamp}/
+            nles5_base_path = (
+                f"gs://{self.config.gcs_bucket}/gold/nles5_nitrogen_estimation_nitrogen_estimates/"
+            )
 
-            # Check if the path exists
-            paths = await asyncio.to_thread(self.gcs.list_files, f"{nles5_path}*")
+            # Check if the base path exists
+            paths = await asyncio.to_thread(self.gcs.list_files, f"{nles5_base_path}*")
             if not paths:
                 logger.warning("NLES5 data path not found")
                 return []
 
-            # For now, return the known years from the documentation
-            # TODO: In a full implementation, we could query the actual data to get available years
-            # Based on the plan, NLES5 covers 2021-2022 and can be extended to 2025
-            known_nles5_years = [2021, 2022]
+            # Find timestamped directories (format: YYYYMMDD_HHMMSS)
+            timestamp_dirs = []
+            for path in paths:
+                # Extract directory name from path
+                parts = path.replace(nles5_base_path, "").split("/")
+                if parts and parts[0] and parts[0][0].isdigit():
+                    timestamp_dirs.append(parts[0])
 
-            logger.info(f"NLES5 data found, assuming years: {known_nles5_years}")
-            return known_nles5_years
+            if not timestamp_dirs:
+                logger.warning("No NLES5 timestamped directories found")
+                return []
+
+            # Use the most recent timestamp directory
+            latest_timestamp = sorted(timestamp_dirs)[-1]
+            latest_path = f"{nles5_base_path}{latest_timestamp}/data.parquet"
+
+            logger.info(f"Checking NLES5 data in latest directory: {latest_timestamp}")
+
+            # Query the parquet file to get available years using DuckDB
+            try:
+                query = f"""
+                SELECT DISTINCT year
+                FROM read_parquet('{latest_path}')
+                ORDER BY year
+                """
+                result = await asyncio.to_thread(self.gcs.duckdb_conn.execute, query)
+                years = [row[0] for row in result.fetchall()]
+
+                if years:
+                    logger.info(f"NLES5 years detected from data: {years}")
+                    return years
+                else:
+                    logger.warning("No years found in NLES5 data")
+                    return []
+
+            except Exception as query_error:
+                logger.warning(f"Could not query NLES5 data for years: {query_error}")
+                # Fallback to known years from documentation
+                known_years = [2021, 2022]
+                logger.info(f"Using fallback NLES5 years: {known_years}")
+                return known_years
 
         except Exception as e:
             logger.error(f"Error detecting NLES5 years: {e}")

--- a/backend/pipelines/unified_pipeline/test_year_detection.py
+++ b/backend/pipelines/unified_pipeline/test_year_detection.py
@@ -35,8 +35,8 @@ async def main():
         cloudflare_r2_bucket="",
     )
 
-    # Initialize GCS access and year detector
-    gcs_access = GCSDataAccess(config)
+    # Initialize GCS access (creates its own DuckDB connection) and year detector
+    gcs_access = GCSDataAccess()  # No connection parameter - creates new one
     year_detector = DataSourceYearDetector(config, gcs_access)
 
     # Detect available years


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes NLES5 nitrogen estimation year detection returning empty list.

## 💡 Solution
- Corrected NLES5 data path from `gold/nles5_nitrogen_estimation/latest/` to `gold/nles5_nitrogen_estimation_nitrogen_estimates/{timestamp}/`
- Auto-detect latest timestamped directory (format: `YYYYMMDD_HHMMSS`)
- Query parquet file using DuckDB to discover available years from actual data
- Fallback to known years [2021, 2022] if DuckDB query fails

## ✅ How to Do Self-Test
```bash
cd backend/pipelines/unified_pipeline
uv run python test_year_detection.py
```

Should show:
```
NLES5 years detected from data: [2021, 2022, 2023]
nles5_estimation: 3 years -> [2021, 2022, 2023]
```

## 📝 Additional Notes
- Builds on #536 (field_production fix)
- Now all data sources are properly detected
- NLES5 data will be included in PMTiles for years 2021-2023
- More robust: automatically discovers new years as NLES5 data is updated