### PR TITLE
fix: strip gs:// prefix in GEUS dataverse bronze upload

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/geus_dataverse_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/geus_dataverse_pesticides.py
@@ -151,13 +151,13 @@ class GEUSDataversePesticidesBronze(
         """
         run_timestamp = self.date_pattern
         relative_path = f"bronze/{self.config.dataset}/{run_timestamp}/{filename}"
-        gcs_path = f"gs://{self.config.bucket}/{relative_path}"
+        storage_path = f"{self.config.bucket}/{relative_path}"
 
-        # Stream binary content directly to GCS using gcsfs
-        with self.gcs_access.fs.open(gcs_path, "wb") as f:
+        # Stream binary content directly to storage using s3fs (R2)
+        with self.gcs_access.fs.open(storage_path, "wb") as f:
             f.write(rds_content)
 
-        self.log.info(f"Saved {filename} to {gcs_path}")
+        self.log.info(f"Saved {filename} to {storage_path}")
         return relative_path
 
     async def run(self) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary

- The GEUS Dataverse Pesticides bronze pipeline passed `gs://bucket/path` directly to `self.gcs_access.fs.open()`, but since the storage backend is now s3fs (Cloudflare R2), it tried to parse `gs:` as a bucket name and failed with `Invalid bucket name "gs:"`
- Fixed by using bare `bucket/path` format, matching the pattern already used by `svineflytning_pipeline` and `chr_pipeline`

## Changes

### `unified_pipeline/bronze/geus_dataverse_pesticides.py`
- `_save_rds_to_gcs()`: Changed `gs://{bucket}/{path}` → `{bucket}/{path}` for the `fs.open()` call

## Test plan

- [ ] Re-run unified pipeline `geus_dataverse_pesticides` — should no longer get "Invalid bucket name" error
- [ ] Verify AM_pest.rds and AM_pfas.rds are saved to R2 bronze layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)