### PR TITLE
Fix GitHub Actions failures: add R2 storage support and fix workflow syntax

### DIFF
--- a/.github/workflows/unified_pipeline_monthly.yml
+++ b/.github/workflows/unified_pipeline_monthly.yml
@@ -272,7 +272,7 @@ jobs:
 
             if [ -z "$MATRIX_SOURCE" ]; then
               echo "❌ ERROR: matrix.source is empty or null"
-              echo "Matrix values: ${{ toJson(matrix) }}"
+              echo "Matrix values: source=${MATRIX_SOURCE} description=${MATRIX_DESCRIPTION} duration=${MATRIX_DURATION}"
               exit 1
             fi
 
@@ -490,7 +490,7 @@ jobs:
 
             if [ -z "$MATRIX_SOURCE" ]; then
               echo "❌ ERROR: matrix.source is empty or null"
-              echo "Matrix values: ${{ toJson(matrix) }}"
+              echo "Matrix values: source=${MATRIX_SOURCE} description=${MATRIX_DESCRIPTION} duration=${MATRIX_DURATION}"
               exit 1
             fi
 

--- a/backend/pipelines/drive_data_pipeline/bronze/storage.py
+++ b/backend/pipelines/drive_data_pipeline/bronze/storage.py
@@ -65,7 +65,7 @@ class BronzeStorageManager:
 
         # Store timestamp for use in create_folder_structure
         # The actual directory creation happens in create_folder_structure based on subfolder
-        if self.storage_manager.storage_type.lower() == "gcs":
+        if self.storage_manager.storage_type.lower() in ("gcs", "r2"):
             # GCS storage - use bronze as base
             run_dir = Path("bronze")
         else:
@@ -203,7 +203,7 @@ class BronzeStorageManager:
                         f"backend at {file_path}"
                     )
                     # For GCS, try a brief retry since there might be eventual consistency issues
-                    if self.storage_manager.storage_type.lower() == "gcs":
+                    if self.storage_manager.storage_type.lower() in ("gcs", "r2"):
                         import time
 
                         time.sleep(0.5)  # Brief wait for GCS consistency

--- a/backend/pipelines/drive_data_pipeline/config/settings.py
+++ b/backend/pipelines/drive_data_pipeline/config/settings.py
@@ -17,6 +17,7 @@ class StorageType(str, Enum):
 
     LOCAL = "local"
     GCS = "gcs"
+    R2 = "r2"
 
 
 class LogLevel(str, Enum):
@@ -43,8 +44,14 @@ class Settings(BaseModel):
     )
 
     # Storage settings
-    storage_type: StorageType = Field(StorageType.LOCAL, description="Storage type (local or gcs)")
+    storage_type: StorageType = Field(
+        StorageType.LOCAL, description="Storage type (local, gcs, or r2)"
+    )
     gcs_bucket: str | None = Field(None, description="GCS bucket name (if using GCS)")
+    r2_bucket: str | None = Field(None, description="R2 bucket name (if using R2)")
+    r2_access_key_id: str | None = Field(None, description="R2 access key ID")
+    r2_secret_access_key: str | None = Field(None, description="R2 secret access key")
+    r2_account_id: str | None = Field(None, description="R2 account ID")
 
     # Logging settings
     log_level: LogLevel = Field(LogLevel.INFO, description="Logging level")
@@ -70,6 +77,10 @@ class Settings(BaseModel):
         # Validate GCS bucket
         if self.storage_type == StorageType.GCS and not self.gcs_bucket:
             raise ValueError("GCS bucket must be specified when using GCS storage")
+
+        # Validate R2 bucket
+        if self.storage_type == StorageType.R2 and not self.r2_bucket:
+            raise ValueError("R2 bucket must be specified when using R2 storage")
 
         # Validate credentials file
         if not self.use_public_access and self.google_application_credentials is not None:
@@ -98,9 +109,15 @@ def get_settings() -> Settings:
     environment = os.getenv("ENVIRONMENT", "development")
 
     # Auto-configure storage type based on environment
+    # R2 takes precedence if credentials are available
+    r2_bucket = os.getenv("R2_BUCKET")
     if environment.lower() in ("production", "container"):
-        default_storage_type = "gcs"
-        default_gcs_bucket = os.getenv("GCS_BUCKET", "landbruget-data")
+        if r2_bucket or os.getenv("R2_ACCESS_KEY_ID"):
+            default_storage_type = "r2"
+            default_gcs_bucket = None
+        else:
+            default_storage_type = "gcs"
+            default_gcs_bucket = os.getenv("GCS_BUCKET", "landbruget-data")
     else:
         default_storage_type = "local"
         default_gcs_bucket = None
