### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/arbejdstilsynet_inspections_pipeline.yml
+++ b/.github/workflows/arbejdstilsynet_inspections_pipeline.yml
@@ -56,12 +56,12 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Set up environment variables
       working-directory: backend/pipelines/arbejdstilsynet_inspections
@@ -90,7 +90,7 @@ jobs:
         exit 1
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: pipeline-output

--- a/.github/workflows/bbr_buildings_pipeline.yml
+++ b/.github/workflows/bbr_buildings_pipeline.yml
@@ -58,7 +58,7 @@ jobs:
         echo "$BRONZE_TIMESTAMP" > /tmp/bronze_timestamp.txt
         
     - name: Upload bronze timestamp artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: bronze-timestamp
         path: /tmp/bronze_timestamp.txt
@@ -84,7 +84,7 @@ jobs:
     - uses: actions/checkout@v6
     
     - name: Download bronze timestamp artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: bronze-timestamp
         path: /tmp/
@@ -113,12 +113,12 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Set up environment variables
       env:
@@ -187,7 +187,7 @@ jobs:
     - uses: actions/checkout@v6
     
     - name: Download bronze timestamp artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: bronze-timestamp
         path: /tmp/
@@ -216,12 +216,12 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Set up environment variables
       env:
@@ -297,12 +297,12 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Set up environment variables
       env:
@@ -398,7 +398,7 @@ jobs:
         echo "✅ Silver layer processing completed!"
 
     - name: Upload Silver Pipeline Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: silver-pipeline-results

--- a/.github/workflows/bmd_monthly_pipeline.yml
+++ b/.github/workflows/bmd_monthly_pipeline.yml
@@ -54,13 +54,13 @@ jobs:
       - name: Authenticate to Google Cloud (Production only)
         id: auth
         if: env.ENVIRONMENT == 'production'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK (Production only)
         if: env.ENVIRONMENT == 'production'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Create data directories
         run: |
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload artifacts (Development only)
         if: env.ENVIRONMENT == 'development'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bmd-data
           path: |

--- a/.github/workflows/chr_pipeline.yml
+++ b/.github/workflows/chr_pipeline.yml
@@ -167,12 +167,12 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Set up environment variables
         env:
@@ -245,7 +245,7 @@ jobs:
           $CMD
 
       - name: Upload context artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chr-context-data
           path: /tmp/chr_context.json
@@ -259,7 +259,7 @@ jobs:
           echo "Bronze timestamp: $BRONZE_TIMESTAMP"
 
       - name: Upload bronze timestamp artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bronze-timestamp
           path: /tmp/bronze_timestamp.txt
@@ -267,7 +267,7 @@ jobs:
 
       - name: Upload bronze data summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bronze-foundation-logs
           path: |
@@ -315,21 +315,21 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-data
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -486,21 +486,21 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-data
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -645,21 +645,21 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-data
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -767,21 +767,21 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-data
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -849,7 +849,7 @@ jobs:
           $CMD
 
       - name: Upload updated context artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chr-context-with-details
           path: /tmp/chr_context_with_details.json
@@ -895,21 +895,21 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Download context artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: chr-context-with-details
           path: /tmp/
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -1055,15 +1055,15 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Download bronze timestamp artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bronze-timestamp
           path: /tmp/
@@ -1125,12 +1125,12 @@ jobs:
 
       - id: 'auth-silver'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Run silver processing (Streaming Mode)
         working-directory: backend/pipelines/chr_pipeline
@@ -1202,12 +1202,12 @@ jobs:
 
       - id: 'auth-gold'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Set up environment variables
         env:
@@ -1257,7 +1257,7 @@ jobs:
           fi
 
       - name: Download bronze timestamp artifact (if available)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: bronze-timestamp
@@ -1397,12 +1397,12 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Set up environment variables
         env:

--- a/.github/workflows/cvr_enrichment_pipeline.yml
+++ b/.github/workflows/cvr_enrichment_pipeline.yml
@@ -58,12 +58,12 @@ jobs:
           pip install -e .
       
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: Run CVR Collection
         id: collection
