### PR TITLE
fix: use list.extend for performance in silver layer

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/geus_borehole_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/geus_borehole_pesticides.py
@@ -20,7 +20,6 @@ Each batch is saved as a separate parquet file, which the silver layer reads in
 chunks for processing.
 """
 
-import asyncio
 import ssl
 import xml.etree.ElementTree as ET
 from asyncio import Semaphore

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
@@ -816,8 +816,7 @@ class GEUSBoreholePesticidesSilver(
                     f"SELECT payload FROM read_parquet('{gcs_uri}')"
                 ).fetchall()
 
-                for row in result:
-                    gml_data.append(row[0])
+                gml_data.extend(row[0] for row in result)
 
             except Exception as e:
                 self.log.warning(f"Failed to read chunk {path}: {e}")


### PR DESCRIPTION
## Summary
Simple lint fix - use `list.extend` instead of for-loop with `append` for better performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)