### PR TITLE
fix(property-owners): bypass google-auth mTLS metadata endpoint

### DIFF
--- a/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
+++ b/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
@@ -910,6 +910,14 @@ validate_success() {
     fi
 }
 
+# Force HTTP for GCE metadata server - newer google-auth versions may attempt
+# mTLS/HTTPS metadata endpoint which fails SSL cert verification on this VM.
+# GCE_METADATA_HOST bypasses DNS and goes directly to the metadata IP over HTTP.
+# GCE_METADATA_ROOT sets the full base URL (fallback for older google-auth versions).
+export GCE_METADATA_HOST="169.254.169.254"
+export GCE_METADATA_ROOT="http://metadata.google.internal"
+log_with_timestamp "✅ GCE metadata configured: HOST=169.254.169.254 (bypasses DNS + mTLS)"
+
 # Run the enhanced transfer script
 log_with_timestamp "Executing enhanced transfer script with processing..."
 sync


### PR DESCRIPTION
## 🛠️ Issue Fix

Resolves property-owners SFTP pipeline metadata server failures on GCE VMs.

## 💡 Solution

Added `GCE_METADATA_HOST=169.254.169.254` environment variable before running the transfer script. This forces the Python google-auth library to bypass DNS and mTLS endpoint negotiation, using direct HTTP to the GCE metadata server IP.

**Root cause**: Newer google-auth versions attempt an HTTPS/mTLS metadata endpoint which fails SSL certificate verification in restricted compute environments. Setting `GCE_METADATA_HOST` is the [Google-documented workaround](https://cloud.google.com/compute/docs/troubleshooting/troubleshoot-metadata-server).

## ✅ Testing

VM startup script now logs metadata configuration before executing Python. Once merged and VM is spun up, check logs for:
- `✅ GCE metadata configured: HOST=169.254.169.254`
- Python should successfully authenticate and fetch SFTP credentials
- Silver output files should appear in GCS

## 📝 Additional Notes

Also set `GCE_METADATA_ROOT` for fallback compatibility with older google-auth versions.