@@ -94,7 +94,7 @@ jobs:
           echo "success=true" >> $GITHUB_OUTPUT
 
       - name: Upload CVR Collection Data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-collection-data
           path: /tmp/cvr_collection_data.parquet
@@ -122,15 +122,15 @@ jobs:
           pip install -e .
       
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: Download CVR Collection Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-collection-data
           path: /tmp/
@@ -161,7 +161,7 @@ jobs:
           echo "✅ Company Fetching completed successfully"
 
       - name: Upload Company Data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-company-data
           path: /tmp/cvr_company_data.parquet
@@ -189,15 +189,15 @@ jobs:
           pip install -e .
       
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: Download Company Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-company-data
           path: /tmp/
@@ -219,7 +219,7 @@ jobs:
           $CMD
 
       - name: Upload P-Number Data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-pnumber-data
           path: /tmp/cvr_pnumber_data.parquet
@@ -247,15 +247,15 @@ jobs:
           pip install -e .
       
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: Download Company Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-company-data
           path: /tmp/
@@ -290,7 +290,7 @@ jobs:
           fi
       
       - name: Upload Financial Data Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-financial-data
           path: /tmp/cvr_financial_data.parquet
@@ -320,21 +320,21 @@ jobs:
           pip install -e .
       
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: Download Company and P-Number Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-company-data
           path: /tmp/
       
       - name: Download P-Number Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-pnumber-data
           path: /tmp/
@@ -366,7 +366,7 @@ jobs:
           fi
       
       - name: Upload Address Data Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cvr-address-data
           path: /tmp/cvr_address_data.parquet
@@ -396,34 +396,34 @@ jobs:
           pip install -e .
       
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: Download Company Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-company-data
           path: /tmp/
       
       - name: Download P-Number Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-pnumber-data
           path: /tmp/
       
       - name: Download Financial Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-financial-data
           path: /tmp/
         continue-on-error: true  # Don't fail if financial data not available
       
       - name: Download Address Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvr-address-data
           path: /tmp/

--- a/.github/workflows/dma_pipeline.yml
+++ b/.github/workflows/dma_pipeline.yml
@@ -53,12 +53,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.PROJECT_ID }}
 

--- a/.github/workflows/drive_pipeline.yml
+++ b/.github/workflows/drive_pipeline.yml
@@ -81,12 +81,12 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Set up environment variables
       env:
@@ -243,12 +243,12 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Set up environment variables
       env:
@@ -341,12 +341,12 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Set up environment variables
       env:

--- a/.github/workflows/field_area_analysis_multi_stage.yml
+++ b/.github/workflows/field_area_analysis_multi_stage.yml
@@ -68,7 +68,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -107,7 +107,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -146,7 +146,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -185,7 +185,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -224,7 +224,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -265,7 +265,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -305,7 +305,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -366,7 +366,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -412,7 +412,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -453,7 +453,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -493,7 +493,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -534,7 +534,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -574,7 +574,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -615,7 +615,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -655,7 +655,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -696,7 +696,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -743,7 +743,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Consolidate Results (Independent)

--- a/.github/workflows/fvm_wfs_matrix_download.yml
+++ b/.github/workflows/fvm_wfs_matrix_download.yml
@@ -170,12 +170,12 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Process FVM WFS Layer
         run: |
@@ -230,12 +230,12 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Run Field Enrichment for ${{ matrix.year }}
         run: |

--- a/.github/workflows/h3-pfas-analysis.yml
+++ b/.github/workflows/h3-pfas-analysis.yml
@@ -139,12 +139,12 @@ jobs:
           python-version: '3.11'
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml') }}
@@ -196,12 +196,12 @@ jobs:
           uv pip install --system -e ".[production]"
       
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: Verify GCS access
         run: |
@@ -283,7 +283,7 @@ jobs:
       
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-year${{ matrix.year }}-${{ github.run_id }}
           path: |
@@ -338,7 +338,7 @@ jobs:
           cat artifacts/summary_${{ matrix.year }}.json
 
       - name: Upload output paths as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: output-paths-year${{ matrix.year }}
           path: artifacts/
