### PR TITLE
fix(property-owners): resolve VM startup deadlock

### DIFF
--- a/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
+++ b/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
@@ -54,10 +54,18 @@ fi
 
 log_with_timestamp "✅ Sufficient disk space available"
 
+# Wait for unattended-upgrades to release the dpkg lock (Debian 12 holds it at boot)
+log_with_timestamp "Waiting for dpkg lock to be released..."
+timeout 300 bash -c 'while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
+    log_with_timestamp "dpkg/apt lock held, waiting 10s..."
+    sleep 10
+done' || log_with_timestamp "WARNING: Timed out waiting for dpkg lock, proceeding anyway"
+log_with_timestamp "✅ dpkg lock released"
+
 # Install required packages
 log_with_timestamp "Installing required packages..."
-apt-get update
-apt-get install -y python3-pip python3-venv git dnsutils iputils-ping unzip
+DEBIAN_FRONTEND=noninteractive apt-get update -q
+DEBIAN_FRONTEND=noninteractive apt-get install -y -q python3-pip python3-venv git dnsutils iputils-ping unzip
 
 log_with_timestamp "✅ System packages installed"
 check_resources
@@ -67,13 +75,15 @@ log_with_timestamp "Creating Python virtual environment..."
 python3 -m venv /opt/transfer-env
 source /opt/transfer-env/bin/activate
 
-# Install uv first
+# Install uv (canonical method for Linux VMs)
 log_with_timestamp "Installing uv..."
-pip3 install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
 
-# Install required Python packages (added ijson, pyarrow, uuid for processing)
+# Install required Python packages
+# Note: 'uuid' is Python stdlib — no install needed
 log_with_timestamp "Installing Python packages (ijson, pyarrow, geopandas, etc.)..."
-uv pip install google-cloud-storage google-cloud-secret-manager paramiko ijson pyarrow uuid geopandas shapely pyproj
+uv pip install google-cloud-storage google-cloud-secret-manager paramiko ijson pyarrow geopandas shapely pyproj
 
 log_with_timestamp "✅ Python packages installed"
 check_resources


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes timeout issues in `property_owners_sftp_transfer_pipeline.yml` where VMs were hanging for 60+ minutes before forced deletion.

## 💡 Solution

**Root cause**: Debian 12's `unattended-upgrades` service holds the dpkg lock at startup. The VM startup script hit `apt-get update` and silently blocked indefinitely.

**Changes**:
- Added 5-minute dpkg lock wait with polling before any apt commands
- Added `DEBIAN_FRONTEND=noninteractive` and `-q` flags to suppress interactive prompts
- Updated `uv` installation to use canonical curl method (better for CI/servers)
- Removed unnecessary `uuid` package (Python stdlib since 2.5)

## ✅ Testing

Rerun the property owners pipeline manually:
```bash
gh workflow run property_owners_sftp_transfer_pipeline.yml
```

VM should now complete SFTP download and Parquet processing within 30-45 minutes instead of timing out.

## 📝 Additional Notes

This is a known Debian/GCP issue with unattended-upgrades; the fix is standard practice for GCE startup scripts. No code logic changes—only infrastructure reliability improvements.