### PR TITLE
feat(pipeline): add pipeline metadata to GEUS borehole pesticides

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/geus_borehole_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/geus_borehole_pesticides.py
@@ -667,6 +667,34 @@ class GEUSBoreholePesticidesBronze(
             )
             self.gcs_access.upload_json(manifest, manifest_path)
 
+            # Create and save pipeline metadata for data tracing
+            if self.pipeline_metadata_manager and self.processing_start_time:
+                try:
+                    import time
+
+                    total_records = (
+                        boreholes_meta["total_features"]
+                        + analyses_meta["total_features"]
+                        + pesticide_meta["total_features"]
+                    )
+                    processing_duration = time.time() - self.processing_start_time
+
+                    pipeline_metadata = self.pipeline_metadata_manager.create_metadata(
+                        source_key="geus_borehole_pesticides",
+                        record_count=total_records,
+                        processing_duration=processing_duration,
+                    )
+
+                    # Save pipeline metadata alongside manifest
+                    metadata_path = (
+                        f"gs://{self.config.bucket}/bronze/{self.config.dataset}/"
+                        f"{run_timestamp}/pipeline_metadata.json"
+                    )
+                    self.gcs_access.upload_json(pipeline_metadata.model_dump(), metadata_path)
+                    self.log.info(f"✅ Pipeline metadata saved to {metadata_path}")
+                except Exception as e:
+                    self.log.warning(f"⚠️ Failed to create pipeline metadata: {e}")
+
             self.log.info("GEUS Borehole Pesticides bronze job completed successfully")
 
             # Return metadata for silver layer (or it can read from GCS manifest)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_borehole_pesticides.py
@@ -1009,19 +1009,33 @@ class GEUSBoreholePesticidesSilver(
             if all_analyses:
                 self._validate_geometries(joined_table)
 
-            # Save to GCS
+            # Save to GCS with pipeline metadata for data tracing
             self.log.info("Saving data to GCS...")
 
             # Save boreholes (all boreholes, not just those with pesticides)
-            self.save_data_direct(boreholes_table, "geus_boreholes", self.config.bucket, "silver")
+            self._save_data_with_metadata(
+                data=boreholes_table,
+                dataset="geus_boreholes",
+                source_key="geus_borehole_pesticides",
+                bucket=self.config.bucket,
+                stage="silver",
+            )
 
             # Save pesticide analyses if we have any
             if all_analyses:
-                self.save_data_direct(
-                    analyses_table, "geus_pesticide_analyses", self.config.bucket, "silver"
+                self._save_data_with_metadata(
+                    data=analyses_table,
+                    dataset="geus_pesticide_analyses",
+                    source_key="geus_borehole_pesticides",
+                    bucket=self.config.bucket,
+                    stage="silver",
                 )
-                self.save_data_direct(
-                    joined_table, "geus_borehole_pesticides", self.config.bucket, "silver"
+                self._save_data_with_metadata(
+                    data=joined_table,
+                    dataset="geus_borehole_pesticides",
+                    source_key="geus_borehole_pesticides",
+                    bucket=self.config.bucket,
+                    stage="silver",
                 )
 
             self.log.info("GEUS Borehole Pesticides silver job completed successfully")


### PR DESCRIPTION
## Summary

Adds pipeline metadata support to the GEUS borehole pesticides pipeline, bringing it in line with other pipelines (cadastral, etc.) for data tracing and lineage tracking.

## Changes

### Bronze layer
- Create and save `pipeline_metadata.json` alongside `manifest.json`
- Includes total record count (boreholes + analyses + pesticide_analyses)
- Includes processing duration and source key

### Silver layer
- Replace `save_data_direct()` with `_save_data_with_metadata()`
- Pipeline metadata now saved for all three output tables:
  - `geus_boreholes`
  - `geus_pesticide_analyses`  
  - `geus_borehole_pesticides`

## Test plan

- [ ] Run pipeline and verify `pipeline_metadata.json` is created in bronze output
- [ ] Verify silver layer creates metadata alongside each output table

🤖 Generated with [Claude Code](https://claude.com/claude-code)