### PR TITLE
fix(pipeline): add debug logging and fail on partial success

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/app.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/app.py
@@ -679,11 +679,11 @@ def execute(cli_config: cli_models.CliConfig) -> int:
         log.error(f"❌ Pipeline failed: No jobs completed successfully (0/{total_jobs})")
         return 1
     if successful_jobs < total_jobs:
-        log.warning(
-            f"⚠️  Pipeline completed with partial success: "
-            f"{successful_jobs}/{total_jobs} jobs completed successfully"
+        log.error(
+            f"❌ Pipeline failed: Only {successful_jobs}/{total_jobs} jobs completed successfully. "
+            f"All jobs must succeed for a complete pipeline run."
         )
-        return 0  # Still consider it a success if at least one job completed
+        return 1  # Fail if any job failed - partial success is still a failure
     log.info(
         f"✅ Pipeline completed successfully: "
         f"{successful_jobs}/{total_jobs} jobs completed successfully"

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
@@ -228,6 +228,15 @@ class GEUSBoreholePesticidesSilver(
             try:
                 root = ET.fromstring(gml_chunk)
 
+                # Debug: Log first chunk structure to understand format
+                if i == 0:
+                    self.log.info(f"First chunk root tag: {root.tag}")
+                    members = root.findall(".//wfs:member", self.config.namespaces)
+                    self.log.info(f"Found {len(members)} wfs:member elements in first chunk")
+                    if members:
+                        for child in members[0]:
+                            self.log.info(f"  First member child tag: {child.tag}")
+
                 # Find all borehole features via wfs:member path (most reliable)
                 for member in root.findall(".//wfs:member", self.config.namespaces):
                     for child in member:


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes pipeline incorrectly reporting success when silver layer fails.

## 💡 Solution

**1. Add Debug Logging**
- Added logging to silver layer to print GML structure on first chunk
- Helps diagnose why boreholes are not being parsed

**2. Fail on Partial Success**
- Changed exit code from 0 to 1 when only some jobs succeed
- Previously: bronze succeeds + silver fails = exit 0 (SUCCESS)
- Now: bronze succeeds + silver fails = exit 1 (FAILURE)

This ensures CI properly fails when the silver layer cannot parse boreholes.

## ✅ How to Test
```bash
# Run pipeline - should now fail with exit code 1 if silver layer fails
gh workflow run unified_pipeline.yml --field source=geus_borehole_pesticides
```

## 📝 Additional Notes
The debug logging will help identify why 0 boreholes are being parsed from the 89 GML chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)