### PR TITLE
fix(chr-pipeline): pin lxml<5.4 for xmlsec compatibility

### DIFF
--- a/backend/pipelines/chr_pipeline/pyproject.toml
+++ b/backend/pipelines/chr_pipeline/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
     "zeep~=4.3.1",
     "certifi~=2025.6.15",
-    "lxml>=5.2",
+    "lxml>=5.2,<5.4",
     "xmlsec==1.3.14",
     "s3fs>=2024.1.0",
     "python-dotenv~=1.1.1",
@@ -38,8 +38,8 @@ only-packages = true
 artifacts = ["*.py"]
 
 [tool.uv]
-# xmlsec and lxml binary wheels bundle different libxml2 versions causing runtime mismatch
-# CI uses --no-binary lxml to build from source against system libxml2
+# xmlsec 1.3.14 binary wheels are only compatible with lxml <5.4
+# lxml 5.4+ and 6.x bundle a different libxml2 causing runtime mismatch
 # See: https://github.com/xmlsec/python-xmlsec/issues/316
 
 [tool.uv.sources]

--- a/backend/pipelines/chr_pipeline/uv.lock
+++ b/backend/pipelines/chr_pipeline/uv.lock
@@ -339,7 +339,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "landbruget-common", editable = "../../common" },
     { name = "loguru", specifier = "~=0.7.3" },
-    { name = "lxml", specifier = ">=5.2" },
+    { name = "lxml", specifier = ">=5.2,<5.4" },
     { name = "pyarrow", specifier = "~=20.0.0" },
     { name = "python-dotenv", specifier = "~=1.1.1" },
     { name = "s3fs", specifier = ">=2024.1.0" },


### PR DESCRIPTION
## Summary
- Pins `lxml>=5.2,<5.4` — locally verified that lxml 5.4.0+ has the same libxml2 mismatch as 6.x
- Reverts the unnecessary `--no-binary lxml` and system deps from #776 (didn't help)
- **Locally tested end-to-end**: `uv pip install -e .` then `from zeep.wsse.username import UsernameToken` succeeds

### Local test results
| lxml version | xmlsec 1.3.14 | Status |
|---|---|---|
| 5.2.1 – 5.3.2 | 1.3.14 | ✅ OK |
| 5.4.0 | 1.3.14 | ❌ mismatch |
| 6.0.2 | 1.3.14 | ❌ mismatch |

## Test plan
- [x] Local: `uv pip install -e .` + import test passes
- [ ] CI: CHR pipeline bronze-foundation job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)