### PR TITLE
fix(pipeline): TRY() wrap for TopologyException in Stage 1C

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/fields_properties.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/fields_properties.py
@@ -233,25 +233,28 @@ class FieldsPropertiesIntersection(FieldAnalysisStageBase):
                         property_area_m2,
 
                         -- Calculate intersection area and percentages
+                        -- TRY() wraps ST_Intersection to handle invalid geometries
+                        -- (DuckDB 1.5 TopologyException on malformed polygons)
                         ST_Area_Spheroid(
-                            ST_Intersection(field_geometry, property_geometry)
+                            TRY(ST_Intersection(field_geometry, property_geometry))
                         ) as intersection_area_m2,
-                        (ST_Area_Spheroid(ST_Intersection(field_geometry, property_geometry)) /
+                        (ST_Area_Spheroid(TRY(ST_Intersection(field_geometry, property_geometry))) /
                          field_area_m2) * 100 as field_area_share_pct,
-                        (ST_Area_Spheroid(ST_Intersection(field_geometry, property_geometry)) /
+                        (ST_Area_Spheroid(TRY(ST_Intersection(field_geometry, property_geometry))) /
                          property_area_m2) * 100 as property_area_share_pct,
 
                         -- STREAM intersection geometries for downstream spatial analysis
                         field_geometry,
                         property_geometry,
-                        ST_Intersection(field_geometry, property_geometry) as intersection_geometry
+                        TRY(ST_Intersection(field_geometry, property_geometry)) as intersection_geometry
 
                     FROM chunk_raw_intersections
                     WHERE
                         -- Filter out tiny intersections (< 1% of field area or < 100 m²)
-                        ST_Area_Spheroid(ST_Intersection(field_geometry, property_geometry)) > 100
+                        -- TRY() returns NULL for invalid geometries, which are filtered out
+                        ST_Area_Spheroid(TRY(ST_Intersection(field_geometry, property_geometry))) > 100
                         AND (
-                            ST_Area_Spheroid(ST_Intersection(field_geometry, property_geometry)) /
+                            ST_Area_Spheroid(TRY(ST_Intersection(field_geometry, property_geometry))) /
                             field_area_m2
                         ) > 0.01
                 """)


### PR DESCRIPTION
## Summary
- Stage 1C (Fields × Properties) crashes with `TopologyException: Ring edge missing` on invalid property geometries
- Wrap all `ST_Intersection()` calls with `TRY()` per DuckDB 1.5 requirements
- Invalid geometries return NULL, filtered out by existing area thresholds (>100m², >1% of field)

## Test plan
- [ ] Re-run field area analysis pipeline for 2024 and 2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)