### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,8 @@ updates:
       dev-dependencies:
         dependency-type: "development"
 
-  # Backend Python packages
-  - package-ecosystem: "pip"
+  # Backend Python packages (uv)
+  - package-ecosystem: "uv"
     directories:
       - "/backend/common"
       - "/backend/pipelines/unified_pipeline"


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
Added `.github/dependabot.yml` to configure Dependabot for automated dependency updates across the project:
- **Frontend (npm)**: Weekly updates with dev dependencies grouped separately
- **Backend (pip)**: Monitors all 12 Python pipeline packages for updates
- **GitHub Actions**: Keeps workflow actions up to date

Updates are checked every Monday with a limit of 10 open PRs per ecosystem.

## ✅ How to Test
Enable Dependabot version updates in repository settings (Settings → Code security and analysis → Dependabot version updates). Dependabot will automatically start creating PRs Monday mornings.

## 📝 Additional Notes
This is a zero-code change that enables automated dependency management. No action required once merged—GitHub handles everything automatically.