### PR TITLE
fix(pipeline): handle DuckDB 1.5 GeoParquet geometry types in field area analysis

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/bnbo_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/bnbo_prefilter.py
@@ -54,21 +54,67 @@ class BNBOPreFilter(PreFilteringStageBase):
         # COORDINATE VALIDATION: Check coordinate bounds to ensure proper lon/lat order
         self.log.info("🌍 Validating BNBO coordinate bounds and order...")
 
-        # Coordinate validation: geometry is stored as WKB (BLOB) in parquet files
+        # Since geometry may be GEOMETRY('OGC:CRS84') from GeoParquet, use direct approach first
         try:
             coord_validation = self.conn.execute("""
                 SELECT
-                    MIN(ST_XMin(ST_GeomFromWKB(geometry))) as min_x,
-                    MAX(ST_XMax(ST_GeomFromWKB(geometry))) as max_x,
-                    MIN(ST_YMin(ST_GeomFromWKB(geometry))) as min_y,
-                    MAX(ST_YMax(ST_GeomFromWKB(geometry))) as max_y
+                    MIN(ST_XMin(geometry)) as min_x,
+                    MAX(ST_XMax(geometry)) as max_x,
+                    MIN(ST_YMin(geometry)) as min_y,
+                    MAX(ST_YMax(geometry)) as max_y
                 FROM bnbo_status_raw
                 WHERE geometry IS NOT NULL
                 LIMIT 1000
             """).fetchone()
         except Exception as e:
-            self.log.warning(f"⚠️ Coordinate validation failed: {e}")
-            coord_validation = None
+            self.log.warning(f"⚠️ Direct coordinate validation failed: {e}")
+            self.log.info("🔄 Trying with type-safe CASE statement...")
+            try:
+                coord_validation = self.conn.execute("""
+                    SELECT
+                        MIN(ST_XMin(
+                            CASE
+                                WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                    ST_GeomFromText(geometry)
+                                WHEN typeof(geometry) = 'BLOB' THEN
+                                    ST_GeomFromWKB(geometry)
+                                ELSE geometry
+                            END
+                        )) as min_x,
+                        MAX(ST_XMax(
+                            CASE
+                                WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                    ST_GeomFromText(geometry)
+                                WHEN typeof(geometry) = 'BLOB' THEN
+                                    ST_GeomFromWKB(geometry)
+                                ELSE geometry
+                            END
+                        )) as max_x,
+                        MIN(ST_YMin(
+                            CASE
+                                WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                    ST_GeomFromText(geometry)
+                                WHEN typeof(geometry) = 'BLOB' THEN
+                                    ST_GeomFromWKB(geometry)
+                                ELSE geometry
+                            END
+                        )) as min_y,
+                        MAX(ST_YMax(
+                            CASE
+                                WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                    ST_GeomFromText(geometry)
+                                WHEN typeof(geometry) = 'BLOB' THEN
+                                    ST_GeomFromWKB(geometry)
+                                ELSE geometry
+                            END
+                        )) as max_y
+                    FROM bnbo_status_raw
+                    WHERE geometry IS NOT NULL
+                    LIMIT 1000
+                """).fetchone()
+            except Exception as e2:
+                self.log.warning(f"⚠️ Fallback coordinate validation also failed: {e2}")
+                coord_validation = None
 
         if coord_validation:
             min_x, max_x, min_y, max_y = coord_validation
