### PR TITLE
ci: upgrade all GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/arbejdstilsynet_inspections_pipeline.yml
+++ b/.github/workflows/arbejdstilsynet_inspections_pipeline.yml
@@ -86,7 +86,7 @@ jobs:
         exit 1
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: pipeline-output

--- a/.github/workflows/bbr_buildings_pipeline.yml
+++ b/.github/workflows/bbr_buildings_pipeline.yml
@@ -59,7 +59,7 @@ jobs:
         echo "$BRONZE_TIMESTAMP" > /tmp/bronze_timestamp.txt
 
     - name: Upload bronze timestamp artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: bronze-timestamp
         path: /tmp/bronze_timestamp.txt
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Download bronze timestamp artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: bronze-timestamp
         path: /tmp/
@@ -190,7 +190,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Download bronze timestamp artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: bronze-timestamp
         path: /tmp/
@@ -390,7 +390,7 @@ jobs:
         echo "✅ Silver layer processing completed!"
 
     - name: Upload Silver Pipeline Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: silver-pipeline-results

--- a/.github/workflows/bmd_monthly_pipeline.yml
+++ b/.github/workflows/bmd_monthly_pipeline.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload artifacts (Development only)
         if: env.ENVIRONMENT == 'development'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bmd-data
           path: |

--- a/.github/workflows/chr_pipeline.yml
+++ b/.github/workflows/chr_pipeline.yml
@@ -283,7 +283,7 @@ jobs:
           $CMD
 
       - name: Upload context artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chr-context-data
           path: /tmp/chr_context.json
@@ -297,7 +297,7 @@ jobs:
           echo "Bronze timestamp: $BRONZE_TIMESTAMP"
 
       - name: Upload bronze timestamp artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bronze-timestamp
           path: /tmp/bronze_timestamp.txt
@@ -305,7 +305,7 @@ jobs:
 
       - name: Upload bronze data summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bronze-foundation-logs
           path: |
@@ -353,13 +353,13 @@ jobs:
 
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-data
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -528,13 +528,13 @@ jobs:
 
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-data
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -686,13 +686,13 @@ jobs:
 
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-data
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -816,13 +816,13 @@ jobs:
 
 
       - name: Download context artifact with herd details
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-with-details
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -976,13 +976,13 @@ jobs:
 
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-data
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -1058,7 +1058,7 @@ jobs:
           $CMD
 
       - name: Upload updated context artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chr-context-with-details
           path: /tmp/chr_context_with_details.json
@@ -1116,13 +1116,13 @@ jobs:
 
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-with-details
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -1292,7 +1292,7 @@ jobs:
 
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -1504,7 +1504,7 @@ jobs:
           fi
 
       - name: Download bronze timestamp artifact (if available)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: bronze-timestamp

--- a/.github/workflows/climate_pipeline.yml
+++ b/.github/workflows/climate_pipeline.yml
@@ -92,14 +92,14 @@ jobs:
         echo "{\"batches\": $(seq 0 $((batch_count - 1)) | jq -R . | jq -s .)}" > /tmp/batches_${{ matrix.year }}.json
 
     - name: Upload CVR list artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cvrs-${{ matrix.year }}
         path: /tmp/cvrs_${{ matrix.year }}.json
         retention-days: 1
 
     - name: Upload batch info artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: batches-${{ matrix.year }}
         path: /tmp/batches_${{ matrix.year }}.json
@@ -116,7 +116,7 @@ jobs:
 
     steps:
     - name: Download batch info
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: batches-*
         path: /tmp/batch_info
@@ -171,7 +171,7 @@ jobs:
         uv pip install --system pandas pyarrow
 
     - name: Download CVR list
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cvrs-2021
         path: /tmp
@@ -187,7 +187,7 @@ jobs:
           --output-dir /tmp/climate_output_2021
 
     - name: Upload batch result
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: batch-2021-${{ matrix.batch }}
         path: /tmp/climate_output_2021/batch_*.parquet
@@ -227,7 +227,7 @@ jobs:
         uv pip install --system pandas pyarrow
 
     - name: Download CVR list
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cvrs-2022
         path: /tmp
@@ -243,7 +243,7 @@ jobs:
           --output-dir /tmp/climate_output_2022
 
     - name: Upload batch result
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: batch-2022-${{ matrix.batch }}
         path: /tmp/climate_output_2022/batch_*.parquet
