### PR TITLE
feat(pipeline): enable independent bronze/silver stages for GEUS borehole pesticides

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/geus_borehole_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/geus_borehole_pesticides.py
@@ -246,13 +246,16 @@ class GEUSBoreholePesticidesBronze(
         """
         Save intermediate GML chunks to GCS to avoid memory accumulation.
 
+        Path structure: bronze/{dataset}/{run_timestamp}/chunks/{layer_type}/chunk_{num}.parquet
+        This puts the run timestamp at the top level so all chunks from a run are grouped together.
+
         Args:
             layer_type: Type of layer (boreholes, analyses, pesticide_analyses)
             chunk_num: Chunk number for filename
             gml_data: List of GML strings to save
 
         Returns:
-            GCS path where the chunk was saved
+            GCS path where the chunk was saved (relative to bucket)
         """
         current_timestamp = self.conn.execute("SELECT current_timestamp").fetchone()[0]
 
@@ -285,9 +288,17 @@ class GEUSBoreholePesticidesBronze(
             ],
         )
 
-        # Save to GCS
-        gcs_path = f"{self.config.dataset}/chunks/{layer_type}/chunk_{chunk_num:04d}"
-        self._save_data(chunk_table, gcs_path, self.config.bucket, stage="bronze")
+        # Build GCS path with run timestamp at top level:
+        # bronze/{dataset}/{run_timestamp}/chunks/{layer_type}/chunk_0000.parquet
+        run_timestamp = self.date_pattern  # Consistent across entire run
+        relative_path = (
+            f"bronze/{self.config.dataset}/{run_timestamp}/chunks/{layer_type}/"
+            f"chunk_{chunk_num:04d}.parquet"
+        )
+        gcs_path = f"gs://{self.config.bucket}/{relative_path}"
+
+        # Save directly to GCS using gcs_access (bypasses _save_data's timestamp logic)
+        self.gcs_access.upload_from_duckdb_table(chunk_table, gcs_path)
 
         # Clean up tables
         self.conn.execute(f"DROP TABLE {temp_table}")
