### PR TITLE
fix: resolve properties and bnbo-water stage failures

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/properties_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/properties_prefilter.py
@@ -30,8 +30,14 @@ class PropertiesPreFilter(PreFilteringStageBase):
         self._load_fields_for_filtering()
 
         # Load full properties dataset (PROBE side - the massive dataset)
+        # property_cadastral_merged is a gold layer dataset, not silver
         self.log.info("Loading full properties dataset (6.5M properties)...")
-        self._load_silver_dataset(CONFIG.properties_dataset, "properties_full")
+        pattern = f"gs://{CONFIG.bucket}/gold/{CONFIG.properties_dataset}/*/*.parquet"
+        files = self.gcs_access.list_files(pattern)
+        if not files:
+            raise FileNotFoundError(f"No gold data found for {CONFIG.properties_dataset}")
+        latest_path = sorted(files)[-1]
+        self.gcs_access.query_parquet_direct(latest_path, "SELECT *", "properties_full")
 
         # Log dataset sizes
         properties_count = self.conn.execute("SELECT COUNT(*) FROM properties_full").fetchone()[0]

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage2/fields_bnbo_water.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage2/fields_bnbo_water.py
@@ -124,7 +124,7 @@ class FieldsBNBOWaterCoverage(FieldAnalysisStageBase):
         self.log.info("📦 Step 2: Creating field_bnbo_water_intersections (3-way water-covered)")
         self.conn.execute("""
             CREATE OR REPLACE TABLE field_bnbo_water_intersections AS
-            SELECT 
+            SELECT
                 fbi.field_uuid,
                 fbi.field_id,
                 fbi.block_id,
@@ -135,9 +135,9 @@ class FieldsBNBOWaterCoverage(FieldAnalysisStageBase):
                 wpbi.project_id,
                 ST_Intersection(fbi.field_bnbo_geometry, wpbi.intersection_geometry) as field_bnbo_water_geometry
             FROM field_bnbo_intersections fbi
-            JOIN water_projects_bnbo_intersections wpbi 
-                ON fbi.bnbo_id = wpbi.bnbo_id  -- FIX: Ensure same BNBO to prevent cross-contamination
-                AND ST_Intersects(fbi.field_bnbo_geometry, wpbi.intersection_geometry)
+            JOIN water_projects_bnbo_intersections wpbi
+                ON ST_Intersects(fbi.field_bnbo_geometry, wpbi.intersection_geometry)
+            WHERE fbi.bnbo_id = wpbi.bnbo_id
         """)
 
         # Get result statistics


### PR DESCRIPTION
## Summary

- **properties_prefilter**: Fix `No silver data found for property_cadastral_merged` — load from gold layer instead of silver, since `PropertyCadastralMergeGold` saves to `gold/` not `silver/`
- **fields_bnbo_water (stage2)**: Fix DuckDB 1.5 `SPATIAL_JOIN` binding error — move `bnbo_id = wpbi.bnbo_id` from `JOIN ON` to `WHERE` clause (DuckDB 1.5 doesn't support mixing non-spatial equality with `ST_Intersects` in the same `ON` clause)

These failures were exposed by the `st_geomfromwkb` fix in #698 which allowed more stages to run. The original run had properties-prefilter skipped due to strategy cancellation.

## Test plan

- [ ] Triggered manual workflow run: https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/23153400887
- [ ] `stage0-properties-prefilter` should pass (gold path fix)
- [ ] `stage2-fields-bnbo-water` should pass (WHERE clause fix)
- [ ] All other passing stages continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)