@@ -114,6 +131,10 @@ def get_settings() -> Settings:
         use_public_access=os.getenv("USE_PUBLIC_ACCESS", "false").lower() in ("true", "1", "yes"),
         storage_type=os.getenv("STORAGE_TYPE", default_storage_type),
         gcs_bucket=os.getenv("GCS_BUCKET", default_gcs_bucket),
+        r2_bucket=r2_bucket,
+        r2_access_key_id=os.getenv("R2_ACCESS_KEY_ID"),
+        r2_secret_access_key=os.getenv("R2_SECRET_ACCESS_KEY"),
+        r2_account_id=os.getenv("R2_ACCOUNT_ID"),
         log_level=os.getenv("LOG_LEVEL", "INFO"),
         max_workers=int(os.getenv("MAX_WORKERS", "4")),
     )

--- a/backend/pipelines/drive_data_pipeline/main.py
+++ b/backend/pipelines/drive_data_pipeline/main.py
@@ -472,9 +472,13 @@ def main() -> int:
         # then public access if enabled
 
         # Initialize storage manager
+        # Use r2_bucket for R2 storage, gcs_bucket for GCS, None for local
+        bucket_name = (
+            settings.r2_bucket if settings.storage_type.value == "r2" else settings.gcs_bucket
+        )
         storage_manager = get_storage_manager(
             storage_type=settings.storage_type.value,
-            bucket_name=settings.gcs_bucket,
+            bucket_name=bucket_name,
             base_dir=str(settings.base_path),
         )
 
@@ -581,7 +585,7 @@ def main() -> int:
 
                 # Look for dataset directories in bronze path
                 # Handle both local and GCS storage
-                if settings.storage_type.value == "gcs":
+                if settings.storage_type.value in ("gcs", "r2"):
                     # For GCS, use the storage manager to list directories
                     try:
                         # List dataset directories (fertiliser, work_permits, etc.)
@@ -711,7 +715,7 @@ def main() -> int:
                     )
 
                     # For GCS storage, also check recursively
-                    if storage_manager.storage_type.lower() == "gcs":
+                    if storage_manager.storage_type.lower() in ("gcs", "r2"):
                         # GCS storage - list with recursive prefix
                         prefix = str(bronze_run_path).rstrip("/") + "/"
                         if hasattr(storage_manager, "gcs_bucket") and storage_manager.gcs_bucket:

--- a/backend/pipelines/drive_data_pipeline/silver/storage.py
+++ b/backend/pipelines/drive_data_pipeline/silver/storage.py
@@ -65,7 +65,7 @@ class SilverStorageManager(DuckDBProcessor):
 
         # Store timestamp for use in create_output_directory
         # The actual directory creation happens in create_output_directory based on subfolder
-        if self.storage_manager.storage_type.lower() == "gcs":
+        if self.storage_manager.storage_type.lower() in ("gcs", "r2"):
             # GCS storage - use empty path as base since base_path already includes
             # the silver structure
             # This prevents the nested silver/silver/... issue

--- a/backend/pipelines/drive_data_pipeline/utils/storage.py
+++ b/backend/pipelines/drive_data_pipeline/utils/storage.py
@@ -52,21 +52,23 @@ class DriveStorageManager:
         self.bucket_name = bucket_name
         self.base_dir = Path(base_dir) if base_dir else Path()
 
-        if storage_type.lower() == "gcs":
+        if storage_type.lower() in ("gcs", "r2"):
             if not bucket_name:
-                raise ValueError("bucket_name is required for GCS storage")
+                raise ValueError("bucket_name is required for GCS/R2 storage")
 
-            # Try to use optimized GCS access, fallback to legacy if needed
+            # Try to use optimized GCS/R2 access (GCSDataAccess supports both via s3fs), fallback to legacy if needed
             if GCSDataAccess:
                 try:
                     self.gcs_access = GCSDataAccess()
                     self.use_optimized = True
                     logger.info(
-                        f"✅ DriveStorageManager: Initialized with optimized GCS access "
+                        f"✅ DriveStorageManager: Initialized with optimized {storage_type.upper()} access "
                         f"for bucket: {bucket_name}"
                     )
                 except Exception as e:
-                    logger.warning(f"⚠️ Failed to initialize optimized GCS access: {e}")
+                    logger.warning(
+                        f"⚠️ Failed to initialize optimized {storage_type.upper()} access: {e}"
+                    )
                     self.gcs_access = None
                     self.use_optimized = False
                     self._init_fallback_gcs(bucket_name)
@@ -113,7 +115,7 @@ class DriveStorageManager:
             else:
                 file_bytes = data
 
