### PR TITLE
fix(pipeline): fix SPATIAL_JOIN column binding in Stage 2A

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/water_projects_bnbo.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/water_projects_bnbo.py
@@ -47,29 +47,16 @@ class WaterProjectsBNBOIntersection(FieldAnalysisStageBase):
             "🚀 PERFORMANCE: 4.8x faster than original (2.4K → 500 water projects, 3.7K → 1K BNBO)"
         )
 
-        # Use ST_Dump for multipolygon decomposition and add unique IDs
-        self.log.info("Decomposing BNBO polygons with ST_Dump and adding unique IDs...")
-
-        # Step 1: Decompose multipolygons with ST_Dump
-        self.conn.execute("""
-            CREATE OR REPLACE TABLE bnbo_status_decomposed AS
-            SELECT
-                status_category,
-                UNNEST(ST_Dump(geometry)).geom as geometry
-            FROM bnbo_status_raw
-        """)
-
-        # Step 2: Add unique IDs with ROW_NUMBER using the decomposed geometries
+        # Stage 0 already decomposed with ST_Dump and assigned bnbo_id
+        # Preserve the existing bnbo_id from Stage 0 output
+        self.log.info("Using Stage 0 bnbo_id (already decomposed and ID-assigned)...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE bnbo_status AS
             SELECT
-                ROW_NUMBER() OVER (
-                    ORDER BY status_category, ST_X(ST_Centroid(geometry)),
-                             ST_Y(ST_Centroid(geometry))
-                ) as bnbo_id,
+                bnbo_id,
                 status_category,
                 geometry
-            FROM bnbo_status_decomposed
+            FROM bnbo_status_raw
         """)
 
         # Clean up temporary table

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage2/fields_bnbo_water.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage2/fields_bnbo_water.py
@@ -136,8 +136,8 @@ class FieldsBNBOWaterCoverage(FieldAnalysisStageBase):
                 ST_Intersection(fbi.field_bnbo_geometry, wpbi.intersection_geometry) as field_bnbo_water_geometry
             FROM field_bnbo_intersections fbi
             JOIN water_projects_bnbo_intersections wpbi
-                ON ST_Intersects(fbi.field_bnbo_geometry, wpbi.intersection_geometry)
-            WHERE fbi.bnbo_id = wpbi.bnbo_id
+                ON fbi.bnbo_id = wpbi.bnbo_id
+                AND ST_Intersects(fbi.field_bnbo_geometry, wpbi.intersection_geometry)
         """)
 
         # Get result statistics


### PR DESCRIPTION
## Summary
- Fix `INTERNAL Error: Failed to bind column reference "bnbo_id"` in Stage 2A (fields × BNBO water coverage)
- Move `bnbo_id` equality predicate from WHERE to ON clause — DuckDB's SPATIAL_JOIN operator doesn't project columns only referenced in WHERE
- Remove redundant ST_Dump + ROW_NUMBER in Stage 1A that independently regenerated `bnbo_id`, risking ID mismatch with Stage 0

## Test plan
- [ ] Re-run `stage2-fields-bnbo-water` CI job for both 2024 and 2025
- [ ] Verify Stage 1A still produces correct water project × BNBO intersections
- [ ] Verify Stage 2A produces non-empty `field_bnbo_water_intersections` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)