### PR TITLE
fix(cvr_enrichment): propagate PIPELINE_START_TIME to data_parsing and data_consolidation jobs

### DIFF
--- a/.github/workflows/cvr_enrichment_pipeline.yml
+++ b/.github/workflows/cvr_enrichment_pipeline.yml
@@ -456,7 +456,7 @@ jobs:
   data_parsing:
     name: "Data Parsing (Silver Layer)"
     runs-on: ubuntu-latest
-    needs: company_fetching_consolidate
+    needs: [cvr_collection, company_fetching_consolidate]
     if: ${{ !cancelled() && (inputs.run_only_step == 'none' && !contains(inputs.skip_steps, 'data_parsing')) }}
 
     steps:
@@ -494,6 +494,7 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.log_level || 'INFO' }}
           PYTHONUNBUFFERED: 1
+          PIPELINE_START_TIME: ${{ needs.cvr_collection.outputs.pipeline_timestamp }}
         run: |
           cd backend/pipelines/unified_pipeline
 
@@ -523,7 +524,7 @@ jobs:
   data_consolidation:
     name: "Data Consolidation (Gold Layer)"
     runs-on: ubuntu-latest
-    needs: data_parsing
+    needs: [cvr_collection, data_parsing]
     if: ${{ !cancelled() && (inputs.run_only_step == 'none' && !contains(inputs.skip_steps, 'data_consolidation')) }}
 
     steps:
@@ -561,6 +562,7 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.log_level || 'INFO' }}
           PYTHONUNBUFFERED: 1
+          PIPELINE_START_TIME: ${{ needs.cvr_collection.outputs.pipeline_timestamp }}
         run: |
           cd backend/pipelines/unified_pipeline
 


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/21099870358

## 💡 Solution
The Data Consolidation (Gold Layer) job was failing because each job in the workflow generated its own timestamp instead of using a shared one. This caused the Data Consolidation job to look for Silver layer data at a different path than where Data Parsing saved it (404 Not Found).

The fix ensures all jobs use the same `PIPELINE_START_TIME` timestamp from the `cvr_collection` job by:
- Adding `cvr_collection` to the `needs` array for both `data_parsing` and `data_consolidation`
- Passing the `pipeline_timestamp` output as an environment variable to both jobs

## ✅ How to Do Self-Test
This fix resolves the CVR Enrichment Pipeline failure. The next scheduled run (1st of month at 02:00 UTC) or a manual workflow dispatch should now complete successfully with all downstream jobs receiving the consolidated data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)