### PR TITLE
fix(ci): add missing R2 credentials to CHR silver-processing step

### DIFF
--- a/.github/workflows/chr_pipeline.yml
+++ b/.github/workflows/chr_pipeline.yml
@@ -1382,7 +1382,9 @@ jobs:
         working-directory: backend/pipelines/chr_pipeline
         env:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
-
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID || vars.R2_ACCOUNT_ID }}
           CHR_FORCE_STREAMING: "true"
           GITHUB_ACTIONS: "true"
         run: |


### PR DESCRIPTION
## 🛠️ Issue Fix
The CHR pipeline's silver-processing step was failing during streaming mode with "R2 credentials not configured" error. The step was missing three required R2 credential environment variables.

## 💡 Solution
Added `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `R2_ACCOUNT_ID` to the silver-processing step's `env:` block, matching the pattern used by all other steps in the workflow.

## ✅ How to Test
Trigger the CHR pipeline workflow with `step: silver_all` input and confirm the silver-processing job completes successfully.