### PR TITLE
fix(pipeline): use correct Danish characters in Arbejdstilsynet column names

### DIFF
--- a/backend/pipelines/arbejdstilsynet_inspections/silver/transform.py
+++ b/backend/pipelines/arbejdstilsynet_inspections/silver/transform.py
@@ -176,9 +176,9 @@ class SilverPipeline:
         self.column_rename = {
             "Dato": "date",
             "Antal": "case_count",
-            "Afgoerelse": "decision",
-            "Arbejdsmiljoeproblem (emne)": "work_env_issue",
-            "Paaklaget": "appealed",
+            "Afgørelse": "decision",
+            "Arbejdsmiljøproblem (emne)": "work_env_issue",
+            "Påklaget": "appealed",
             "Efterkommet": "complied",
             "Produktionsenhed": "company_name",
             "P-nummer": "company_id",

--- a/backend/pipelines/arbejdstilsynet_inspections/tests/integration/test_bronze_to_silver.py
+++ b/backend/pipelines/arbejdstilsynet_inspections/tests/integration/test_bronze_to_silver.py
@@ -25,9 +25,9 @@ from silver.transform import SilverPipeline
 @pytest.fixture
 def sample_raw_csv():
     """Create realistic work inspection CSV data."""
-    return """Dato,Antal,Afgoerelse,Arbejdsmiljoeproblem (emne),Paaklaget,Efterkommet,Produktionsenhed,P-nummer,Branche,Produktionenhedens adresse
+    return """Dato,Antal,Afgørelse,Arbejdsmiljøproblem (emne),Påklaget,Efterkommet,Produktionsenhed,P-nummer,Branche,Produktionenhedens adresse
 2024-01-15,5,Påbud,Støj og vibrationer,,Efterkommet,Dansk Landbrug A/S,1234567890,Landbrug, skovbrug og fiskeri,Landbrugsvej 1 4000 Roskilde
-2024-01-16,10,Strakspåbud,Kemiske stoffer,Paaklaget,,Danish Crown Slagteri,2345678901,Slagterier,Slagtervej 2 8000 Aarhus
+2024-01-16,10,Strakspåbud,Kemiske stoffer,Påklaget,,Danish Crown Slagteri,2345678901,Slagterier,Slagtervej 2 8000 Aarhus
 2024-01-17,3,Forbud,Arbejde i høj,,,MT Højgaard A/S,3456789012,Anlægsarbejde,Byggevej 3 2000 København
 2024-01-18,8,Vejledning,Ergonomi,,Efterkommet,Arla Foods,4567890123,Fødevarer,Mejerivej 4 6000 Kolding
 2024-01-19,2,Påbud,Maskiner og teknisk udstyr,,,Vestjyllands Byggecenter,5678901234,Anlægsarbejde,Anlægsvej 5 7500 Holstebro"""
@@ -307,7 +307,7 @@ class TestDataTransformationAccuracy:
     def test_danish_character_normalization(self, temp_workspace):
         """Test that Danish characters are properly normalized."""
         # Create data with Danish characters
-        csv_content = """Dato,Antal,Afgoerelse,Arbejdsmiljoeproblem (emne),Paaklaget,Efterkommet,Produktionsenhed,P-nummer,Branche,Produktionenhedens adresse
+        csv_content = """Dato,Antal,Afgørelse,Arbejdsmiljøproblem (emne),Påklaget,Efterkommet,Produktionsenhed,P-nummer,Branche,Produktionenhedens adresse
 2024-01-15,5,Påbud,Støj og vibrationer,,Efterkommet,Dansk Landbrug,1234567890,Landbrug,Vejlevej 1"""
 
         bronze_timestamp = "20240115_120000"
@@ -351,7 +351,7 @@ class TestDataTransformationAccuracy:
     def test_null_handling_consistency(self, temp_workspace):
         """Test that null values are consistently handled."""
         # Create data with various empty representations
-        csv_content = """Dato,Antal,Afgoerelse,Arbejdsmiljoeproblem (emne),Paaklaget,Efterkommet,Produktionsenhed,P-nummer,Branche,Produktionenhedens adresse
+        csv_content = """Dato,Antal,Afgørelse,Arbejdsmiljøproblem (emne),Påklaget,Efterkommet,Produktionsenhed,P-nummer,Branche,Produktionenhedens adresse
 2024-01-15,5,Påbud,Støj,,Efterkommet,Company A,1234567890,Landbrug,Address 1
 2024-01-16,10,,Issue,,,,Company B,2345678901,Industri,
 2024-01-17,,Vejledning,Problem,,,Company C,3456789012,,Address 3"""

--- a/backend/pipelines/arbejdstilsynet_inspections/tests/silver/test_transform.py
+++ b/backend/pipelines/arbejdstilsynet_inspections/tests/silver/test_transform.py
@@ -29,9 +29,9 @@ def sample_raw_data():
         {
             "Dato": ["2024-01-15", "2024-01-16", "2024-01-17"],
             "Antal": ["5", "10", "3"],
-            "Afgoerelse": ["Påbud", "Strakspåbud", "Vejledning"],
-            "Arbejdsmiljoeproblem (emne)": ["Støj", "Kemikalier", "Ergonomi"],
-            "Paaklaget": ["", "Paaklaget", ""],
+            "Afgørelse": ["Påbud", "Strakspåbud", "Vejledning"],
+            "Arbejdsmiljøproblem (emne)": ["Støj", "Kemikalier", "Ergonomi"],
+            "Påklaget": ["", "Påklaget", ""],
             "Efterkommet": ["Efterkommet", "", "Efterkommet"],
             "Produktionsenhed": ["Test Farm A/S", "Test Farm B ApS", "Test Farm C"],
             "P-nummer": ["1234567890", "2345678901", "3456789012"],
@@ -111,7 +111,7 @@ class TestColumnOperations:
                 ('2024-01-01', '5', 'Test', 'Issue', '', '', 'Company', '1234567890', 'Industry', 'Address'),
                 ('2024-01-01', '5', 'Test', 'Issue', '', '', 'Company', '1234567890', 'Industry', 'Address'),
                 ('2024-01-02', '10', 'Test2', 'Issue2', '', '', 'Company2', '2345678901', 'Industry2', 'Address2')
-            ) AS t(Dato, Antal, Afgoerelse, "Arbejdsmiljoeproblem (emne)", Paaklaget, Efterkommet, Produktionsenhed, "P-nummer", Branche, "Produktionenhedens adresse")
+            ) AS t(Dato, Antal, Afgørelse, "Arbejdsmiljøproblem (emne)", Påklaget, Efterkommet, Produktionsenhed, "P-nummer", Branche, "Produktionenhedens adresse")
         """)
 
         pipeline.rename_columns()
