### PR TITLE
fix: water_projects pipeline resilience + N2000_HYDROLOGI from miljoeportal.dk

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/water_projects.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/water_projects.py
@@ -77,6 +77,7 @@ class WaterProjectsBronzeConfig(BaseJobConfig):
     layers: ClassVar[list[str]] = [
         "N2000_projekter:Hydrologi_E",
         "N2000_projekter:Hydrologi_F",
+        "landbrugsdrift:N2000_HYDROLOGI",
         "Ovrige_projekter:Vandloebsrestaurering_E",
         "Ovrige_projekter:Vandloebsrestaurering_F",
         "Vandprojekter:Fosfor_E_samlet",
@@ -92,6 +93,7 @@ class WaterProjectsBronzeConfig(BaseJobConfig):
         "Klima_lavbund_demarkation___offentlige_projekter:0",
     ]
     url_mapping: ClassVar[dict[str, str]] = {
+        "landbrugsdrift:N2000_HYDROLOGI": "https://arld-extgeo.miljoeportal.dk/geoserver/wfs",
         "vandprojekter:kla_projektforslag": "https://wfs2-miljoegis.mim.dk/vandprojekter/wfs",
         "vandprojekter:kla_projektomraader": "https://wfs2-miljoegis.mim.dk/vandprojekter/wfs",
         "Klima_lavbund_demarkation___offentlige_projekter:0": "https://gis.nst.dk/server/rest/services/autonom/Klima_lavbund_demarkation___offentlige_projekter/FeatureServer",
@@ -422,8 +424,8 @@ class WaterProjectsBronze(BaseSource[WaterProjectsBronzeConfig], BronzeJobInterf
                     ]  # Add layer as metadata
                     raw_features.extend(raw_data_with_metadata)
                 except Exception as e:
-                    self.log.error(f"Error occured while fetching chunk: {e}")
-                    raise e
+                    self.log.warning(f"Failed to fetch layer {layer} (skipping): {e}")
+                    continue
         if not raw_features:
             self.log.warning("No raw features fetched")
             return None

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/water_projects.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/water_projects.py
@@ -66,6 +66,7 @@ class WaterProjectsSilverConfig(BaseJobConfig):
     layers: ClassVar[list[str]] = [
         "N2000_projekter:Hydrologi_E",
         "N2000_projekter:Hydrologi_F",
+        "landbrugsdrift:N2000_HYDROLOGI",
         "Ovrige_projekter:Vandloebsrestaurering_E",
         "Ovrige_projekter:Vandloebsrestaurering_F",
         "Vandprojekter:Fosfor_E_samlet",


### PR DESCRIPTION
## Summary

- **Resilience fix**: Changed `raise e` to `continue` when a WFS layer fails — a single `Connection reset by peer` from `geodata.fvm.dk` no longer crashes the entire water_projects pipeline
- **New data source**: Added `landbrugsdrift:N2000_HYDROLOGI` (1,381 features, EPSG:25832) from `https://arld-extgeo.miljoeportal.dk/geoserver/wfs` as a complementary N2000 hydrology layer alongside the existing `Hydrologi_E`/`Hydrologi_F` layers
- Silver config synced to include the new layer

## Context

The failing CI job (67052964053) showed `RetryError` after 5 attempts with `[Errno 104] Connection reset by peer` on `N2000_projekter:Hydrologi_E` from `geodata.fvm.dk`. The previous behavior was to raise and abort all remaining layers.

The new `arld-extgeo.miljoeportal.dk` URL was tested and confirmed working (title: "N2000-arealer til hydrologi", EPSG:25832, WFS 1.0/1.1/2.0).

## Test plan

- [ ] Verify water_projects pipeline runs in CI without failing if one layer has a transient connection error
- [ ] Verify `landbrugsdrift:N2000_HYDROLOGI` features appear in silver output (columns: `temanavn`, `kode`)
- [ ] Confirm other layers still process normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)