@@ -362,7 +362,7 @@ jobs:
           python-version: '3.11'
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       
@@ -407,15 +407,15 @@ jobs:
           uv pip install --system -e ".[production]"
       
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: Download output path artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: output-paths-year*
           path: downloaded-artifacts/
@@ -497,13 +497,13 @@ jobs:
       
       - name: Authenticate to Google Cloud
         if: needs.h3-pfas-analysis.result == 'success'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       
       - name: Set up Cloud SDK
         if: needs.h3-pfas-analysis.result == 'success'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       
       - name: List final outputs
         if: needs.h3-pfas-analysis.result == 'success' && needs.cumulative-analysis.result == 'success'

--- a/.github/workflows/parquet_to_supabase_migration.yml
+++ b/.github/workflows/parquet_to_supabase_migration.yml
@@ -179,12 +179,12 @@ jobs:
         pip install pandas duckdb psycopg2-binary psutil asyncio
         
     - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v3
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
         
     - name: Setup Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v3
       
     - name: Run Data Migration Phase
       env:
@@ -221,7 +221,7 @@ jobs:
         cp logs/migration/migration_${{ github.event.inputs.environment }}_*.log migration_artifacts/ || true
         
     - name: Upload Migration Logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: migration-logs-${{ matrix.phase }}-${{ needs.pre_migration_checks.outputs.migration_id }}
@@ -321,7 +321,7 @@ jobs:
         fi
         
     - name: Upload Validation Reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: validation-reports-${{ needs.pre_migration_checks.outputs.migration_id }}
@@ -416,7 +416,7 @@ jobs:
         cat migration_summary.md
         
     - name: Comment on PR (if applicable)
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       if: github.event.pull_request
       with:
         script: |

--- a/.github/workflows/pesticide_disaggregation_matrix.yml
+++ b/.github/workflows/pesticide_disaggregation_matrix.yml
@@ -52,7 +52,7 @@ jobs:
         pip install -e .
 
     - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -213,7 +213,7 @@ jobs:
         pip install -e .
 
     - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
 

--- a/.github/workflows/property_owners_sftp_transfer_pipeline.yml
+++ b/.github/workflows/property_owners_sftp_transfer_pipeline.yml
@@ -22,12 +22,12 @@ jobs:
 
     - name: Authenticate to Google Cloud
       id: auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
 
     - name: Clean up any stuck VMs from previous runs
       run: |

--- a/.github/workflows/run_field_uuid_migration.yml
+++ b/.github/workflows/run_field_uuid_migration.yml
@@ -36,7 +36,7 @@ jobs:
         run: source .venv/bin/activate && uv pip install -r backend/requirements.txt
 
       - name: Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 

--- a/.github/workflows/svineflytning_pipeline.yml
+++ b/.github/workflows/svineflytning_pipeline.yml
@@ -89,12 +89,12 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: 'Set up environment variables'
       env:
@@ -183,7 +183,7 @@ jobs:
         exit 1
 
     - name: Upload bronze artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()  # Upload even if the pipeline fails
       with:
         name: bronze-output
@@ -191,7 +191,7 @@ jobs:
         retention-days: 7
         
     - name: Upload silver artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()  # Upload even if the pipeline fails
       with:
         name: silver-output

--- a/.github/workflows/unified_pipeline.yml
+++ b/.github/workflows/unified_pipeline.yml
@@ -129,7 +129,7 @@ jobs:
           pip install -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -286,7 +286,7 @@ jobs:
           uv pip install --system -e .
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 


### PR DESCRIPTION
## 🛠️ Issue Fix
Addresses GitHub Actions Node.js 20 deprecation warnings. Node.js 24 becomes the default June 2nd, 2026.

## 💡 Solution
Updated all GitHub Actions to latest versions:
- `actions/cache`: v4 → v5
- `actions/upload-artifact`: v3/v4 → v7
- `actions/download-artifact`: v4 → v8
- `actions/github-script`: v6 → v8
- `astral-sh/setup-uv`: v3 → v7
- `google-github-actions/auth`: v1/v2 → v3
- `google-github-actions/setup-gcloud`: v1/v2 → v3

Applied to all 17 workflow files (16 with changes).

## ✅ How to Do Self-Test
GitHub Actions will automatically use these versions on next workflow run.