### PR TITLE
fix(pmtiles): group pesticide summary by field_id only to prevent join explosion

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/data_loader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/data_loader.py
@@ -516,7 +516,6 @@ class PMTilesDataLoader:
                 summary_query = f"""
                 CREATE OR REPLACE TABLE temp_pesticide_summary AS
                 SELECT
-                    field_uuid,
                     -- Extract field_id from MatchedBlockID (stored as 'block_' || field_id)
                     -- Used as stable join key since field_uuid changes when FVM geometry is re-run
                     REGEXP_REPLACE(
@@ -654,22 +653,19 @@ class PMTilesDataLoader:
                         THEN COALESCE(DosageQuantity, 0) ELSE 0 END) as total_dosage_tablets,
 
 
-                    -- Proximity data
-                    residential_buildings_formatted,
-                    educational_facilities_formatted,
-                    water_distance_formatted,
+                    -- Proximity data (ANY_VALUE since proximity is per field_uuid which may vary)
+                    ANY_VALUE(residential_buildings_formatted) as residential_buildings_formatted,
+                    ANY_VALUE(educational_facilities_formatted) as educational_facilities_formatted,
+                    ANY_VALUE(water_distance_formatted) as water_distance_formatted,
                     AVG(MatchConfidence) as avg_match_confidence
                 FROM {enhanced_pesticide_table}
-                GROUP BY field_uuid, REGEXP_REPLACE(COALESCE(MatchedBlockID, ''), '^block_', ''),
-                         residential_buildings_formatted,
-                         educational_facilities_formatted, water_distance_formatted
+                GROUP BY REGEXP_REPLACE(COALESCE(MatchedBlockID, ''), '^block_', '')
                 """
             else:
                 # Fallback to basic aggregation without BMD classifications
                 summary_query = f"""
                 CREATE OR REPLACE TABLE temp_pesticide_summary AS
                 SELECT
-                    field_uuid,
                     -- Extract field_id from MatchedBlockID (stored as 'block_' || field_id)
                     REGEXP_REPLACE(
                         COALESCE(MatchedBlockID, ''), '^block_', ''
@@ -750,15 +746,13 @@ class PMTilesDataLoader:
                     SUM(CASE WHEN DosageUnit IN ('3', 'tablet', 'tabletter')
                         THEN COALESCE(DosageQuantity, 0) ELSE 0 END) as total_dosage_tablets,
 
-                    -- Proximity data
-                    residential_buildings_formatted,
-                    educational_facilities_formatted,
-                    water_distance_formatted,
+                    -- Proximity data (ANY_VALUE since proximity is per field_uuid which may vary)
+                    ANY_VALUE(residential_buildings_formatted) as residential_buildings_formatted,
+                    ANY_VALUE(educational_facilities_formatted) as educational_facilities_formatted,
+                    ANY_VALUE(water_distance_formatted) as water_distance_formatted,
                     AVG(MatchConfidence) as avg_match_confidence
                 FROM {pesticide_table}
-                GROUP BY field_uuid, REGEXP_REPLACE(COALESCE(MatchedBlockID, ''), '^block_', ''),
-                         residential_buildings_formatted,
-                         educational_facilities_formatted, water_distance_formatted
+                GROUP BY REGEXP_REPLACE(COALESCE(MatchedBlockID, ''), '^block_', '')
                 """
 
             await asyncio.to_thread(self.conn.execute, summary_query)


### PR DESCRIPTION
## Summary

Fixes the OOM/disk exhaustion in the PMTiles generator that caused all years except 2024 to fail after the field_id join fix (PR #579).

- Removes `field_uuid` from `SELECT` and `GROUP BY` in `temp_pesticide_summary` (both BMD and fallback queries)
- Replaces bare proximity column references in `GROUP BY` with `ANY_VALUE()` aggregations

## Root cause

After PR #579 made the join work (field_id instead of field_uuid), a new problem appeared: `temp_pesticide_summary` was still grouping by `field_uuid` AND the proximity columns. Since field_uuid changes when FVM geometry is re-run, the same field_id had multiple rows in the summary → the LEFT JOIN fanned out from ~600K to 12M rows → DuckDB exhausted the runner's 13 GiB temp disk exporting GeoJSON.

## Fix

Group strictly by `field_id` only. Use `ANY_VALUE()` for proximity strings (they're computed per field_uuid but represent the same field). This guarantees exactly one summary row per field → 1-to-1 join → ~600K output rows.

## Test plan

- [ ] Merge this PR
- [ ] Trigger `generate-pmtiles.yml` on main
- [ ] Verify all years succeed with `Field analysis PMTiles: 1/1 successful`
- [ ] Verify `DEBUG: Created pesticide summary with ~200K records` (not 12M)
- [ ] Confirm fields on https://www.landbruget.dk/markanalyse show pesticide belastning colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)