### PR TITLE
fix(property-owners): bypass GCS metadata server auto-detection

### DIFF
--- a/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
+++ b/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
@@ -559,7 +559,7 @@ class SFTPToGCSTransferWithProcessing:
     def __init__(self):
         self.project_id = "landbrugsdata-1"
         self.bucket_name = "landbruget-data"
-        self.storage_client = storage.Client()
+        self.storage_client = storage.Client(project=self.project_id)
         self.secret_client = secretmanager.SecretManagerServiceClient()
         self.processor = PropertyDataProcessor()
         logger.info("SFTPToGCSTransferWithProcessing initialized.")


### PR DESCRIPTION
## 🛠️ Issue Fix

Fixes GitHub Actions workflow timeout: property owners pipeline VM silently failed during startup.

## 💡 Solution

Pass `project=self.project_id` to `storage.Client()` constructor to bypass broken auto-detection from GCE metadata server.

**Root cause**: google-cloud-storage 3.9.0 + google-auth 2.49.1 construct metadata server URLs with `https://` instead of `http://`, causing project ID auto-detection to fail silently. The project ID is already hardcoded in the class, so we skip auto-detection by passing it directly.

## ✅ How to Test

The property_owners_sftp_transfer_pipeline.yml workflow will successfully create and run the VM on next execution, uploading processed property ownership data to GCS within 60 minutes instead of timing out.

## 📝 Additional Notes

This unblocks the weekly property owners SFTP transfer that was completely broken since the latest google-auth dependency resolution.