@@ -97,7 +143,7 @@ class BNBOPreFilter(PreFilteringStageBase):
             self.log.info("🧭 BNBO COORDINATE ORDER CHECK - Fetching sample centroids...")
             sample_wkt = self.conn.execute("""
                 SELECT
-                    ST_AsText(ST_Centroid(ST_GeomFromWKB(geometry))) as wkt_centroid
+                    ST_AsText(ST_Centroid(geometry)) as wkt_centroid
                 FROM bnbo_status_raw
                 WHERE geometry IS NOT NULL
                 LIMIT 5
@@ -188,15 +234,38 @@ class BNBOPreFilter(PreFilteringStageBase):
 
             self.log.warning(f"   Traceback: {traceback.format_exc()}")
 
-        # Geometry is stored as WKB (BLOB) in parquet files - convert with ST_GeomFromWKB
-        self.conn.execute("""
-            CREATE OR REPLACE TABLE bnbo_status_full AS
-            SELECT
-                status_category,
-                UNNEST(ST_Dump(ST_GeomFromWKB(geometry))).geom as geometry
-            FROM bnbo_status_raw
-            WHERE geometry IS NOT NULL
-        """)
+        # Geometry may be GEOMETRY('OGC:CRS84') from GeoParquet or BLOB - handle both
+        try:
+            self.conn.execute("""
+                CREATE OR REPLACE TABLE bnbo_status_full AS
+                SELECT
+                    status_category,
+                    UNNEST(ST_Dump(geometry)).geom as geometry
+                FROM bnbo_status_raw
+                WHERE geometry IS NOT NULL
+            """)
+        except Exception as e:
+            self.log.warning(f"⚠️ Failed with direct geometry approach: {e}")
+            self.log.info("🔄 Trying with type-safe CASE statement...")
+
+            # Fallback: Use type-safe approach with explicit type checking
+            self.conn.execute("""
+                CREATE OR REPLACE TABLE bnbo_status_full AS
+                SELECT
+                    status_category,
+                    UNNEST(ST_Dump(
+                        CASE
+                            WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                ST_GeomFromText(geometry)
+                            WHEN typeof(geometry) = 'BLOB' THEN
+                                ST_GeomFromWKB(geometry)
+                            ELSE
+                                geometry
+                        END
+                    )).geom as geometry
+                FROM bnbo_status_raw
+                WHERE geometry IS NOT NULL
+            """)
 
         # Log dataset sizes
         raw_count = self.conn.execute("SELECT COUNT(*) FROM bnbo_status_raw").fetchone()[0]

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/properties_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/properties_prefilter.py
@@ -70,7 +70,7 @@ class PropertiesPreFilter(PreFilteringStageBase):
         self.conn.execute("""
             CREATE OR REPLACE TABLE properties_filtered AS
             SELECT
-                bestemtFastEjendomBFENr,
+                bfe_number,
                 geometry,
                 ST_Area_Spheroid(geometry) as property_area_m2
             FROM properties_full
@@ -93,11 +93,11 @@ class PropertiesPreFilter(PreFilteringStageBase):
             self.conn.execute(f"""
                 CREATE OR REPLACE TABLE properties_chunk AS
                 SELECT
-                    bestemtFastEjendomBFENr,
+                    bfe_number,
                     geometry,
                     ST_Area_Spheroid(geometry) as property_area_m2
                 FROM properties_full
-                ORDER BY bestemtFastEjendomBFENr
+                ORDER BY bfe_number
                 LIMIT {chunk_size} OFFSET {offset}
             """)
 
@@ -110,7 +110,7 @@ class PropertiesPreFilter(PreFilteringStageBase):
             self.conn.execute("""
                 CREATE OR REPLACE TABLE chunk_filtered AS
                 SELECT DISTINCT
-                    p.bestemtFastEjendomBFENr,
+                    p.bfe_number,
                     p.geometry,
                     p.property_area_m2
                 FROM fields_for_filtering f

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/water_projects_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/water_projects_prefilter.py
@@ -57,21 +57,67 @@ class WaterProjectsPreFilter(PreFilteringStageBase):
         # COORDINATE VALIDATION: Check coordinate bounds to ensure proper lon/lat order
         self.log.info("🌍 Validating water projects coordinate bounds and order...")
 
-        # Coordinate validation: geometry is stored as WKB (BLOB) in parquet files
+        # Since geometry may be GEOMETRY('OGC:CRS84') from GeoParquet, use direct approach first
         try:
             coord_validation = self.conn.execute("""
                 SELECT
-                    MIN(ST_XMin(ST_GeomFromWKB(geometry))) as min_x,
-                    MAX(ST_XMax(ST_GeomFromWKB(geometry))) as max_x,
-                    MIN(ST_YMin(ST_GeomFromWKB(geometry))) as min_y,
-                    MAX(ST_YMax(ST_GeomFromWKB(geometry))) as max_y
+                    MIN(ST_XMin(geometry)) as min_x,
+                    MAX(ST_XMax(geometry)) as max_x,
+                    MIN(ST_YMin(geometry)) as min_y,
+                    MAX(ST_YMax(geometry)) as max_y
                 FROM water_projects_raw
                 WHERE geometry IS NOT NULL
                 LIMIT 1000
             """).fetchone()
         except Exception as e:
-            self.log.warning(f"⚠️ Coordinate validation failed: {e}")
-            coord_validation = None
+            self.log.warning(f"⚠️ Direct coordinate validation failed: {e}")
+            self.log.info("🔄 Trying with type-safe CASE statement...")
+            try:
+                coord_validation = self.conn.execute("""
+                    SELECT
+                        MIN(ST_XMin(
+                            CASE
+                                WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                    ST_GeomFromText(geometry)
+                                WHEN typeof(geometry) = 'BLOB' THEN
+                                    ST_GeomFromWKB(geometry)
+                                ELSE geometry
+                            END
+                        )) as min_x,
+                        MAX(ST_XMax(
+                            CASE
+                                WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                    ST_GeomFromText(geometry)
+                                WHEN typeof(geometry) = 'BLOB' THEN
+                                    ST_GeomFromWKB(geometry)
+                                ELSE geometry
+                            END
+                        )) as max_x,
+                        MIN(ST_YMin(
+                            CASE
+                                WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                    ST_GeomFromText(geometry)
+                                WHEN typeof(geometry) = 'BLOB' THEN
+                                    ST_GeomFromWKB(geometry)
+                                ELSE geometry
+                            END
+                        )) as min_y,
+                        MAX(ST_YMax(
+                            CASE
+                                WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                    ST_GeomFromText(geometry)
+                                WHEN typeof(geometry) = 'BLOB' THEN
+                                    ST_GeomFromWKB(geometry)
+                                ELSE geometry
+                            END
+                        )) as max_y
+                    FROM water_projects_raw
+                    WHERE geometry IS NOT NULL
+                    LIMIT 1000
+                """).fetchone()
+            except Exception as e2:
+                self.log.warning(f"⚠️ Fallback coordinate validation also failed: {e2}")
+                coord_validation = None
 
         if coord_validation and all(v is not None for v in coord_validation):
             min_x, max_x, min_y, max_y = coord_validation
@@ -103,7 +149,7 @@ class WaterProjectsPreFilter(PreFilteringStageBase):
             self.log.info("🧭 WATER PROJECTS COORDINATE ORDER CHECK - Fetching sample centroids...")
             sample_wkt = self.conn.execute("""
                 SELECT
-                    ST_AsText(ST_Centroid(ST_GeomFromWKB(geometry))) as wkt_centroid
+                    ST_AsText(ST_Centroid(geometry)) as wkt_centroid
                 FROM water_projects_raw
                 WHERE geometry IS NOT NULL
                 LIMIT 5
@@ -201,15 +247,38 @@ class WaterProjectsPreFilter(PreFilteringStageBase):
 
             self.log.warning(f"   Traceback: {traceback.format_exc()}")
 
-        # Geometry is stored as WKB (BLOB) in parquet files - convert with ST_GeomFromWKB
-        self.conn.execute("""
-            CREATE OR REPLACE TABLE water_projects_full AS
-            SELECT
-                project_id,
-                UNNEST(ST_Dump(ST_GeomFromWKB(geometry))).geom as geometry
-            FROM water_projects_raw
-            WHERE geometry IS NOT NULL
-        """)
+        # Geometry may be GEOMETRY('OGC:CRS84') from GeoParquet or BLOB - handle both
+        try:
+            self.conn.execute("""
+                CREATE OR REPLACE TABLE water_projects_full AS
+                SELECT
+                    project_id,
+                    UNNEST(ST_Dump(geometry)).geom as geometry
+                FROM water_projects_raw
+                WHERE geometry IS NOT NULL
+            """)
+        except Exception as e:
+            self.log.warning(f"⚠️ Failed with direct geometry approach: {e}")
+            self.log.info("🔄 Trying with type-safe CASE statement...")
+
+            # Fallback: Use type-safe approach with explicit type checking
+            self.conn.execute("""
+                CREATE OR REPLACE TABLE water_projects_full AS
+                SELECT
+                    project_id,
+                    UNNEST(ST_Dump(
+                        CASE
+                            WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
+                                ST_GeomFromText(geometry)
+                            WHEN typeof(geometry) = 'BLOB' THEN
+                                ST_GeomFromWKB(geometry)
+                            ELSE
+                                geometry
+                        END
+                    )).geom as geometry
+                FROM water_projects_raw
+                WHERE geometry IS NOT NULL
+            """)
 
         # Log dataset sizes
         raw_count = self.conn.execute("SELECT COUNT(*) FROM water_projects_raw").fetchone()[0]

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage4/consolidate_two_tables.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage4/consolidate_two_tables.py
@@ -183,8 +183,12 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                         FROM {table_name}
                     """)
                     self.log.info(f"  ✅ Converted {table_name}.{geom_col} from BLOB to GEOMETRY")
+                elif col_type and col_type.startswith("GEOMETRY"):
+                    self.log.debug(
+                        f"  ℹ️ {table_name}.{geom_col} is already {col_type}, no conversion needed"
+                    )
                 else:
-                    self.log.debug(f"  ℹ️ {table_name}.{geom_col} is already {col_type}")
+                    self.log.warning(f"  ⚠️ {table_name}.{geom_col} has unexpected type {col_type}")
 
             except Exception as e:
                 self.log.warning(f"Could not convert {table_name}.{geom_col}: {e}")


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes the `field_area_analysis_multi_stage` CI pipeline failures ([run #23399451967](https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/23399451967)).

## 💡 Solution
- [x] **DuckDB 1.5 GeoParquet compatibility**: `water_projects_prefilter` and `bnbo_prefilter` called `ST_GeomFromWKB()` on geometry columns already typed as `GEOMETRY('OGC:CRS84')` by DuckDB 1.5. Applied the same type-safe pattern already used by `wetlands_prefilter` and `soil_types_prefilter`: try geometry directly first, fallback to `CASE WHEN typeof()` for BLOB/VARCHAR.
- [x] **Column name fix**: `properties_prefilter` referenced `bestemtFastEjendomBFENr` but `property_cadastral_merge` outputs `bfe_number`. Renamed all 4 occurrences.
- [x] **Defensive type handling**: `consolidate_two_tables` now explicitly handles typed GEOMETRY variants (e.g. `GEOMETRY('OGC:CRS84')`) instead of silently falling through.

## ✅ How to Do Self-Test
1. Re-run the `field_area_analysis_multi_stage` workflow and verify all stage 0 jobs pass
2. Verify stage 4 consolidation succeeds (was failing as cascade from stage 0)

## 📝 Additional Notes
- This is a [known DuckDB spatial issue](https://github.com/duckdb/duckdb_spatial/issues/766) — GeoParquet files now load with typed geometry (`GEOMETRY('OGC:CRS84')`) instead of plain `BLOB`
- `wetlands_prefilter` and `soil_types_prefilter` already had this fix and passed CI — this PR brings the remaining prefilters in line
- `grukos_prefilter` failures were cancellations (timeout), not code bugs — no changes needed