### PR TITLE
Restore pre-commit hooks and ruff configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  # Backend: Python linting and formatting via ruff
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^backend/
+      - id: ruff-format
+        files: ^backend/
+
+  # Frontend: JS/TS linting via oxlint
+  - repo: local
+    hooks:
+      - id: oxlint
+        name: oxlint
+        language: node
+        entry: ./frontend/node_modules/.bin/oxlint
+        args: [--deny-warnings]
+        files: ^frontend/src/.*\.(ts|tsx|js|jsx)$
+        pass_filenames: false
+        additional_dependencies: []
+
+      - id: oxfmt
+        name: oxfmt
+        language: node
+        entry: ./frontend/node_modules/.bin/oxfmt
+        args: [--write, frontend/src/]
+        files: ^frontend/src/.*\.(ts|tsx|js|jsx)$
+        pass_filenames: false
+        additional_dependencies: []

--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      # Run the linter
+      - id: ruff
+        args: [--fix]
+      # Run the formatter
+      - id: ruff-format 

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,0 +1,18 @@
+[lint]
+# Select basic, non-controversial rules
+select = [
+    "F",   # Pyflakes (undefined names, unused imports)
+    "E9",  # Syntax errors
+    "W6",  # PEP 8 warnings that are clearly wrong
+]
+
+# Ignore rules that are too strict for legacy code
+ignore = [
+    "E501",  # Line too long (let formatter handle this)
+]
+
+[format]
+# Use Black-compatible formatting
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"


### PR DESCRIPTION
## 🛠️ Issue Fix
Restores pre-commit configuration that was previously deleted from the repository.

## 💡 Solution
- Restored `backend/.pre-commit-config.yaml` with ruff linter and formatter hooks
- Restored `backend/ruff.toml` with lint and format configuration
- Added root-level `.pre-commit-config.yaml` that covers both:
  - Backend Python files: ruff lint + format (v0.8.4)
  - Frontend TypeScript/JavaScript files: oxlint lint + oxfmt formatter

The frontend tooling integrates with existing npm scripts (`npm run lint` and `npm run fmt`).

## ✅ How to Do Self-Test
```bash
# Install pre-commit hooks
pre-commit install

# Run hooks on staged files (git commit will also run them)
pre-commit run --all-files
```

## 📝 Additional Notes
The oxlint/oxfmt hooks use local Node.js binaries already installed in frontend dependencies.