### PR TITLE
fix(pipeline): correct GML namespace to 3.2 for GEUS borehole data

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
@@ -46,7 +46,7 @@ class GEUSBoreholePesticidesSilverConfig(BaseJobConfig):
     namespaces: ClassVar[dict[str, str]] = {
         "wfs": "http://www.opengis.net/wfs/2.0",
         "ms": "http://mapserver.gis.umn.edu/mapserver",  # Actual feature namespace
-        "gml": "http://www.opengis.net/gml",  # GML 3.1.1, not 3.2
+        "gml": "http://www.opengis.net/gml/3.2",  # GML 3.2 (verified from GEUS API response)
     }
 
     # Tracked pesticides (stofnr -> substance name)


### PR DESCRIPTION
## Summary
- Fixes the GEUS borehole pesticides silver layer parsing 0 boreholes

## Root Cause
The GEUS API returns GML 3.2 (`xmlns:gml="http://www.opengis.net/gml/3.2"`) but we were using 
the GML 3.1.1 namespace (`http://www.opengis.net/gml`). This caused the `gml:Point` XPath 
lookup to fail silently and return None.

## Verification
Tested with actual GEUS API response:
```python
# OLD namespace (http://www.opengis.net/gml)
>>> feature.find('.//gml:Point', namespaces)
None  # ❌ Fails

# NEW namespace (http://www.opengis.net/gml/3.2)  
>>> feature.find('.//gml:Point', namespaces)
<Element '{http://www.opengis.net/gml/3.2}Point'>  # ✅ Works
```

## Test plan
- [ ] Merge and trigger pipeline run
- [ ] Verify boreholes are parsed (should be ~400k+)
- [ ] Verify silver layer completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)