### PR TITLE
fix: extract centroid calculation and fix GeoJSON vertex bias

### DIFF
--- a/frontend/src/components/field-analysis/FieldAnalysisMap.tsx
+++ b/frontend/src/components/field-analysis/FieldAnalysisMap.tsx
@@ -21,6 +21,7 @@ import { LayerVisibility, FilterState, FieldAnalysisData } from './types';
 import { getDecileBreakpoints, getColorScheme } from './colorUtils';
 import { SearchBar } from './SearchBar';
 import { ColorLegend } from './ColorLegend';
+import { computeCentroid } from '@/utils/geo';
 
 // Type for MapLibre map instance - updated for @vis.gl/react-maplibre
 interface MapInstance {
@@ -2026,8 +2027,15 @@ const FieldAnalysisMap = memo(function FieldAnalysisMap({
     const uniqueFields: Record<string, FieldAnalysisData> = {};
 
     fieldFeatures.forEach((feature) => {
-      const fieldData = feature.properties as FieldAnalysisData;
+      const fieldData = { ...feature.properties } as FieldAnalysisData;
       if (fieldData.field_uuid && !uniqueFields[fieldData.field_uuid]) {
+        // Compute centroid from geometry for coordinate export
+        if (feature.geometry && !fieldData.click_coordinates) {
+          const centroid = computeCentroid(feature.geometry);
+          if (centroid) {
+            fieldData.click_coordinates = centroid;
+          }
+        }
         uniqueFields[fieldData.field_uuid] = fieldData;
       }
     });

--- a/frontend/src/components/field-analysis/types.ts
+++ b/frontend/src/components/field-analysis/types.ts
@@ -1,5 +1,7 @@
 export interface FieldAnalysisData {
   field_uuid: string;
+  mark_id?: string;
+  markblok_id?: string;
   kommune: string;
   cvr_number: string;
   area_hectares: number;

--- a/frontend/src/utils/csv-export.ts
+++ b/frontend/src/utils/csv-export.ts
@@ -11,6 +11,8 @@ export function convertToCSV(fields: FieldAnalysisData[]): string {
   // Define CSV headers in Danish
   const headers = [
     'Mark UUID',
+    'Markblok',
+    'Marknr',
     'Kommune',
     'CVR Nummer',
     'Areal (ha)',
@@ -53,6 +55,8 @@ export function convertToCSV(fields: FieldAnalysisData[]): string {
   // Convert data rows
   const rows = fields.map((field) => [
     field.field_uuid || '',
+    field.markblok_id || '',
+    field.mark_id || '',
     field.kommune || '',
     field.cvr_number || '',
     field.area_hectares?.toString() || '',

--- a/frontend/src/utils/geo.ts
+++ b/frontend/src/utils/geo.ts
@@ -1,0 +1,39 @@
+import type { Geometry } from 'geojson';
+
+/**
+ * Compute an approximate centroid from a GeoJSON Polygon or MultiPolygon geometry.
+ * Uses the mean of the outer ring vertices (excluding the duplicate closing vertex
+ * per RFC 7946 §3.1.6).
+ *
+ * Returns null for unsupported geometry types or empty coordinate arrays.
+ */
+export function computeCentroid(
+  geometry: Geometry
+): { lat: number; lng: number } | null {
+  const coords =
+    geometry.type === 'Polygon'
+      ? geometry.coordinates[0]
+      : geometry.type === 'MultiPolygon'
+        ? geometry.coordinates[0][0]
+        : null;
+
+  // A valid ring has at least 4 positions (3 unique + closing duplicate)
+  if (!coords || coords.length < 4) {
+    return null;
+  }
+
+  // Exclude the closing vertex (duplicate of first) per GeoJSON spec
+  const uniqueCount = coords.length - 1;
+  let sumLng = 0;
+  let sumLat = 0;
+
+  for (let i = 0; i < uniqueCount; i++) {
+    sumLng += coords[i][0];
+    sumLat += coords[i][1];
+  }
+
+  return {
+    lat: sumLat / uniqueCount,
+    lng: sumLng / uniqueCount,
+  };
+}


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes #595
Fixes #596

## 💡 Solution
- **Extract centroid logic**: Moved complex geometric calculation from `FieldAnalysisMap` component to new `frontend/src/utils/geo.ts` utility function per CLAUDE.md presentational-only rule
- **Fix properties mutation**: Clone `feature.properties` before mutating to prevent TypeError from MapLibre's frozen feature objects
- **Fix GeoJSON centroid bias**: Exclude duplicate closing vertex when computing centroid average per RFC 7946 §3.1.6 (polygon rings are explicitly closed with first == last)
- **Add field identifiers**: Extended `FieldAnalysisData` type with optional `mark_id` and `markblok_id` fields for CSV export

## ✅ How to Do Self-Test
- [x] oxlint passes (no warnings/errors)
- [x] TypeScript compiles cleanly
- [x] Component correctly imports and uses centroid utility
- [x] Feature properties are cloned before mutation
- [x] Centroid calculation excludes closing vertex

## 📝 Additional Notes
No breaking changes — all new fields are optional.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)