### PR TITLE
fix(pipelines): use R2_BUCKET across all pipelines

### DIFF
--- a/backend/pipelines/arbejdstilsynet_inspections/main.py
+++ b/backend/pipelines/arbejdstilsynet_inspections/main.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # Determine GCS bucket to use
     actual_gcs_bucket = args.gcs_bucket
     if not actual_gcs_bucket:
-        actual_gcs_bucket = os.getenv("GCS_BUCKET")
+        actual_gcs_bucket = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")
         if actual_gcs_bucket:
             logger.info(f"Using GCS_BUCKET from environment variable: {actual_gcs_bucket}")
         else:

--- a/backend/pipelines/bbr_buildings/config/settings.py
+++ b/backend/pipelines/bbr_buildings/config/settings.py
@@ -49,7 +49,7 @@ class Settings:
         )
 
         # Google Cloud Storage
-        self.gcs_bucket = os.getenv("GCS_BUCKET", "landbruget-data")
+        self.gcs_bucket = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
         self.gcs_credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 
         # Output directories

--- a/backend/pipelines/bbr_buildings/main.py
+++ b/backend/pipelines/bbr_buildings/main.py
@@ -984,7 +984,7 @@ def _upload_bronze_data_to_gcs(
 
     try:
         gcs_access = GCSDataAccess()
-        bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+        bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
 
         # Upload building IDs as JSON
         building_ids_path = (
@@ -1031,9 +1031,9 @@ def _load_latest_inspire_bronze_data_from_gcs(logger: logging.Logger) -> tuple[l
         logger.error("❌ GCS not available - cannot load bronze data")
         return [], None
 
-    bucket_name = os.getenv("GCS_BUCKET")
+    bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")
     if not bucket_name:
-        logger.error("❌ GCS_BUCKET not set - cannot load bronze data")
+        logger.error("❌ R2_BUCKET/GCS_BUCKET not set - cannot load bronze data")
         return [], None
 
     try:
@@ -1099,7 +1099,7 @@ def _load_geodanmark_data_from_gcs(logger: logging.Logger, timestamp: str | None
 
     try:
         gcs_access = GCSDataAccess()
-        bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+        bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
 
         # Determine which timestamp to use
         if timestamp:
@@ -1374,7 +1374,7 @@ def _load_bronze_data_from_gcs(
 
     try:
         gcs_access = GCSDataAccess()
-        bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+        bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
 
         # Load building IDs from INSPIRE subdirectory
         building_ids_path = (
@@ -1414,7 +1414,7 @@ def _upload_silver_data_to_gcs(
 
     try:
         gcs_access = GCSDataAccess()
-        bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+        bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
 
         # Upload processed files (with coordinate fixes) if available
         processed_dir = silver_output_dir / "processed"

--- a/backend/pipelines/bmd_scraper/main.py
+++ b/backend/pipelines/bmd_scraper/main.py
@@ -74,7 +74,7 @@ def run_bronze_stage(bronze_dir: Path) -> Path | None:
 
         # If in production environment, upload to GCS
         if os.getenv("ENVIRONMENT") == "production":
-            bucket_name = os.getenv("GCS_BUCKET")
+            bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")
             if bucket_name:
                 logger.info(f"Uploading bronze data to GCS bucket {bucket_name}")
                 storage = GCSStorage(bucket_name=bucket_name)
@@ -171,7 +171,7 @@ def run_silver_stage(bronze_file: Path, silver_dir: Path) -> Path | None:
 
         # If in production environment, upload to GCS
         if os.getenv("ENVIRONMENT") == "production":
-            bucket_name = os.getenv("GCS_BUCKET")
+            bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")
             if bucket_name:
                 logger.info(f"Uploading silver data to GCS bucket {bucket_name}")
                 success = upload_to_gcs(parquet_file, bucket_name)

--- a/backend/pipelines/chr_pipeline/bronze/export.py
+++ b/backend/pipelines/chr_pipeline/bronze/export.py
@@ -39,7 +39,7 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 # Initialize storage paths and clients
-GCS_BUCKET = os.getenv("GCS_BUCKET")
+GCS_BUCKET = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")
 GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 LOCAL_DATA_PATH = os.getenv(
     "LOCAL_DATA_PATH", "/tmp/data"

--- a/backend/pipelines/chr_pipeline/bronze/herd_discovery.py
+++ b/backend/pipelines/chr_pipeline/bronze/herd_discovery.py
@@ -309,7 +309,7 @@ def save_discovery_results(
             import os
 
             gcs_data_access = GCSDataAccess()
-            bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+            bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
             config_path = f"gs://{bucket_name}/bronze/chr/config/discovery_results_{year}.json"
 
             gcs_data_access.upload_json(discovery_data, config_path)
@@ -342,7 +342,7 @@ def load_previous_discovery_results(year: int) -> tuple[list[dict], list[int]] |
             import os
 
             gcs_data_access = GCSDataAccess()
-            bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+            bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
             config_path = f"gs://{bucket_name}/bronze/chr/config/discovery_results_{year}.json"
 
             if gcs_data_access.file_exists(config_path):

--- a/backend/pipelines/chr_pipeline/bronze/load_chr_dyr.py
+++ b/backend/pipelines/chr_pipeline/bronze/load_chr_dyr.py
@@ -169,7 +169,7 @@ def finalize_consolidated_processing():
 
         from .export import EXPORT_TIMESTAMP
 
-        bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+        bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
 
         # Add month suffix if matrix job (environment variable set by GitHub Actions)
         month_suffix = os.getenv("BRONZE_MONTH_SUFFIX", "")

--- a/backend/pipelines/chr_pipeline/bronze/persistence.py
+++ b/backend/pipelines/chr_pipeline/bronze/persistence.py
@@ -36,7 +36,7 @@ def _load_problematic_herds() -> None:
     if GCS_AVAILABLE:
         try:
             gcs = GCSDataAccess()
-            bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+            bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
             problematic_herds_path = "bronze/chr/problematic_herds.json"
             gcs_path = f"gs://{bucket_name}/{problematic_herds_path}"
 
@@ -67,7 +67,7 @@ def _save_problematic_herds() -> None:
     if GCS_AVAILABLE:
         try:
             gcs = GCSDataAccess()
-            bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+            bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
             problematic_herds_path = "bronze/chr/problematic_herds.json"
             gcs_path = f"gs://{bucket_name}/{problematic_herds_path}"
 

--- a/backend/pipelines/chr_pipeline/bronze/volume_management.py
+++ b/backend/pipelines/chr_pipeline/bronze/volume_management.py
@@ -38,7 +38,7 @@ def _load_high_volume_herds() -> None:
     if GCS_AVAILABLE:
         try:
             gcs_data_access = GCSDataAccess()
-            bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+            bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
             config_path = f"gs://{bucket_name}/bronze/chr/config/high_volume_herds.json"
 
             if gcs_data_access.file_exists(config_path):
@@ -94,7 +94,7 @@ def _save_high_volume_herds() -> None:
     if GCS_AVAILABLE:
         try:
             gcs_data_access = GCSDataAccess()
-            bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+            bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
             config_path = f"gs://{bucket_name}/bronze/chr/config/high_volume_herds.json"
 
             gcs_data_access.upload_json(_HIGH_VOLUME_HERDS, config_path)

--- a/backend/pipelines/chr_pipeline/silver/chr_silver_processing.py
+++ b/backend/pipelines/chr_pipeline/silver/chr_silver_processing.py
@@ -68,7 +68,7 @@ def download_bronze_data_from_gcs(bronze_dir_override: str, local_bronze_dir: Pa
         logging.error("GCS utilities not available - cannot download bronze data")
         return False
 
-    bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+    bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
     if not bucket_name:
         logging.error("GCS_BUCKET not set - cannot download bronze data")
         return False
@@ -280,7 +280,7 @@ def process_chr_data_streaming(
         logging.info(f"Using bronze timestamp as export timestamp: {export_timestamp}")
 
     # Get GCS bucket from environment
-    bucket_name = os.getenv("GCS_BUCKET", "landbruget-data")
+    bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
     if not bucket_name:
         logging.error("GCS_BUCKET environment variable not set")
         return False

--- a/backend/pipelines/chr_pipeline/silver/export.py
+++ b/backend/pipelines/chr_pipeline/silver/export.py
@@ -138,7 +138,7 @@ def upload_silver_data_to_gcs(silver_dir: Path, export_timestamp: str) -> bool:
         logging.warning("GCS utilities not available - skipping silver data upload")
         return False
 
-    bucket_name = os.getenv("GCS_BUCKET")
+    bucket_name = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")
     if not bucket_name:
         logging.warning("GCS_BUCKET not set - skipping silver data upload")
         return False

--- a/backend/pipelines/climate/data_loader.py
+++ b/backend/pipelines/climate/data_loader.py
@@ -51,7 +51,7 @@ class ClimateDataLoader:
         Args:
             bucket: GCS bucket name. Defaults to GCS_BUCKET env var or 'landbruget-data'
         """
-        self.bucket = bucket or os.getenv("GCS_BUCKET", "landbruget-data")
+        self.bucket = bucket or os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
         self.gcs = GCSDataAccess()
         logger.info(f"ClimateDataLoader initialized with bucket: {self.bucket}")
 

--- a/backend/pipelines/climate/output_writer.py
+++ b/backend/pipelines/climate/output_writer.py
@@ -50,7 +50,7 @@ class ClimateOutputWriter:
         Args:
             bucket: GCS bucket name. Defaults to GCS_BUCKET env var or 'landbruget-data'
         """
-        self.bucket = bucket or os.getenv("GCS_BUCKET", "landbruget-data")
+        self.bucket = bucket or os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data")
         self.gcs = GCSDataAccess()
         self._duckdb_conn = duckdb.connect()
         logger.info(f"ClimateOutputWriter initialized with bucket: {self.bucket}")

--- a/backend/pipelines/dma_scraper/main.py
+++ b/backend/pipelines/dma_scraper/main.py
@@ -218,7 +218,9 @@ PREFIX_SILVER_SAVE_PATH = os.environ.get("SILVER_OUTPUT_DIR", "silver/dma")
 # Initialize storage backend based on environment
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "development")
 if ENVIRONMENT.lower() in ("production", "container"):
-    storage_backend = OptimizedStorageBackend(os.environ.get("GCS_BUCKET", "landbruget-data"))
+    storage_backend = OptimizedStorageBackend(
+        os.environ.get("R2_BUCKET") or os.environ.get("GCS_BUCKET", "landbruget-data")
+    )
 else:
     storage_backend = LocalStorageBackend(os.environ.get("BRONZE_OUTPUT_DIR", "."))
 

--- a/backend/pipelines/h3_pfas_exposure_pipeline/src/h3_pfas_exposure/config/settings.py
+++ b/backend/pipelines/h3_pfas_exposure_pipeline/src/h3_pfas_exposure/config/settings.py
@@ -88,7 +88,7 @@ class H3PFASConfig:
             chunk_size=int(os.getenv("CHUNK_SIZE", "25000")),
             memory_limit="12GB",  # Always use 12GB - no env dependency
             thread_count=int(os.getenv("THREAD_COUNT", "4")),
-            bucket=os.getenv("GCS_BUCKET", "landbruget-data"),
+            bucket=os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET", "landbruget-data"),
             enable_progress_tracking=os.getenv("ENABLE_PROGRESS_TRACKING", "true").lower()
             == "true",
             log_chunk_details=os.getenv("LOG_CHUNK_DETAILS", "false").lower() == "true",

--- a/backend/pipelines/svineflytning_pipeline/bronze/export.py
+++ b/backend/pipelines/svineflytning_pipeline/bronze/export.py
@@ -41,7 +41,7 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 # Initialize storage paths and clients
-GCS_BUCKET = os.getenv("GCS_BUCKET")
+GCS_BUCKET = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")
 GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 
 # Use GCS if we have the required configuration


### PR DESCRIPTION
## Summary
- CI sets `R2_BUCKET`, not `GCS_BUCKET`, but most pipelines only checked `GCS_BUCKET`
- This caused silent upload/download failures across multiple pipelines in CI
- All 16 affected files now consistently use `R2_BUCKET → GCS_BUCKET → default` pattern

## Affected pipelines
- `bbr_buildings` (main.py + config/settings.py)
- `chr_pipeline` (bronze/export, bronze/herd_discovery, bronze/load_chr_dyr, bronze/persistence, bronze/volume_management, silver/chr_silver_processing, silver/export)
- `bmd_scraper`
- `arbejdstilsynet_inspections`
- `dma_scraper`
- `svineflytning_pipeline` (bronze/export)
- `climate` (data_loader, output_writer)
- `h3_pfas_exposure_pipeline`

## Test plan
- [ ] Re-run BBR Buildings Pipeline (full) — verify silver layer can read bronze data from R2
- [ ] Spot-check CHR pipeline workflow passes
- [ ] Verify no regressions in unified_pipeline (already had correct pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)