@@ -178,7 +178,7 @@ class TestDataTypeCasting:
             CREATE TABLE raw_data AS
             SELECT * FROM (VALUES
                 ('invalid-date', 'not-a-number', 'Test', 'Issue', '', '', 'Company', '1234567890', 'Industry', 'Address')
-            ) AS t(Dato, Antal, Afgoerelse, "Arbejdsmiljoeproblem (emne)", Paaklaget, Efterkommet, Produktionsenhed, "P-nummer", Branche, "Produktionenhedens adresse")
+            ) AS t(Dato, Antal, Afgørelse, "Arbejdsmiljøproblem (emne)", Påklaget, Efterkommet, Produktionsenhed, "P-nummer", Branche, "Produktionenhedens adresse")
         """)
 
         pipeline.rename_columns()
@@ -203,7 +203,7 @@ class TestDataTypeCasting:
             SELECT * FROM (VALUES
                 ('2024-01-15', '5', 'Test', 'Issue', '', '', 'Company', '1234567890', 'Industry', 'Address'),
                 ('2024-12-31', '10', 'Test', 'Issue', '', '', 'Company', '1234567890', 'Industry', 'Address')
-            ) AS t(Dato, Antal, Afgoerelse, "Arbejdsmiljoeproblem (emne)", Paaklaget, Efterkommet, Produktionsenhed, "P-nummer", Branche, "Produktionenhedens adresse")
+            ) AS t(Dato, Antal, Afgørelse, "Arbejdsmiljøproblem (emne)", Påklaget, Efterkommet, Produktionsenhed, "P-nummer", Branche, "Produktionenhedens adresse")
         """)
 
         pipeline.rename_columns()
@@ -229,7 +229,7 @@ class TestDataTypeCasting:
             SELECT * FROM (VALUES
                 ('2024-02-29', '5', 'Test', 'Issue', '', '', 'Company', '1234567890', 'Industry', 'Address'),
                 ('2023-02-29', '5', 'Test', 'Issue', '', '', 'Company', '1234567890', 'Industry', 'Address')
-            ) AS t(Dato, Antal, Afgoerelse, "Arbejdsmiljoeproblem (emne)", Paaklaget, Efterkommet, Produktionsenhed, "P-nummer", Branche, "Produktionenhedens adresse")
+            ) AS t(Dato, Antal, Afgørelse, "Arbejdsmiljøproblem (emne)", Påklaget, Efterkommet, Produktionsenhed, "P-nummer", Branche, "Produktionenhedens adresse")
         """)
 
         pipeline.rename_columns()


### PR DESCRIPTION
## Summary

Fixes the Arbejdstilsynet inspections pipeline failure by correcting column name mappings to use proper Danish characters.

## Problem

The pipeline was failing with:
```
ERROR:SilverPipeline:Column name 'Afgørelse' must be lowercase.
ERROR:SilverPipeline:Pipeline failed at step: validate_column_names
```

The source data uses Danish characters (ø, å) in column names, but the column_rename dictionary used ASCII approximations (oe, aa), causing the rename to fail and leaving columns with uppercase names.

## Solution

- Updated `column_rename` dictionary to use correct Danish characters:
  - `Afgoerelse` → `Afgørelse` 
  - `Arbejdsmiljoeproblem (emne)` → `Arbejdsmiljøproblem (emne)`
  - `Paaklaget` → `Påklaget`
- Updated test fixtures to match actual source data format

## Testing

✅ All silver transform tests pass (17/17)
- Column renaming test validates correct character handling
- Type casting and validation tests confirm no regressions

## Fixes

GitHub Actions run: https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/21127713851/job/60752080686

🤖 Generated with [Claude Code](https://claude.com/claude-code)