### PR TITLE
fix(bbr-buildings): force VARCHAR types to prevent schema conflicts during combine

### DIFF
--- a/backend/pipelines/bbr_buildings/bronze/bulk_geodanmark_graphql_fetcher.py
+++ b/backend/pipelines/bbr_buildings/bronze/bulk_geodanmark_graphql_fetcher.py
@@ -56,6 +56,31 @@ BUILDING_FIELDS = """
 # Max page size allowed by Datafordeleren GraphQL API
 MAX_PAGE_SIZE = 1000
 
+# Explicit column types for read_json — prevents type inference variability
+# across pages/batches (e.g. BBRaktion inferred as VARCHAR vs JSON, or
+# registreringTil as TIMESTAMP vs VARCHAR depending on first record seen).
+BUILDING_COLUMNS = {
+    "id_lokalId": "VARCHAR",
+    "BBRUUID": "VARCHAR",
+    "bygningstype": "VARCHAR",
+    "status": "VARCHAR",
+    "geometristatus": "VARCHAR",
+    "BBRaktion": "VARCHAR",
+    "maalestedBygning": "VARCHAR",
+    "metode3D": "VARCHAR",
+    "overlapBygning": "VARCHAR",
+    "synligBygning": "VARCHAR",
+    "underMinimumBygning": "VARCHAR",
+    "dataansvar": "VARCHAR",
+    "registreringFra": "VARCHAR",
+    "registreringTil": "VARCHAR",
+    "virkningFra": "VARCHAR",
+    "geometri_wkt": "VARCHAR",
+}
+
+# Column list for explicit SELECT during combine (cast everything to VARCHAR)
+_COMBINE_COLUMNS = [c for c in BUILDING_COLUMNS if c != "geometri_wkt"]
+
 
 class BulkGeoDanmarkGraphQLFetcher:
     def __init__(self, api_key: str) -> None:
@@ -161,12 +186,13 @@ class BulkGeoDanmarkGraphQLFetcher:
             for rec in records:
                 tmp.write(_json.dumps(rec) + "\n")
 
+        col_spec = ", ".join(f"'{k}': '{v}'" for k, v in BUILDING_COLUMNS.items())
         self.conn.execute(f"""
             CREATE TABLE {table_name} AS
             SELECT
                 * EXCLUDE (geometri_wkt),
                 TRY(ST_GeomFromText(geometri_wkt)) AS geometri
-            FROM read_json_auto('{tmp_path}')
+            FROM read_json('{tmp_path}', columns={{{col_spec}}})
         """)
 
         Path(tmp_path).unlink(missing_ok=True)
@@ -350,19 +376,35 @@ class BulkGeoDanmarkGraphQLFetcher:
 
         logger.info(f"Combining {len(valid_files)} valid intermediate files")
 
-        file_list = "', '".join(valid_files)
-
         try:
-            # Handle potential schema mismatches with union_by_name
+            # Read each file individually, casting all text columns to VARCHAR
+            # to resolve type conflicts (e.g. BBRaktion stored as JSON in some
+            # files and VARCHAR in others — DuckDB's read_parquet union_by_name
+            # cannot reconcile these).
+            union_parts = []
+            for i, f in enumerate(valid_files):
+                cols = self.conn.execute(
+                    f"SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet('{f}'))"
+                ).fetchall()
+                select_parts = []
+                for col_name, col_type in cols:
+                    if col_name in _COMBINE_COLUMNS and col_type != "VARCHAR":
+                        select_parts.append(f'TRY_CAST("{col_name}" AS VARCHAR) AS "{col_name}"')
+                    else:
+                        select_parts.append(f'"{col_name}"')
+                select_clause = ", ".join(select_parts)
+                union_parts.append(f"SELECT {select_clause} FROM read_parquet('{f}')")
+
+            union_query = " UNION ALL ".join(union_parts)
+
             self.conn.execute(f"""
