### PR TITLE
fix: add GCP auth to discover-folders job in drive pipeline

### DIFF
--- a/.github/workflows/drive_pipeline.yml
+++ b/.github/workflows/drive_pipeline.yml
@@ -87,6 +87,12 @@ jobs:
         sudo apt-get install -y tesseract-ocr poppler-utils
         uv pip install --system -e .
 
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v3'
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
     - name: Set up environment variables
       env:
         R2_BUCKET: ${{ secrets.R2_BUCKET }}


### PR DESCRIPTION
## 🛠️ Issue Fix
The Google Drive matrix job was being skipped because the `discover-folders` job failed with `DefaultCredentialsError`, preventing folder discovery.

## 💡 Solution
Added the `google-github-actions/auth@v3` step to the `discover-folders` job in the drive pipeline workflow. This step was present in both `run-single` and `run-matrix` jobs but missing in `discover-folders`, which is required to authenticate with Google Cloud and discover Drive folders.

Without this auth step, the discovery script couldn't authenticate, exited with an error, and produced empty output. This caused the `run-matrix` condition to fail (checking `folders != '[]' && folders != ''`), resulting in the matrix job being skipped.

## ✅ How to Test
Manually trigger the workflow with `use_matrix=true` to verify that:
1. The `discover-folders` job completes successfully
2. The `run-matrix` job is no longer skipped
3. Matrix jobs run for each discovered folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)