### PR TITLE
chore: add gitignore rules to prevent large file commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,30 @@ backend/test_wfs.py
 pmtiles/
 *.pmtiles
 
+# DuckDB temp files (never commit these — can be GB in size)
+backend/.tmp/
+**/.tmp/
+*.tmp
+
+# Large static data files (store in GCS, not git)
+backend/src/sources/static/**/*.xlsx
+backend/pipelines/**/sample_*.xml
+backend/pipelines/**/wfs_capabilities.xml
+
+# Caching
+.pytest_cache/
+.ruff_cache/
+data_cache/
+
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# Data samples directory (contains large analysis files)
+data_samples/
+
 # Root level files that shouldn't be committed
 /Landbrugsstoette_2023.xlsx
 /Landbrugsvisum_statistik.pdf


### PR DESCRIPTION
## Summary

- Adds `backend/.tmp/` pattern to block DuckDB temp files (were ~2.3 GB in history)
- Adds `backend/src/sources/static/**/*.xlsx` to block large static data files
- Adds `backend/pipelines/**/wfs_capabilities.xml` and `sample_*.xml` patterns
- Adds `*.tmp` catch-all

## Context

This PR accompanies a git history rewrite that reduced the repo from **2.76 GB → 160 MB** (94% reduction) by removing accidentally committed large files:
- DuckDB temp storage files (~2.3 GB)
- PMTiles files (~210 MB, already gitignored but in history)
- Pesticide/fertilizer xlsx files (~330 MB)
- BBR buildings WFS sample XML (64 MB)
- Drive data pipeline PDFs and json files

These files belong in GCS (Bronze layer), not git history.

## Test plan
- [ ] Verify `backend/.tmp/` files are ignored locally
- [ ] Verify no large files can be accidentally staged