### PR TITLE
fix(pipeline): cast crypto_hash BLOB to VARCHAR in address geocoding

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/address_geocoding.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/cvr_enrichment/address_geocoding.py
@@ -763,16 +763,16 @@ class AddressGeocoding(BaseSource[AddressGeocodingConfig], GoldJobInterface):
                          OR NOT REGEXP_MATCHES(TRIM(CAST(cvr_number AS VARCHAR)), '^[1-9][0-9]{7}$')
                     THEN NULL
                     ELSE CONCAT(
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                               TRIM(CAST(cvr_number AS VARCHAR)))), 1, 8), '-',
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                               TRIM(CAST(cvr_number AS VARCHAR)))), 9, 4), '-',
-                        '5', SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                                      TRIM(CAST(cvr_number AS VARCHAR)))), 13, 3), '-',
-                        CONCAT('8', SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                                               TRIM(CAST(cvr_number AS VARCHAR)))), 17, 3)), '-',
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
-                               TRIM(CAST(cvr_number AS VARCHAR)))), 21, 12)
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                               TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 1, 8), '-',
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                               TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 9, 4), '-',
+                        '5', SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                                      TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 13, 3), '-',
+                        CONCAT('8', SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                                               TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 17, 3)), '-',
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'company-cvr-',
+                               TRIM(CAST(cvr_number AS VARCHAR)))) AS VARCHAR), 21, 12)
                     )
                 END
             )
@@ -784,16 +784,16 @@ class AddressGeocoding(BaseSource[AddressGeocodingConfig], GoldJobInterface):
                     WHEN p_number IS NULL
                     THEN NULL
                     ELSE CONCAT(
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
-                               TRIM(CAST(p_number AS VARCHAR)))), 1, 8), '-',
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
-                               TRIM(CAST(p_number AS VARCHAR)))), 9, 4), '-',
-                        '5', SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
-                                      TRIM(CAST(p_number AS VARCHAR)))), 13, 3), '-',
-                        CONCAT('8', SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
-                                               TRIM(CAST(p_number AS VARCHAR)))), 17, 3)), '-',
-                        SUBSTR(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
-                               TRIM(CAST(p_number AS VARCHAR)))), 21, 12)
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
+                               TRIM(CAST(p_number AS VARCHAR)))) AS VARCHAR), 1, 8), '-',
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
+                               TRIM(CAST(p_number AS VARCHAR)))) AS VARCHAR), 9, 4), '-',
+                        '5', SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
+                                      TRIM(CAST(p_number AS VARCHAR)))) AS VARCHAR), 13, 3), '-',
+                        CONCAT('8', SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
+                                               TRIM(CAST(p_number AS VARCHAR)))) AS VARCHAR), 17, 3)), '-',
+                        SUBSTR(CAST(crypto_hash('md5', CONCAT('{namespace}', 'pnumber-',
+                               TRIM(CAST(p_number AS VARCHAR)))) AS VARCHAR), 21, 12)
                     )
                 END
             )


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes GitHub Actions workflow failure: https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/21124692493

The CVR Enrichment Pipeline's Address Geocoding step was failing with a DuckDB type error.

## 💡 Solution

DuckDB's `crypto_hash()` function returns BLOB type, but `SUBSTR()` requires VARCHAR. Added explicit `CAST(... AS VARCHAR)` to all crypto_hash calls in the UUID generation functions.

Changes:
- Cast crypto_hash() results to VARCHAR in company_uuid function (5 instances)
- Cast crypto_hash() results to VARCHAR in pnumber_uuid function (5 instances)

## ✅ How to Self-Test

The fix will be validated by the next CVR Enrichment Pipeline run (scheduled weekly or manual trigger).

The error was:
```
Binder Error: No function matches the given name and argument types 'substr(BLOB, INTEGER_LITERAL, INTEGER_LITERAL)'
```

With the fix, the UUID generation will work correctly as DuckDB can properly cast the BLOB to VARCHAR.