@@ -295,10 +306,11 @@ class GEUSBoreholePesticidesBronze(
 
         self.log.info(
             f"Saved intermediate chunk {chunk_num} for {layer_type} "
-            f"({len(gml_data)} GML responses) to {gcs_path}"
+            f"({len(gml_data)} GML responses) to {relative_path}"
         )
 
-        return gcs_path
+        # Return the relative path (without gs://bucket/) for manifest
+        return relative_path
 
     async def _fetch_layer_data_streaming(
         self, session: aiohttp.ClientSession, typename: str, cql_filter: str | None = None
@@ -621,10 +633,13 @@ class GEUSBoreholePesticidesBronze(
             )
 
             # Save metadata manifest for silver layer
+            # Path structure: bronze/{dataset}/{run_timestamp}/manifest.json
+            run_timestamp = self.date_pattern
             manifest = {
                 "dataset": self.config.dataset,
                 "bucket": self.config.bucket,
                 "source_crs": self.config.source_crs,
+                "run_timestamp": run_timestamp,
                 "layers": {
                     "boreholes": {
                         "total_features": boreholes_meta["total_features"],
@@ -644,13 +659,13 @@ class GEUSBoreholePesticidesBronze(
                 },
             }
 
-            # Save manifest to GCS
-            self._save_data(
-                manifest,
-                f"{self.config.dataset}/manifest",
-                self.config.bucket,
-                stage="bronze",
+            # Save manifest directly to GCS with proper path hierarchy
+            # bronze/{dataset}/{run_timestamp}/manifest.json
+            manifest_path = (
+                f"gs://{self.config.bucket}/bronze/{self.config.dataset}/"
+                f"{run_timestamp}/manifest.json"
             )
+            self.gcs_access.upload_json(manifest, manifest_path)
 
             self.log.info("GEUS Borehole Pesticides bronze job completed successfully")
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
@@ -799,7 +799,8 @@ class GEUSBoreholePesticidesSilver(
         Read GML data from GCS chunk files.
 
         Args:
-            chunk_paths: List of GCS paths to chunk parquet files
+            chunk_paths: List of relative paths to chunk parquet files.
+                New format: bronze/{dataset}/{timestamp}/chunks/{layer}/chunk_0000.parquet
 
         Returns:
             List of GML strings from the chunks
@@ -807,25 +808,14 @@ class GEUSBoreholePesticidesSilver(
         gml_data = []
         for path in chunk_paths:
             try:
-                # The _save_data method creates paths like:
-                # bronze/{dataset}/chunks/{layer}/{chunk_name}/{timestamp}/data.parquet
-                # We need to find the latest file using glob pattern
-                gcs_pattern = f"gs://{self.config.bucket}/bronze/{path}/*/data.parquet"
-                self.log.debug(f"Looking for chunk files matching: {gcs_pattern}")
-
-                # Use list_files to find matching files
-                matching_files = self.gcs_access.list_files(gcs_pattern)
-                if not matching_files:
-                    self.log.warning(f"No files found matching {gcs_pattern}")
-                    continue
-
-                # Get the most recent file (sorted by path which includes timestamp)
-                latest_file = sorted(matching_files, reverse=True)[0]
-                self.log.debug(f"Reading chunk from {latest_file}")
+                # New path structure already includes full relative path:
+                # bronze/{dataset}/{timestamp}/chunks/{layer}/chunk_0000.parquet
+                gcs_path = f"gs://{self.config.bucket}/{path}"
+                self.log.debug(f"Reading chunk from {gcs_path}")
 
                 # Read the parquet file
                 result = self.conn.execute(
-                    f"SELECT payload FROM read_parquet('{latest_file}')"
+                    f"SELECT payload FROM read_parquet('{gcs_path}')"
                 ).fetchall()
 
                 gml_data.extend(row[0] for row in result)
@@ -899,9 +889,10 @@ class GEUSBoreholePesticidesSilver(
                 self.log.info("No bronze data passed - reading from GCS (independent silver run)")
 
                 # Find the latest manifest in GCS
-                # The bronze layer saves manifests with timestamps like:
-                # bronze/geus_borehole_pesticides/manifest/{timestamp}/data.parquet
-                manifest_pattern = f"gs://{self.config.bucket}/bronze/{self.config.dataset}/manifest/*/data.parquet"
+                # New path structure: bronze/{dataset}/{run_timestamp}/manifest.json
+                manifest_pattern = (
+                    f"gs://{self.config.bucket}/bronze/{self.config.dataset}/*/manifest.json"
+                )
                 self.log.info(f"Looking for manifest files matching: {manifest_pattern}")
 
                 manifest_files = self.gcs_access.list_files(manifest_pattern)
@@ -916,55 +907,52 @@ class GEUSBoreholePesticidesSilver(
                 latest_manifest = sorted(manifest_files, reverse=True)[0]
                 self.log.info(f"Reading manifest from {latest_manifest}")
 
-                # Read and parse manifest
+                # Read and parse manifest (JSON format)
                 try:
-                    manifest_df = self.conn.execute(
-                        f"SELECT * FROM read_parquet('{latest_manifest}')"
-                    ).fetchdf()
+                    manifest = self.gcs_access.download_json(latest_manifest)
+                    self.log.info(
+                        f"Loaded manifest for run {manifest.get('run_timestamp', 'unknown')}"
+                    )
 
-                    # The manifest is stored as a parquet file - extract the JSON-like structure
-                    # It should have columns matching the manifest dict keys
-                    if manifest_df.empty:
-                        self.log.error("Manifest file is empty")
-                        return None
-
-                    # For now, find chunks by listing files in GCS directly
-                    # since the manifest structure might vary
-                    self.log.info("Reading chunk files from GCS based on manifest structure...")
+                    # Read chunks from paths stored in manifest
+                    layers = manifest.get("layers", {})
 
                     # Read boreholes chunks
-                    boreholes_pattern = f"gs://{self.config.bucket}/bronze/{self.config.dataset}/chunks/boreholes/*/*/data.parquet"
-                    boreholes_files = sorted(self.gcs_access.list_files(boreholes_pattern))
-                    self.log.info(f"Found {len(boreholes_files)} borehole chunk files")
-
+                    boreholes_paths = layers.get("boreholes", {}).get("saved_paths", [])
+                    self.log.info(
+                        f"Reading {len(boreholes_paths)} borehole chunks from manifest..."
+                    )
                     boreholes_gml = []
-                    for bf in boreholes_files:
+                    for path in boreholes_paths:
+                        gcs_path = f"gs://{self.config.bucket}/{path}"
                         result = self.conn.execute(
-                            f"SELECT payload FROM read_parquet('{bf}')"
+                            f"SELECT payload FROM read_parquet('{gcs_path}')"
                         ).fetchall()
                         boreholes_gml.extend(row[0] for row in result)
 
                     # Read analyses chunks
-                    analyses_pattern = f"gs://{self.config.bucket}/bronze/{self.config.dataset}/chunks/analyses/*/*/data.parquet"
-                    analyses_files = sorted(self.gcs_access.list_files(analyses_pattern))
-                    self.log.info(f"Found {len(analyses_files)} facility analyses chunk files")
-
+                    analyses_paths = layers.get("analyses", {}).get("saved_paths", [])
+                    self.log.info(
+                        f"Reading {len(analyses_paths)} facility analyses chunks from manifest..."
+                    )
                     analyses_gml = []
-                    for af in analyses_files:
+                    for path in analyses_paths:
+                        gcs_path = f"gs://{self.config.bucket}/{path}"
                         result = self.conn.execute(
-                            f"SELECT payload FROM read_parquet('{af}')"
+                            f"SELECT payload FROM read_parquet('{gcs_path}')"
                         ).fetchall()
                         analyses_gml.extend(row[0] for row in result)
 
                     # Read pesticide analyses chunks
-                    pesticide_pattern = f"gs://{self.config.bucket}/bronze/{self.config.dataset}/chunks/pesticide_analyses/*/*/data.parquet"
-                    pesticide_files = sorted(self.gcs_access.list_files(pesticide_pattern))
-                    self.log.info(f"Found {len(pesticide_files)} pesticide analyses chunk files")
-
+                    pesticide_paths = layers.get("pesticide_analyses", {}).get("saved_paths", [])
+                    self.log.info(
+                        f"Reading {len(pesticide_paths)} pesticide analyses chunks from manifest..."
+                    )
                     pesticide_analyses_gml = []
-                    for pf in pesticide_files:
+                    for path in pesticide_paths:
+                        gcs_path = f"gs://{self.config.bucket}/{path}"
                         result = self.conn.execute(
-                            f"SELECT payload FROM read_parquet('{pf}')"
+                            f"SELECT payload FROM read_parquet('{gcs_path}')"
                         ).fetchall()
                         pesticide_analyses_gml.extend(row[0] for row in result)
 


### PR DESCRIPTION
## Summary

- Enable running bronze and silver stages independently for GEUS borehole pesticides pipeline
- Improved GCS path hierarchy: `bronze/{dataset}/{run_timestamp}/chunks/{layer}/chunk_0000.parquet`
- Silver layer can now read from GCS when run independently (without bronze data in memory)

## Changes

### Bronze layer
- Save chunks with run timestamp at top level of path hierarchy
- Save manifest as JSON at `bronze/{dataset}/{run_timestamp}/manifest.json`
- Manifest includes `run_timestamp` field and paths to all chunks

### Silver layer  
- Read manifest from GCS when `bronze_data` is not passed
- Find latest run by sorting manifest files by timestamp in path
- Read chunks directly from paths stored in manifest

## Usage

Run stages together (default):
```bash
python -m unified_pipeline run -s geus_borehole_pesticides -j all
```

Run stages independently:
```bash
# First run bronze
python -m unified_pipeline run -s geus_borehole_pesticides -j bronze

# Then run silver (reads from GCS)
python -m unified_pipeline run -s geus_borehole_pesticides -j silver
```

## Test plan

- [ ] Run bronze stage independently - verify chunks saved to GCS with correct path structure
- [ ] Run silver stage independently - verify it reads from GCS and processes correctly
- [ ] Run both stages together - verify in-memory passing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)