### PR TITLE
fix(workflows): use single quotes for JSON payloads in workflow dispatches

### DIFF
--- a/.github/workflows/unified_pipeline_monthly.yml
+++ b/.github/workflows/unified_pipeline_monthly.yml
@@ -219,7 +219,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/fvm_wfs_matrix_download.yml/dispatches" \
-              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"stage\":\"all\",\"layer_types\":\"all\",\"years\":\"all\"}}")
+              -d '{"ref":"${{ github.ref }}","inputs":{"stage":"all","layer_types":"all","years":"all"}}')
 
             if [ "$HTTP_CODE" = "204" ]; then
               echo "✅ FVM WFS matrix workflow triggered successfully (HTTP $HTTP_CODE)"
@@ -236,7 +236,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/drive_pipeline.yml/dispatches" \
-              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"log_level\":\"INFO\",\"max_workers\":\"4\"}}")
+              -d '{"ref":"${{ github.ref }}","inputs":{"log_level":"INFO","max_workers":"4"}}')
 
             if [ "$HTTP_CODE" = "204" ]; then
               echo "✅ Google Drive pipeline triggered successfully (HTTP $HTTP_CODE)"
@@ -253,7 +253,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/bbr_buildings_pipeline.yml/dispatches" \
-              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"layer\":\"both\",\"sample_size\":\"0\",\"log_level\":\"INFO\"}}")
+              -d '{"ref":"${{ github.ref }}","inputs":{"layer":"both","sample_size":"0","log_level":"INFO"}}')
 
             if [ "$HTTP_CODE" = "204" ]; then
               echo "✅ BBR Buildings pipeline triggered successfully (HTTP $HTTP_CODE)"
@@ -459,7 +459,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/field_area_analysis_multi_stage.yml/dispatches" \
-              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"stage\":\"all\",\"agricultural_fields_year\":\"both\"}}"
+              -d '{"ref":"${{ github.ref }}","inputs":{"stage":"all","agricultural_fields_year":"both"}}'
             echo "✅ Field Area Analysis matrix workflow triggered successfully"
           elif [ "${{ matrix.source }}" = "fvm_wfs" ]; then
             # FVM WFS - trigger the dedicated matrix workflow
@@ -469,7 +469,7 @@ jobs:
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/fvm_wfs_matrix_download.yml/dispatches" \
-              -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"stage\":\"all\",\"layer_types\":\"all\",\"years\":\"all\"}}")
+              -d '{"ref":"${{ github.ref }}","inputs":{"stage":"all","layer_types":"all","years":"all"}}')
 
             if [ "$HTTP_CODE" = "204" ]; then
               echo "✅ FVM WFS matrix workflow triggered successfully (HTTP $HTTP_CODE)"


### PR DESCRIPTION
## Summary
Fixed potential bash parsing issues in GitHub Actions workflows by changing escaped double-quote JSON strings to single-quoted strings in curl `-d` parameters.

## Changes
- Replace `"{\"key\":\"value\"}"` with `'{"key":"value"}'` in 5 workflow dispatch calls
- Affects `unified_pipeline_monthly.yml`:
  - `fvm_wfs_matrix_download.yml` (2 occurrences)
  - `drive_pipeline.yml`
  - `bbr_buildings_pipeline.yml`
  - `field_area_analysis_multi_stage.yml`

## Why
- Prevents potential JSON parsing errors when triggering downstream workflows
- Matches the pattern already used in `unified_pipeline.yml`
- Resolves workflow failure in run #21099612865

## Testing
- Workflow syntax validated
- Consistent with existing working patterns in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)