### PR TITLE
feat: add password protection to data.landbruget.dk

### DIFF
--- a/data-explorer/src/app/api/auth/route.ts
+++ b/data-explorer/src/app/api/auth/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const AUTH_COOKIE = 'data_auth';
+// Cookie lives for 7 days
+const MAX_AGE = 60 * 60 * 24 * 7;
+
+export async function POST(request: NextRequest) {
+  const { password } = await request.json();
+
+  const sitePassword = process.env.SITE_PASSWORD;
+  const cookieValue = process.env.AUTH_COOKIE_VALUE;
+
+  if (!sitePassword || !cookieValue) {
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
+  }
+
+  if (password !== sitePassword) {
+    return NextResponse.json({ error: 'Incorrect password' }, { status: 401 });
+  }
+
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(AUTH_COOKIE, cookieValue, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: MAX_AGE,
+    path: '/',
+  });
+
+  return response;
+}

--- a/data-explorer/src/app/login/login-form.tsx
+++ b/data-explorer/src/app/login/login-form.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Database, Lock } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export default function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const from = searchParams.get('from') || '/';
+
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const res = await fetch('/api/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+
+      if (res.ok) {
+        router.replace(from);
+      } else {
+        setError('Forkert adgangskode');
+        setPassword('');
+        inputRef.current?.focus();
+      }
+    } catch {
+      setError('Noget gik galt. Prøv igen.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
+      <div className="w-full max-w-sm space-y-8">
+        {/* Logo / branding */}
+        <div className="text-center space-y-3">
+          <div className="inline-flex items-center justify-center w-14 h-14 bg-primary/10 rounded-2xl">
+            <Database className="h-7 w-7 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Landbruget.dk</h1>
+            <p className="text-sm text-muted-foreground mt-1">Data Explorer</p>
+          </div>
+        </div>
+
+        {/* Card */}
+        <div className="rounded-xl border bg-card shadow-sm p-8 space-y-6">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold flex items-center gap-2">
+              <Lock className="h-4 w-4" />
+              Adgangskode påkrævet
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Indtast adgangskoden for at fortsætte.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+              <label htmlFor="password" className="text-sm font-medium">
+                Adgangskode
+              </label>
+              <input
+                ref={inputRef}
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                autoFocus
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                className={cn(
+                  'w-full rounded-lg border bg-background px-3 py-2 text-sm',
+                  'placeholder:text-muted-foreground',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                  'transition-shadow',
+                  error && 'border-destructive focus-visible:ring-destructive'
+                )}
+              />
+              {error && (
+                <p className="text-xs text-destructive font-medium">{error}</p>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading || !password}
+              className={cn(
+                'w-full rounded-lg px-4 py-2.5 text-sm font-semibold',
+                'bg-primary text-primary-foreground',
+                'hover:bg-primary/90 transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                'disabled:opacity-50 disabled:cursor-not-allowed'
+              )}
+            >
+              {loading ? 'Logger ind…' : 'Log ind'}
+            </button>
+          </form>
+        </div>
+
+        <p className="text-center text-xs text-muted-foreground">
+          Del af{' '}
+          <a
+            href="https://landbruget.dk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-foreground hover:text-primary transition-colors"
+          >
+            Landbruget.dk
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/data-explorer/src/app/login/page.tsx
+++ b/data-explorer/src/app/login/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react';
+import LoginForm from './login-form';
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/data-explorer/src/middleware.ts
+++ b/data-explorer/src/middleware.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const AUTH_COOKIE = 'data_auth';
+const LOGIN_PATH = '/login';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Allow login page and auth API through unconditionally
+  if (pathname === LOGIN_PATH || pathname.startsWith('/api/auth')) {
+    return NextResponse.next();
+  }
+
+  // Allow health check through
+  if (pathname === '/api/health' || pathname === '/healthz') {
+    return NextResponse.next();
+  }
+
+  // Allow Next.js internals
+  if (pathname.startsWith('/_next') || pathname.startsWith('/favicon')) {
+    return NextResponse.next();
+  }
+
+  const cookie = request.cookies.get(AUTH_COOKIE);
+
+  if (cookie?.value === process.env.AUTH_COOKIE_VALUE) {
+    return NextResponse.next();
+  }
+
+  const loginUrl = request.nextUrl.clone();
+  loginUrl.pathname = LOGIN_PATH;
+  loginUrl.searchParams.set('from', pathname);
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
## 🛠️ Issue Fix

No issue linked

## 💡 Solution

Added password protection to the data explorer at `data.landbruget.dk` using Next.js middleware:

- **Middleware protection**: All routes (except `/login` and `/api/health`) require authentication
- **Simple login form**: Danish UI with password input
- **Secure auth flow**: POST to `/api/auth` endpoint validates password and sets httpOnly cookie
- **Long-lived session**: Auth cookie persists for 7 days
- **Environment variables**: `SITE_PASSWORD` and `AUTH_COOKIE_VALUE` configured in Vercel production

## ✅ How to Test

1. Visit `https://data.landbruget.dk`
2. You should be redirected to `/login`
3. Enter the password: `landbruget2025`
4. You'll be granted access for 7 days
5. Cookie inspection: Check browser dev tools → Application → Cookies for `data_auth`

## 📝 Additional Notes

- Middleware uses `matcher` to exclude Next.js internals (`/_next`, static assets)
- Auth cookie is secure (only sent over HTTPS in production) and httpOnly (not accessible from JavaScript)
- If accessing a protected route, users are redirected to login and then back to their original destination
- Deployment already completed to production with environment variables set