### PR TITLE
fix(chr-pipeline): build lxml from source to fix xmlsec mismatch

### DIFF
--- a/.github/workflows/chr_pipeline.yml
+++ b/.github/workflows/chr_pipeline.yml
@@ -193,15 +193,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Set up environment variables
@@ -341,15 +346,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Download context artifact
@@ -516,15 +526,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Download context artifact
@@ -674,15 +689,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Download context artifact
@@ -804,15 +824,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Download context artifact with herd details
@@ -964,15 +989,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Download context artifact
@@ -1104,15 +1134,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Download context artifact
@@ -1280,15 +1315,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Download bronze timestamp artifact
@@ -1368,15 +1408,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
       - name: Run silver processing (Streaming Mode)
         working-directory: backend/pipelines/chr_pipeline
@@ -1438,15 +1483,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
       - name: Set up environment variables
         env:
@@ -1642,15 +1692,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: Install dependencies
         run: |
           # Install unified pipeline dependencies FIRST (needed for R2 access)
           cd backend/pipelines/unified_pipeline
           uv pip install --system -e .
 
-          # Install CHR pipeline dependencies
+          # Install CHR pipeline dependencies (build lxml from source to match system libxml2)
           cd ../chr_pipeline
-          uv pip install --system -e .
+          uv pip install --system --no-binary lxml -e .
 
 
       - name: Set up environment variables

--- a/backend/pipelines/chr_pipeline/pyproject.toml
+++ b/backend/pipelines/chr_pipeline/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
     "zeep~=4.3.1",
     "certifi~=2025.6.15",
-    "lxml>=5.2,<6",
+    "lxml>=5.2",
     "xmlsec==1.3.14",
     "s3fs>=2024.1.0",
     "python-dotenv~=1.1.1",
@@ -38,8 +38,8 @@ only-packages = true
 artifacts = ["*.py"]
 
 [tool.uv]
-# xmlsec 1.3.14 binary wheels are only compatible with lxml 5.x
-# lxml 6.x bundles a different libxml2 version causing runtime mismatch
+# xmlsec and lxml binary wheels bundle different libxml2 versions causing runtime mismatch
+# CI uses --no-binary lxml to build from source against system libxml2
 # See: https://github.com/xmlsec/python-xmlsec/issues/316
 
 [tool.uv.sources]

--- a/backend/pipelines/chr_pipeline/uv.lock
+++ b/backend/pipelines/chr_pipeline/uv.lock
@@ -339,7 +339,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "landbruget-common", editable = "../../common" },
     { name = "loguru", specifier = "~=0.7.3" },
-    { name = "lxml", specifier = ">=5.2,<6" },
+    { name = "lxml", specifier = ">=5.2" },
     { name = "pyarrow", specifier = "~=20.0.0" },
     { name = "python-dotenv", specifier = "~=1.1.1" },
     { name = "s3fs", specifier = ">=2024.1.0" },


### PR DESCRIPTION
## Summary
- Adds `apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl` to all CI jobs
- Uses `--no-binary lxml` so lxml is built from source against the system libxml2
- This ensures lxml and xmlsec use the **same** libxml2, eliminating the version mismatch
- Version pinning alone (#773) was insufficient — binary wheels bundle different libxml2 regardless of version

Fixes the `xmlsec.InternalError: lxml & xmlsec libxml2 library version mismatch` from [CI run #23400234319](https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/23400234319)

This is the same approach that originally fixed the issue in commit 6a4a807b6, which was lost during workflow rewrites.

## Test plan
- [ ] CI CHR pipeline bronze-foundation job passes
- [ ] Silver-processing job can download bronze-timestamp artifact and proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)