### PR TITLE
fix: clean up stuck VMs before creating new one to free static IP

### DIFF
--- a/.github/workflows/property_owners_sftp_transfer_pipeline.yml
+++ b/.github/workflows/property_owners_sftp_transfer_pipeline.yml
@@ -29,6 +29,20 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
 
+    - name: Clean up any stuck VMs from previous runs
+      run: |
+        PROJECT_ID="landbrugsdata-1"
+        ZONE="europe-west1-b"
+        echo "Checking for stuck property-owners-pipeline VMs..."
+        STUCK_VMS=$(gcloud compute instances list --project=$PROJECT_ID --zones=$ZONE --filter="name~'property-owners-pipeline'" --format="value(name)" 2>/dev/null || true)
+        if [ -n "$STUCK_VMS" ]; then
+          echo "Found stuck VMs: $STUCK_VMS"
+          echo "$STUCK_VMS" | xargs -I{} gcloud compute instances delete {} --zone=$ZONE --project=$PROJECT_ID --quiet
+          echo "✅ Deleted stuck VMs"
+        else
+          echo "✅ No stuck VMs found"
+        fi
+
     - name: Create SFTP Transfer and Processing VM
       run: |
         # Generate unique VM name with timestamp


### PR DESCRIPTION
## Summary

- When a property-owners VM fails and doesn't self-delete, its static IP stays in use. The next run immediately crashes with `External IP address is already in-use` before even starting.
- Adds a cleanup step before VM creation that lists and deletes any lingering `property-owners-pipeline-*` VMs.

## Syntax verified

- `--filter="name~'property-owners-pipeline'"` — correct gcloud regex filter syntax
- `--zones=` (plural) for `instances list`, `--zone=` (singular) for `instances delete` — both correct
- `xargs -I{}` processes one VM per line, issuing a separate `delete` call each — correct for 0–N stuck VMs

## Test plan

- [ ] Trigger workflow manually — it should find and delete the stuck VM from the previous run, then create and complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)