### PR TITLE
fix(pmtiles): use field_uuid instead of field_id for pesticide and NLES5 joins

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/data_loader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/data_loader.py
@@ -462,7 +462,7 @@ class PMTilesDataLoader:
 
             if nles5_table:
                 query_parts.append(f"""
-                LEFT JOIN {nles5_table} n ON f.field_id = n.field_id
+                LEFT JOIN {nles5_table} n ON f.field_uuid = n.field_uuid
                 """)
 
             # Execute integration query
@@ -516,11 +516,7 @@ class PMTilesDataLoader:
                 summary_query = f"""
                 CREATE OR REPLACE TABLE temp_pesticide_summary AS
                 SELECT
-                    -- Extract field_id from MatchedBlockID (stored as 'block_' || field_id)
-                    -- Used as stable join key since field_uuid changes when FVM geometry is re-run
-                    REGEXP_REPLACE(
-                        COALESCE(MatchedBlockID, ''), '^block_', ''
-                    ) as field_id,
+                    field_uuid,
                     COUNT(*) as pesticide_applications,
                     STRING_AGG(DISTINCT PesticideName, ', ') as pesticides_used,
 
@@ -659,17 +655,14 @@ class PMTilesDataLoader:
                     ANY_VALUE(water_distance_formatted) as water_distance_formatted,
                     AVG(MatchConfidence) as avg_match_confidence
                 FROM {enhanced_pesticide_table}
-                GROUP BY REGEXP_REPLACE(COALESCE(MatchedBlockID, ''), '^block_', '')
+                GROUP BY field_uuid
                 """
             else:
                 # Fallback to basic aggregation without BMD classifications
                 summary_query = f"""
                 CREATE OR REPLACE TABLE temp_pesticide_summary AS
                 SELECT
-                    -- Extract field_id from MatchedBlockID (stored as 'block_' || field_id)
-                    REGEXP_REPLACE(
-                        COALESCE(MatchedBlockID, ''), '^block_', ''
-                    ) as field_id,
+                    field_uuid,
                     COUNT(*) as pesticide_applications,
                     STRING_AGG(DISTINCT PesticideName, ', ') as pesticides_used,
 
@@ -752,7 +745,7 @@ class PMTilesDataLoader:
                     ANY_VALUE(water_distance_formatted) as water_distance_formatted,
                     AVG(MatchConfidence) as avg_match_confidence
                 FROM {pesticide_table}
-                GROUP BY REGEXP_REPLACE(COALESCE(MatchedBlockID, ''), '^block_', '')
+                GROUP BY field_uuid
                 """
 
             await asyncio.to_thread(self.conn.execute, summary_query)
@@ -858,7 +851,7 @@ class PMTilesDataLoader:
                 ps.water_distance_formatted,
                 ps.avg_match_confidence
             FROM {integrated_table} i
-            LEFT JOIN temp_pesticide_summary ps ON CAST(i.field_id AS VARCHAR) = ps.field_id
+            LEFT JOIN temp_pesticide_summary ps ON i.field_uuid = ps.field_uuid
             """
 
             await asyncio.to_thread(self.conn.execute, update_query)


### PR DESCRIPTION
## Summary
Fixed critical data integrity issue where pesticide data was being incorrectly matched across farms. The join key was using `field_id` (Marknr), which is **not unique** across different CVRs. Multiple farms can have field 1, 2, 3, etc., causing cross-farm data contamination.

Replaced all occurrences with `field_uuid`, a deterministic hash of geometry that is unique per field and prevents collisions.

## Changes
- Pesticide summary queries now GROUP BY and SELECT `field_uuid` directly (both BMD and non-BMD paths)
- Pesticide LEFT JOIN now matches on `field_uuid` instead of `field_id`
- NLES5 LEFT JOIN now matches on `field_uuid` instead of `field_id`

## Why this is correct
- `field_uuid` is unique per field geometry (deterministic hash) — no cross-farm collisions
- Pesticide proximity parquet already has `field_uuid` column (from pesticide_disaggregation.py)
- Consistent with env_analysis and production joins which already use `field_uuid`
- If vintage mismatch occurs → NULL pesticide data (correct behavior vs wrong farm's data)

## Testing
Visually verified that:
- All SELECT/GROUP BY clauses now use `field_uuid`
- All three JOIN locations updated consistently
- Changes follow the same pattern as existing working joins (env_analysis, production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)