@@ -283,7 +283,7 @@ jobs:
         uv pip install --system pandas pyarrow
 
     - name: Download CVR list
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cvrs-2023
         path: /tmp
@@ -299,7 +299,7 @@ jobs:
           --output-dir /tmp/climate_output_2023
 
     - name: Upload batch result
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: batch-2023-${{ matrix.batch }}
         path: /tmp/climate_output_2023/batch_*.parquet
@@ -331,14 +331,14 @@ jobs:
         uv pip install --system pandas pyarrow
 
     - name: Download all batch results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: batch-2021-*
         path: /tmp/climate_output_2021
         merge-multiple: true
 
     - name: Download CVR info for batch count
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cvrs-2021
         path: /tmp
@@ -392,14 +392,14 @@ jobs:
         uv pip install --system pandas pyarrow
 
     - name: Download all batch results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: batch-2022-*
         path: /tmp/climate_output_2022
         merge-multiple: true
 
     - name: Download CVR info for batch count
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cvrs-2022
         path: /tmp
@@ -453,14 +453,14 @@ jobs:
         uv pip install --system pandas pyarrow
 
     - name: Download all batch results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: batch-2023-*
         path: /tmp/climate_output_2023
         merge-multiple: true
 
     - name: Download CVR info for batch count
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cvrs-2023
         path: /tmp
@@ -522,7 +522,7 @@ jobs:
 
     steps:
     - name: Download all CVR lists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: cvrs-*
         path: /tmp/cvr_lists

--- a/.github/workflows/cvr_enrichment_pipeline.yml
+++ b/.github/workflows/cvr_enrichment_pipeline.yml
@@ -153,7 +153,7 @@ jobs:
           echo "success=true" >> $GITHUB_OUTPUT
 
       - name: Upload CVR Collection Data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-collection-data
           path: /tmp/cvr_collection_data.parquet
