### PR TITLE
fix(pipeline): prevent DuckDB UINT64 overflow in CVR data parsing

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/company_fetching.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/company_fetching.py
@@ -927,16 +927,31 @@ class CompanyFetching(BaseSource[CompanyFetchingConfig], GoldJobInterface):
 
     def _create_batch_persons_table(self, json_strings: list[str], table_name: str) -> None:
         """Create persons table for a single batch."""
+        # Note: Filter for leadership_count > 0 BEFORE generate_series to avoid
+        # UINT64 overflow when computing (0 - 1) on empty arrays
         self.conn.execute(
             f"""
             CREATE TABLE {table_name} AS
-            WITH leadership_flattened AS (
+            WITH raw_with_leadership_count AS (
                 SELECT
+                    json_data,
                     json_extract(json_data, '$.cvr_number')::INTEGER as cvr_number,
-                    idx as leadership_idx
+                    json_array_length(json_extract(json_data, '$.leadership')) as leadership_count
                 FROM unnest($1) as t(json_data)
-                CROSS JOIN unnest(generate_series(0, json_array_length(json_extract(json_data, '$.leadership')) - 1)) as t2(idx)
-                WHERE json_array_length(json_extract(json_data, '$.leadership')) > 0
+            ),
+            filtered_with_leadership AS (
+                -- Filter BEFORE generate_series to avoid UINT64 overflow on (0-1)
+                SELECT *
+                FROM raw_with_leadership_count
+                WHERE leadership_count > 0
+            ),
+            leadership_flattened AS (
+                SELECT
+                    cvr_number,
+                    json_data,
+                    idx as leadership_idx
+                FROM filtered_with_leadership
+                CROSS JOIN unnest(generate_series(0, (leadership_count - 1)::BIGINT)) as t2(idx)
             )
             SELECT
                 uuid() as person_uuid,
@@ -947,24 +962,38 @@ class CompanyFetching(BaseSource[CompanyFetchingConfig], GoldJobInterface):
                 json_extract_string(json_extract(json_data, '$.leadership[' || leadership_idx || ']'), '$.relation_type') as person_relation_type,
                 json_data as person_data_json,
                 json_extract_string(json_data, '$.processing_timestamp') as processing_timestamp
-            FROM leadership_flattened lf
-            JOIN unnest($1) as t(json_data) ON json_extract(json_data, '$.cvr_number')::INTEGER = lf.cvr_number
+            FROM leadership_flattened
         """,
             [json_strings],
         )
 
     def _create_batch_employment_table(self, json_strings: list[str], table_name: str) -> None:
         """Create employment table for a single batch."""
+        # Note: Filter for employment_count > 0 BEFORE generate_series to avoid
+        # UINT64 overflow when computing (0 - 1) on empty arrays
         self.conn.execute(
             f"""
             CREATE TABLE {table_name} AS
-            WITH employment_flattened AS (
+            WITH raw_with_employment_count AS (
                 SELECT
+                    json_data,
                     json_extract(json_data, '$.cvr_number')::INTEGER as cvr_number,
-                    idx as employment_idx
+                    json_array_length(json_extract(json_data, '$.employment')) as employment_count
                 FROM unnest($1) as t(json_data)
-                CROSS JOIN unnest(generate_series(0, json_array_length(json_extract(json_data, '$.employment')) - 1)) as t2(idx)
-                WHERE json_array_length(json_extract(json_data, '$.employment')) > 0
+            ),
+            filtered_with_employment AS (
+                -- Filter BEFORE generate_series to avoid UINT64 overflow on (0-1)
+                SELECT *
+                FROM raw_with_employment_count
+                WHERE employment_count > 0
+            ),
+            employment_flattened AS (
+                SELECT
+                    cvr_number,
+                    json_data,
+                    idx as employment_idx
+                FROM filtered_with_employment
+                CROSS JOIN unnest(generate_series(0, (employment_count - 1)::BIGINT)) as t2(idx)
             )
             SELECT
                 uuid() as employment_uuid,
@@ -977,8 +1006,7 @@ class CompanyFetching(BaseSource[CompanyFetchingConfig], GoldJobInterface):
                 json_extract(json_extract(json_data, '$.employment[' || employment_idx || ']'), '$.is_current')::BOOLEAN as is_current,
                 json_data as employment_data_json,
                 json_extract_string(json_data, '$.processing_timestamp') as processing_timestamp
-            FROM employment_flattened ef
-            JOIN unnest($1) as t(json_data) ON json_extract(json_data, '$.cvr_number')::INTEGER = ef.cvr_number
+            FROM employment_flattened
         """,
             [json_strings],
         )

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cvr_data_parser.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cvr_data_parser.py
@@ -452,6 +452,8 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
         self.log.info("Parsing persons/leadership data from raw JSON...")
 
         # Create persons table with leadership extraction
