### PR TITLE
Fix Data Explorer R2 URL config for reliable /explore deploys

### DIFF
--- a/data-explorer/src/app/api/ask/route.ts
+++ b/data-explorer/src/app/api/ask/route.ts
@@ -2,8 +2,9 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
+import { getR2BaseUrl } from '@/lib/r2';
 
-const R2_BASE_URL = process.env.NEXT_PUBLIC_R2_BASE_URL || 'https://pub-b8c2f72ba51b4fe6804e9bb92280567c.r2.dev';
+const R2_BASE_URL = getR2BaseUrl();
 
 type Dataset = {
   name: string;

--- a/data-explorer/src/app/example/page.tsx
+++ b/data-explorer/src/app/example/page.tsx
@@ -6,6 +6,7 @@ import { SQLEditor } from '@/components/SQLEditor';
 import { ResultsTable } from '@/components/ResultsTable';
 import { AskInput } from '@/components/AskInput';
 import { executeQuery, registerParquetTable } from '@/lib/duckdb';
+import { getR2BaseUrl } from '@/lib/r2';
 import type { DatasetMetadata } from '@/types';
 
 export default function ExamplePage() {
@@ -15,8 +16,7 @@ export default function ExamplePage() {
   const [error, setError] = useState<string | null>(null);
   const [currentQuery, setCurrentQuery] = useState<string>('');
 
-  // Replace with your actual R2 base URL
-  const R2_BASE_URL = 'https://your-r2-bucket.r2.dev';
+  const R2_BASE_URL = getR2BaseUrl();
 
   async function handleTableSelect(dataset: DatasetMetadata) {
     setSelectedDataset(dataset);

--- a/data-explorer/src/app/explore/page.tsx
+++ b/data-explorer/src/app/explore/page.tsx
@@ -10,6 +10,7 @@ import { ResultsTable } from '@/components/ResultsTable';
 import { SmartResults } from '@/components/SmartResults';
 import { executeQuery, registerParquetTable } from '@/lib/duckdb';
 import { injectData, type Spec } from '@/lib/render/spec-utils';
+import { getR2BaseUrl } from '@/lib/r2';
 import { cn } from '@/lib/utils';
 import type { DatasetMetadata } from '@/types';
 
@@ -36,8 +37,7 @@ export default function ExplorePage() {
     explanation: string;
   } | null>(null);
 
-  const R2_BASE_URL =
-    process.env.NEXT_PUBLIC_R2_BASE_URL || 'https://your-r2-bucket.r2.dev';
+  const R2_BASE_URL = getR2BaseUrl();
 
   async function handleTableSelect(dataset: DatasetMetadata) {
     setSelectedDataset(dataset);

--- a/data-explorer/src/app/page.tsx
+++ b/data-explorer/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
+import { getR2BaseUrl } from '@/lib/r2';
 import type { ManifestData } from '@/types';
 
 const DISPLAY_FONT = 'var(--font-fraunces), Georgia, "Times New Roman", serif';
@@ -70,8 +71,7 @@ export default function HomePage() {
   const [featuresRef, featuresVisible] = useInView(0.1);
   const [ctaRef, ctaVisible] = useInView(0.2);
 
-  const R2_BASE_URL =
-    process.env.NEXT_PUBLIC_R2_BASE_URL || 'https://your-r2-bucket.r2.dev';
+  const R2_BASE_URL = getR2BaseUrl();
 
   useEffect(() => {
     async function loadStats() {

--- a/data-explorer/src/lib/r2.ts
+++ b/data-explorer/src/lib/r2.ts
@@ -1,0 +1,10 @@
+const DEFAULT_R2_BASE_URL =
+  'https://pub-b8c2f72ba51b4fe6804e9bb92280567c.r2.dev';
+
+export function getR2BaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_R2_URL ||
+    process.env.NEXT_PUBLIC_R2_BASE_URL ||
+    DEFAULT_R2_BASE_URL
+  );
+}


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- [x] Added a shared R2 URL resolver so Data Explorer consistently reads `NEXT_PUBLIC_R2_URL` first, then `NEXT_PUBLIC_R2_BASE_URL`, then a safe default.
- [x] Updated `/`, `/explore`, `/example`, and `/api/ask` to use the same resolver instead of placeholder URLs.
- [x] This prevents deploys from silently falling back to `https://your-r2-bucket.r2.dev` and breaking manifest loads.

## ✅ How to Do Self-Test
1. In Vercel project `landbruget-data-explorer`, set `NEXT_PUBLIC_R2_URL` (and optionally `NEXT_PUBLIC_R2_BASE_URL`) to the real R2 URL.
2. Deploy production and open `https://data.landbruget.dk/explore`.
3. Confirm `manifest.json` loads without CORS errors and dataset list appears.
4. Run `cd data-explorer && npm run build` locally.

## 📷 Screenshots (if applicable)
Not included.

## 📝 Additional Notes
This is a focused deployment-safety fix for Data Explorer config consistency.