-                COPY (
-                    SELECT * FROM read_parquet(['{file_list}'], union_by_name=true)
-                ) TO '{self.output_dir}/geodanmark_buildings_complete.geoparquet'
+                COPY ({union_query})
+                TO '{self.output_dir}/geodanmark_buildings_complete.geoparquet'
                 (FORMAT PARQUET)
             """)
 
             count = self.conn.execute(
-                f"SELECT COUNT(*) FROM read_parquet(['{file_list}'], union_by_name=true)"
+                f"SELECT COUNT(*) FROM read_parquet('{self.output_dir}/geodanmark_buildings_complete.geoparquet')"
             ).fetchone()[0]
 
             logger.info(

--- a/backend/pipelines/bbr_buildings/tests/test_graphql_fetcher.py
+++ b/backend/pipelines/bbr_buildings/tests/test_graphql_fetcher.py
@@ -151,3 +151,94 @@ class TestSaveIntermediateResults:
 
         # Restore real conn so __del__ doesn't error
         fetcher.conn = original_conn
+
+
+class TestSchemaConsistency:
+    """Reproduce schema mismatch bugs that crash the pipeline after hours of fetching."""
+
+    def test_combine_with_varchar_vs_json_column(self, fetcher):
+        """BBRaktion as VARCHAR in one file and JSON in another should not crash."""
+        # Batch 0: BBRaktion is a plain string → VARCHAR
+        fetcher.conn.execute(f"""
+            COPY (
+                SELECT 1 AS id_lokalId, 'Mangler afklaring' AS BBRaktion
+            ) TO '{fetcher.output_dir}/geodanmark_buildings_batch_0000.geoparquet' (FORMAT PARQUET)
+        """)
+        # Batch 1: BBRaktion is JSON
+        fetcher.conn.execute(f"""
+            COPY (
+                SELECT 2 AS id_lokalId, '{{"aktion": "value"}}'::JSON AS BBRaktion
+            ) TO '{fetcher.output_dir}/geodanmark_buildings_batch_0001.geoparquet' (FORMAT PARQUET)
+        """)
+
+        fetcher._combine_intermediate_files()
+
+        result = fetcher.conn.execute(
+            f"SELECT COUNT(*) FROM read_parquet('{fetcher.output_dir}/geodanmark_buildings_complete.geoparquet')"
+        ).fetchone()[0]
+        assert result == 2
+
+    def test_combine_with_timestamp_vs_varchar_column(self, fetcher):
+        """registreringTil as TIMESTAMP in one file and VARCHAR in another should not crash."""
+        # Batch 0: registreringTil is TIMESTAMP
+        fetcher.conn.execute(f"""
+            COPY (
+                SELECT 1 AS id_lokalId, TIMESTAMP '2026-03-20 13:15:15' AS registreringTil
+            ) TO '{fetcher.output_dir}/geodanmark_buildings_batch_0000.geoparquet' (FORMAT PARQUET)
+        """)
+        # Batch 1: registreringTil is VARCHAR
+        fetcher.conn.execute(f"""
+            COPY (
+                SELECT 2 AS id_lokalId, '2026-03-20T13:15:15.195000Z' AS registreringTil
+            ) TO '{fetcher.output_dir}/geodanmark_buildings_batch_0001.geoparquet' (FORMAT PARQUET)
+        """)
+
+        fetcher._combine_intermediate_files()
+
+        result = fetcher.conn.execute(
+            f"SELECT COUNT(*) FROM read_parquet('{fetcher.output_dir}/geodanmark_buildings_complete.geoparquet')"
+        ).fetchone()[0]
+        assert result == 2
+
+    def test_nodes_to_duckdb_forces_varchar_types(self, fetcher):
+        """All columns from _nodes_to_duckdb_table should be VARCHAR (not auto-inferred)."""
+        nodes = [
+            {
+                "id_lokalId": "abc-123",
+                "BBRUUID": None,
+                "bygningstype": "Bygning",
+                "status": None,
+                "geometristatus": None,
+                "BBRaktion": "Mangler afklaring",
+                "maalestedBygning": None,
+                "metode3D": None,
+                "overlapBygning": None,
+                "synligBygning": None,
+                "underMinimumBygning": None,
+                "dataansvar": None,
+                "registreringFra": "2026-03-20T13:15:15.195000Z",
+                "registreringTil": None,
+                "virkningFra": "2026-03-20T13:15:15.195000Z",
+                "geometri": {
+                    "wkt": "POLYGON Z((550000 6200000 0, 550010 6200000 0, 550010 6200010 0, 550000 6200010 0, 550000 6200000 0))"
+                },
+            }
+        ]
+
+        fetcher._nodes_to_duckdb_table(nodes, "test_page")
+
+        # Check column types — all should be VARCHAR except geometri (GEOMETRY)
+        columns = fetcher.conn.execute(
+            "SELECT column_name, column_type FROM (DESCRIBE test_page)"
+        ).fetchall()
+        col_types = {name: dtype for name, dtype in columns}
+
+        for col in [
+            "id_lokalId",
+            "BBRUUID",
+            "BBRaktion",
+            "registreringFra",
+            "registreringTil",
+            "virkningFra",
+        ]:
+            assert col_types[col] == "VARCHAR", f"{col} should be VARCHAR, got {col_types[col]}"


### PR DESCRIPTION
## 🛠️ Issue Fix
After ~4 hours of fetching ~6M buildings via GraphQL, the pipeline crashes at the final combine step due to DuckDB type inference inconsistencies across batch files.

Two distinct failures:
1. **Batch save failures** (batches 597, 598): `registreringTil` inferred as TIMESTAMP in some pages but VARCHAR in others within the same batch
2. **Combine failure** (fatal): `BBRaktion` inferred as JSON in some batch files but VARCHAR in others — `union_by_name=true` cannot reconcile these

## 💡 Solution
- [x] Add `BUILDING_COLUMNS` dict with explicit VARCHAR types for all text fields
- [x] Replace `read_json_auto()` with `read_json(columns=...)` in `_nodes_to_duckdb_table` — eliminates type inference variability at the source
- [x] In `_combine_intermediate_files`, read each batch file individually, inspect its schema, and `TRY_CAST` any non-VARCHAR text columns before `UNION ALL` — handles both new and pre-existing batch files with mixed types
- [x] Add 3 regression tests reproducing VARCHAR-vs-JSON, TIMESTAMP-vs-VARCHAR, and type enforcement scenarios

## ✅ How to Self-Test
```bash
cd backend && source venv/bin/activate
cd pipelines/bbr_buildings && pytest tests/test_graphql_fetcher.py -v
```
All 10 tests pass (including 3 new schema consistency tests that reproduce the exact failures from the CI run).

## 📝 Additional Notes
Root cause: `read_json_auto()` makes independent type decisions per page based on the first records it sees. Null-heavy pages or varying value formats cause different type assignments for the same column. Type coercion belongs in the silver layer — bronze should store everything as VARCHAR.