### PR TITLE
fix(workflows): use uv pip for unified pipeline installs

### DIFF
--- a/.github/workflows/bmd_monthly_pipeline.yml
+++ b/.github/workflows/bmd_monthly_pipeline.yml
@@ -39,18 +39,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
 
           # Install unified pipeline dependencies FIRST (needed for GCS access)
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
           # Install the BMD scraper package with appropriate extras
           cd ../bmd_scraper
           if [ "${{ env.ENVIRONMENT }}" == "production" ]; then
-            pip install -e ".[production]"
+            uv pip install --system -e ".[production]"
           else
-            pip install -e .
+            uv pip install --system -e .
           fi
 
       - name: Authenticate to Google Cloud (Production only)

--- a/.github/workflows/climate_pipeline.yml
+++ b/.github/workflows/climate_pipeline.yml
@@ -62,10 +62,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
-        pip install pandas pyarrow
+        uv pip install --system -e .
+        uv pip install --system pandas pyarrow
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -171,10 +171,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
-        pip install pandas pyarrow
+        uv pip install --system -e .
+        uv pip install --system pandas pyarrow
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -235,10 +235,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
-        pip install pandas pyarrow
+        uv pip install --system -e .
+        uv pip install --system pandas pyarrow
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -299,10 +299,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
-        pip install pandas pyarrow
+        uv pip install --system -e .
+        uv pip install --system pandas pyarrow
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -355,10 +355,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
-        pip install pandas pyarrow
+        uv pip install --system -e .
+        uv pip install --system pandas pyarrow
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -424,10 +424,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
-        pip install pandas pyarrow
+        uv pip install --system -e .
+        uv pip install --system pandas pyarrow
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -493,10 +493,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
-        pip install pandas pyarrow
+        uv pip install --system -e .
+        uv pip install --system pandas pyarrow
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2

--- a/.github/workflows/cvr_enrichment_pipeline.yml
+++ b/.github/workflows/cvr_enrichment_pipeline.yml
@@ -114,8 +114,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -178,8 +179,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -240,8 +242,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -467,8 +470,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -533,8 +537,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -599,8 +604,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -695,8 +701,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -785,8 +792,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/field_area_analysis_multi_stage.yml
+++ b/.github/workflows/field_area_analysis_multi_stage.yml
@@ -128,9 +128,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -168,9 +168,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -208,9 +208,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -247,9 +247,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -287,9 +287,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -328,9 +328,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -368,9 +368,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -429,9 +429,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -475,9 +475,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -516,9 +516,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -556,9 +556,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -597,9 +597,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -637,9 +637,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -678,9 +678,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -718,9 +718,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -759,9 +759,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -840,9 +840,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/pesticide_disaggregation_matrix.yml
+++ b/.github/workflows/pesticide_disaggregation_matrix.yml
@@ -51,9 +51,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
+        uv pip install --system -e .
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -209,9 +209,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip uv
         cd backend/pipelines/unified_pipeline
-        pip install -e .
+        uv pip install --system -e .
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2

--- a/.github/workflows/unified_pipeline.yml
+++ b/.github/workflows/unified_pipeline.yml
@@ -142,9 +142,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip uv
           cd backend/pipelines/unified_pipeline
-          pip install -e .
+          uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/21099420277

## 💡 Solution
Updated all workflow files to use `uv pip install --system -e .` instead of `pip install -e .`. The unified_pipeline pyproject.toml uses uv-specific `[tool.uv.sources]` configuration for the local landbruget-common dependency, which regular pip doesn't understand. This was causing all unified pipeline workflows to fail at the "Install dependencies" step.

Applied fix to 6 workflow files:
- unified_pipeline.yml (manual trigger)
- pesticide_disaggregation_matrix.yml
- field_area_analysis_multi_stage.yml
- cvr_enrichment_pipeline.yml
- climate_pipeline.yml
- bmd_monthly_pipeline.yml

## ✅ How to Do Self-Test
The fix will be verified when the failing workflow run is retried or when new pipeline runs are triggered.

## 📝 Additional Notes
This matches the pattern already used correctly in pesticide processing jobs (lines 339-343 of unified_pipeline.yml) and the weekly/monthly unified pipeline workflows which were already using uv correctly.