@@ -184,7 +184,7 @@ jobs:
 
       - name: Download CVR Collection Data
         if: ${{ inputs.run_only_step == 'none' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-collection-data
           path: /tmp/
@@ -240,7 +240,7 @@ jobs:
 
       - name: Download CVR Collection Data
         if: ${{ inputs.run_only_step == 'none' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-collection-data
           path: /tmp/
@@ -431,7 +431,7 @@ jobs:
           fi
 
       - name: Upload Consolidated Raw Data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-raw-company-data
           path: /tmp/cvr_raw_data.parquet
@@ -462,7 +462,7 @@ jobs:
 
       - name: Download Raw Company Data
         if: ${{ inputs.run_only_step == 'none' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-raw-company-data
           path: /tmp/
@@ -492,7 +492,7 @@ jobs:
           echo "✅ Data Parsing completed successfully"
 
       - name: Upload Silver Layer Data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-silver-data
           path: /tmp/cvr_companies_silver.parquet
@@ -523,7 +523,7 @@ jobs:
 
       - name: Download Silver Layer Data
         if: ${{ inputs.run_only_step == 'none' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-silver-data
           path: /tmp/
@@ -553,7 +553,7 @@ jobs:
           echo "✅ Data Consolidation completed successfully"
 
       - name: Upload Company Data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-company-data
           path: /tmp/cvr_company_data.parquet
@@ -584,7 +584,7 @@ jobs:
 
       - name: Download Company Data
         if: ${{ inputs.run_only_step == 'none' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-company-data
           path: /tmp/
@@ -648,7 +648,7 @@ jobs:
           fi
 
       - name: Upload P-Number Data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-pnumber-data
           path: /tmp/cvr_pnumber_data.parquet
@@ -679,7 +679,7 @@ jobs:
 
       - name: Download Company Data
         if: ${{ inputs.run_only_step == 'none' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-company-data
           path: /tmp/
@@ -737,7 +737,7 @@ jobs:
           fi
 
       - name: Upload Financial Data Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-financial-data
           path: /tmp/cvr_financial_data.parquet
@@ -768,7 +768,7 @@ jobs:
 
       - name: Download Company and P-Number Data
         if: ${{ inputs.run_only_step == 'none' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-company-data
           path: /tmp/
@@ -776,7 +776,7 @@ jobs:
 
       - name: Download P-Number Data
         if: ${{ inputs.run_only_step == 'none' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-pnumber-data
           path: /tmp/
@@ -831,7 +831,7 @@ jobs:
           fi
 
       - name: Upload Address Data Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-address-data
           path: /tmp/cvr_address_data.parquet

--- a/.github/workflows/data-quality-validation.yml
+++ b/.github/workflows/data-quality-validation.yml
@@ -76,7 +76,7 @@ jobs:
           echo "| Failed | $FAILED |" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: identifier-validation-results
@@ -126,7 +126,7 @@ jobs:
           echo "All CRS validation tests passed." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: geospatial-validation-results
@@ -176,7 +176,7 @@ jobs:
           echo "All area calculation tests passed." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: area-validation-results
@@ -226,7 +226,7 @@ jobs:
           echo "All CHR discovery tests passed." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: chr-validation-results
@@ -301,7 +301,7 @@ jobs:
           fi
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: baseline-comparison-results
@@ -321,7 +321,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: test-results
 
@@ -381,7 +381,7 @@ jobs:
 
       - name: Post comment to PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/h3-pfas-analysis.yml
+++ b/.github/workflows/h3-pfas-analysis.yml
@@ -174,7 +174,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -306,7 +306,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-year${{ matrix.year }}-${{ github.run_id }}
           path: |
@@ -364,7 +364,7 @@ jobs:
           cat artifacts/summary_${{ matrix.year }}.json
 
       - name: Upload output paths as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: output-paths-year${{ matrix.year }}
           path: artifacts/
@@ -388,7 +388,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -433,7 +433,7 @@ jobs:
           uv pip install --system -e ".[production]"
 
       - name: Download output path artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: output-paths-year*
           path: downloaded-artifacts/

--- a/.github/workflows/parquet_to_supabase_migration.yml
+++ b/.github/workflows/parquet_to_supabase_migration.yml
@@ -235,7 +235,7 @@ jobs:
           cp logs/migration/migration_${{ github.event.inputs.environment }}_*.log migration_artifacts/ || true
 
       - name: Upload Migration Logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: migration-logs-${{ matrix.phase }}-${{ needs.pre_migration_checks.outputs.migration_id }}
@@ -357,7 +357,7 @@ jobs:
           fi
 
       - name: Upload Validation Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: validation-reports-${{ needs.pre_migration_checks.outputs.migration_id }}
@@ -452,7 +452,7 @@ jobs:
           cat migration_summary.md
 
       - name: Comment on PR (if applicable)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: github.event_name == 'pull_request'
         with:
           script: |

--- a/.github/workflows/pmtiles-cache-warmup.yml
+++ b/.github/workflows/pmtiles-cache-warmup.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "18"
 

--- a/.github/workflows/svineflytning_pipeline.yml
+++ b/.github/workflows/svineflytning_pipeline.yml
@@ -188,7 +188,7 @@ jobs:
           exit 1
 
       - name: Upload bronze artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always() # Upload even if the pipeline fails
         with:
           name: bronze-output
@@ -196,7 +196,7 @@ jobs:
           retention-days: 7
 
       - name: Upload silver artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always() # Upload even if the pipeline fails
         with:
           name: silver-output

--- a/.github/workflows/sync-r2.yml
+++ b/.github/workflows/sync-r2.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload sync manifest
         if: ${{ !inputs.dry_run && !inputs.skip_sync }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: r2-sync-manifest
           path: backend/scripts/manifest.json
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload schema documentation artifacts
         if: ${{ !inputs.skip_schema }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: schema-documentation
           path: backend/scripts/schema/


### PR DESCRIPTION
## 🛠️ Issue Fix
Resolves Node.js 20 deprecation warnings from GitHub Actions.

## 💡 Solution
Upgraded all GitHub Actions to their latest major versions:
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `actions/setup-node` v4 → v6
- `actions/github-script` v6/v7 → v8
- `google-github-actions/auth` v1 → v3
- `google-github-actions/setup-gcloud` v1 → v3
- `astral-sh/setup-uv` v5 → v7

These upgrades resolve Node.js 20 deprecation warnings and ensure forward compatibility with Node.js 24.

## ✅ How to Do Self-Test
Run any GitHub Actions workflow and verify no Node.js 20 deprecation warnings appear.

## 📝 Additional Notes
All v7/v8 upgrades use standard artifact upload/download patterns (no special parameters), ensuring backward compatibility. Disabled workflows remain unchanged.