-            if self.storage_type.lower() == "gcs":
+            if self.storage_type.lower() in ("gcs", "r2"):
                 # For GCS, we need to construct the path correctly
                 # Remove any base_dir prefix if it exists in the path
                 gcs_relative_path = str(path)
@@ -180,7 +182,7 @@ class DriveStorageManager:
             StorageError: If the file could not be read
         """
         try:
-            if self.storage_type.lower() == "gcs":
+            if self.storage_type.lower() in ("gcs", "r2"):
                 if self.use_optimized and self.gcs_access:
                     gcs_path = f"gs://{self.bucket_name}/{path}"
 
@@ -218,7 +220,7 @@ class DriveStorageManager:
             StorageError: If the JSON could not be saved
         """
         try:
-            if self.storage_type.lower() == "gcs":
+            if self.storage_type.lower() in ("gcs", "r2"):
                 if self.use_optimized and self.gcs_access:
                     gcs_path = f"gs://{self.bucket_name}/{path}"
                     self.gcs_access.upload_json(data, gcs_path)
@@ -260,7 +262,7 @@ class DriveStorageManager:
             StorageError: If the JSON could not be read
         """
         try:
-            if self.storage_type.lower() == "gcs":
+            if self.storage_type.lower() in ("gcs", "r2"):
                 if self.use_optimized and self.gcs_access:
                     gcs_path = f"gs://{self.bucket_name}/{path}"
                     data = self.gcs_access.download_json(gcs_path)
@@ -302,7 +304,7 @@ class DriveStorageManager:
             StorageError: If the directory could not be read
         """
         try:
-            if self.storage_type.lower() == "gcs":
+            if self.storage_type.lower() in ("gcs", "r2"):
                 if self.use_optimized and self.gcs_access:
                     # Use optimized GCS file listing
                     prefix = (
@@ -365,7 +367,7 @@ class DriveStorageManager:
             StorageError: If the directory could not be created
         """
         try:
-            if self.storage_type.lower() == "gcs":
+            if self.storage_type.lower() in ("gcs", "r2"):
                 # GCS doesn't require directory creation
                 logger.debug(f"Directory ensured for GCS: {path}")
             else:
@@ -387,7 +389,7 @@ class DriveStorageManager:
             True if file exists, False otherwise
         """
         try:
-            if self.storage_type.lower() == "gcs":
+            if self.storage_type.lower() in ("gcs", "r2"):
                 if self.use_optimized and self.gcs_access:
                     gcs_path = f"gs://{self.bucket_name}/{path}"
                     return self.gcs_access.file_exists(gcs_path)


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes multiple GitHub Actions workflow failures:
- Drive data pipeline Pydantic validation error (R2 storage type not recognized)
- Unified pipeline monthly workflow bash syntax error (invalid inline JSON in echo statement)

## 💡 Solution

**Added R2 storage support to drive_data_pipeline**:
- Added `R2 = "r2"` to StorageType enum in config/settings.py
- Added R2 credential fields: r2_bucket, r2_access_key_id, r2_secret_access_key, r2_account_id
- Updated get_settings() to auto-detect R2 in production when R2 credentials are available
- Updated all storage type checks from `== "gcs"` to `in ("gcs", "r2")` across 6 files
- R2 is now treated as S3-compatible storage alongside GCS

**Fixed bash syntax error in unified_pipeline_monthly.yml**:
- Removed unsafe inline GitHub Actions expression substitution: `${{ toJson(matrix) }}`
- Replaced with safe environment variable references already populated in the workflow (MATRIX_SOURCE, MATRIX_DESCRIPTION, MATRIX_DURATION)
- Root cause: JSON with quotes and parentheses broke bash script parsing at load time

## ✅ How to Test

```bash
# Verify drive pipeline still works with GCS
export STORAGE_TYPE=gcs
export GCS_BUCKET=landbruget-data
cd backend/pipelines/drive_data_pipeline && python main.py --bronze-only

# Verify R2 auto-detection works (set R2 credentials to test)
export ENVIRONMENT=production
export R2_BUCKET=test-bucket
export R2_ACCESS_KEY_ID=test-key
cd backend/pipelines/drive_data_pipeline && python -c "from config.settings import get_settings; s = get_settings(); print(f'Storage: {s.storage_type.value}')"
```

## 📝 Additional Notes

This enables the drive_data_pipeline to work with Cloudflare R2 storage, which is used as an S3-compatible backend in the unified pipeline. The changes are backward-compatible with existing GCS deployments.

Two additional issues were identified but not fixed in this PR (require separate investigation):
- CVR Enrichment Weekly consolidation fails with timestamp/path mismatch between Python code and bash consolidation step
- Field Area Analysis Stage 0 fails with DuckDB spatial type casting issue (ST_GeomFromText with BLOB)