+        # Note: We filter for leadership_count > 0 BEFORE the generate_series to avoid
+        # UINT64 overflow when computing (0 - 1) in generate_series upper bound
         self.conn.execute(f"""
             CREATE OR REPLACE TABLE {persons_table} AS
             WITH raw_data_with_varchar AS (
@@ -459,8 +461,15 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
                     cvr_number,
                     CAST(raw_json AS VARCHAR) as raw_json_str,
                     raw_json,
-                    fetch_timestamp
+                    fetch_timestamp,
+                    json_array_length(json_extract(CAST(raw_json AS VARCHAR), '$.leadership')) as leadership_count
                 FROM {raw_data_table}
+            ),
+            raw_data_with_leadership AS (
+                -- Filter BEFORE generate_series to avoid UINT64 overflow on (0-1)
+                SELECT *
+                FROM raw_data_with_varchar
+                WHERE leadership_count > 0
             ),
             leadership_flattened AS (
                 SELECT
@@ -468,11 +477,10 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
                     raw_json_str,
                     fetch_timestamp,
                     idx as leadership_idx
-                FROM raw_data_with_varchar
+                FROM raw_data_with_leadership
                 CROSS JOIN unnest(generate_series(0::BIGINT,
-                    (GREATEST(0, json_array_length(json_extract(raw_json_str, '$.leadership')) - 1))::BIGINT
+                    (leadership_count - 1)::BIGINT
                 )) as t(idx)
-                WHERE json_array_length(json_extract(raw_json_str, '$.leadership')) > 0
             )
             SELECT
                 uuid() as person_uuid,
@@ -504,6 +512,8 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
         self.log.info("Parsing employment data from raw JSON...")
 
         # Create employment table with temporal data extraction
+        # Note: We filter for employment_count > 0 BEFORE the generate_series to avoid
+        # UINT64 overflow when computing (0 - 1) in generate_series upper bound
         self.conn.execute(f"""
             CREATE OR REPLACE TABLE {employment_table} AS
             WITH raw_data_with_varchar AS (
@@ -511,8 +521,15 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
                     cvr_number,
                     CAST(raw_json AS VARCHAR) as raw_json_str,
                     raw_json,
-                    fetch_timestamp
+                    fetch_timestamp,
+                    json_array_length(json_extract(CAST(raw_json AS VARCHAR), '$.employment')) as employment_count
                 FROM {raw_data_table}
+            ),
+            raw_data_with_employment AS (
+                -- Filter BEFORE generate_series to avoid UINT64 overflow on (0-1)
+                SELECT *
+                FROM raw_data_with_varchar
+                WHERE employment_count > 0
             ),
             employment_flattened AS (
                 SELECT
@@ -520,11 +537,10 @@ class CVRDataParser(BaseSource[CVRDataParserConfig], SilverJobInterface):
                     raw_json_str,
                     fetch_timestamp,
                     idx as employment_idx
-                FROM raw_data_with_varchar
+                FROM raw_data_with_employment
                 CROSS JOIN unnest(generate_series(0::BIGINT,
-                    (GREATEST(0, json_array_length(json_extract(raw_json_str, '$.employment')) - 1))::BIGINT
+                    (employment_count - 1)::BIGINT
                 )) as t(idx)
-                WHERE json_array_length(json_extract(raw_json_str, '$.employment')) > 0
             )
             SELECT
                 uuid() as employment_uuid,


### PR DESCRIPTION
## Summary
- Fix overflow error in weekly CVR pipeline that caused the Silver Layer parsing to fail
- Root cause: DuckDB's `json_array_length()` returns UBIGINT, and computing `(0 - 1)` for empty arrays caused unsigned integer overflow
- Solution: Filter rows with empty arrays BEFORE the `generate_series` call

## Problem
The weekly pipeline failed with:
```
Out of Range Error: Overflow in subtraction of UINT64 (0 - 1)!
```
https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/21082330074

## Solution
Changed the SQL pattern from:
```sql
-- OLD (buggy): Subtraction happens BEFORE filter
CROSS JOIN generate_series(0, GREATEST(0, json_array_length(...) - 1))
WHERE json_array_length(...) > 0
```

To:
```sql
-- NEW (fixed): Filter BEFORE subtraction
WITH data_with_count AS (
    SELECT *, json_array_length(...) as count FROM ...
),
filtered AS (
    SELECT * FROM data_with_count WHERE count > 0  -- Filter first!
),
flattened AS (
    SELECT ... FROM filtered
    CROSS JOIN generate_series(0, (count - 1)::BIGINT)  -- Safe now
)
```

## Files Changed
- `cvr_data_parser.py`: Fixed `_parse_persons_data` and `_parse_employment_data`
- `company_fetching.py`: Fixed `_create_batch_persons_table` and `_create_batch_employment_table`

## Test plan
- [x] Python syntax validated
- [x] Ruff linting passed
- [x] Manual test confirms fix works correctly and old pattern fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)