### PR TITLE
fix: add missing dependencies to unified pipeline

### DIFF
--- a/backend/pipelines/unified_pipeline/pyproject.toml
+++ b/backend/pipelines/unified_pipeline/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "zeep>=4.3.1",
     "duckdb>=1.2.2",
     "beautifulsoup4>=4.13.4",
+    "google-cloud-secret-manager>=2.26.0",
+    "requests>=2.32.5",
 ]
 
 [build-system]


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes the `ImportError: cannot import name 'secretmanager' from 'google.cloud'` when running the agricultural_fields pipeline job.

## 💡 Solution
Added missing dependencies to `backend/pipelines/unified_pipeline/pyproject.toml`:
- `google-cloud-secret-manager>=2.26.0` (imported by pesticide_compliance module)
- `requests>=2.32.5` (already used by multiple modules)

The workflow installs dependencies via `pip install -e .` which reads only pyproject.toml, not the top-level backend/requirements.txt. These packages were missing from pyproject.toml despite being used in the codebase.

## ✅ How to Test
The pipeline will successfully import the required modules without ImportError.