### PR TITLE
fix: strip gs:// prefix before s3fs upload

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_disaggregation.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_disaggregation.py
@@ -225,8 +225,12 @@ class PesticideDisaggregationGold(BaseSource[PesticideDisaggregationGoldConfig],
         """Helper method to upload file using gcs_access."""
         import shutil
 
-        gcs_path = f"gs://{bucket_name}/{destination_blob_name}"
-        with open(source_file_path, "rb") as src, self.gcs_access.fs.open(gcs_path, "wb") as dst:
+        # s3fs expects plain bucket/path without gs:// or r2:// prefix
+        storage_path = f"{bucket_name}/{destination_blob_name}"
+        with (
+            open(source_file_path, "rb") as src,
+            self.gcs_access.fs.open(storage_path, "wb") as dst,
+        ):
             shutil.copyfileobj(src, dst)
 
     def _validate_strategy_results(self, strategy_name: str, processed_count: int) -> None:


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes GCS upload failures in pesticide disaggregation pipeline (all 14 year jobs failing with "Invalid bucket name "gs:"").

## 💡 Solution

The pesticide disaggregation pipeline was constructing `gs://bucket/path` URLs and passing them directly to `s3fs.open()`. Since the filesystem migrated from gcsfs to s3fs (Cloudflare R2), it expects plain `bucket/path` format without protocol prefixes. The `gs://` prefix was being parsed as the bucket name `"gs:"`, causing upload failures.

Fixed by removing the `gs://` prefix construction. Pattern aligns with existing code in `base.py:1366`.

## ✅ How to Test

Monitor the next manual unified pipeline run with `pesticide_disaggregation` source. All 14 year jobs (2010-2023) should complete successfully, and upstream `pesticide_proximity` jobs will have access to the saved data.

## 📝 Additional Notes

- This was the root cause of 14 failed matrix jobs in run #23085338918
- Worker safety and property cadastral merge failures are unrelated (missing upstream silver data)
- Change is minimal and focused on path construction only