### PR TITLE
fix(pipeline): Stage 3 SPATIAL_JOIN binding bug + TRY() wrap

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/final_bnbo.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/final_bnbo.py
@@ -103,46 +103,54 @@ class FinalBNBOAnalysis(FieldAnalysisStageBase):
         self.log.info("🔧 Using existing geometries from Stage 2A - No complex recalculations")
 
         # Step 1: Create property × BNBO intersections (total BNBO within properties)
+        # NOTE: Two-step join to work around DuckDB SPATIAL_JOIN bug where same-named
+        # columns (field_uuid) on both sides cause "Failed to bind column reference".
         self.log.info("📦 Step 1: Creating property_bnbo_intersections")
+        self.conn.execute("""
+            CREATE OR REPLACE TABLE _bnbo_candidates AS
+            SELECT
+                p.field_uuid, p.bfe_number, p.property_geometry,
+                fbi.field_id, fbi.block_id, fbi.cvr_number, fbi.year,
+                fbi.bnbo_id, fbi.status_category, fbi.field_bnbo_geometry
+            FROM field_property_intersections p
+            JOIN field_bnbo_intersections fbi ON p.field_uuid = fbi.field_uuid
+        """)
         self.conn.execute("""
             CREATE OR REPLACE TABLE property_bnbo_intersections AS
             SELECT
-                p.field_uuid,
-                p.bfe_number,
-                fbi.field_id,
-                fbi.block_id,
-                fbi.cvr_number,
-                fbi.year,
-                fbi.bnbo_id,
-                fbi.status_category,
-                ST_Intersection(p.property_geometry, fbi.field_bnbo_geometry) as
+                field_uuid, bfe_number, field_id, block_id, cvr_number, year,
+                bnbo_id, status_category,
+                TRY(ST_Intersection(property_geometry, field_bnbo_geometry)) as
                     property_bnbo_geometry
-            FROM field_property_intersections p
-            JOIN field_bnbo_intersections fbi ON p.field_uuid = fbi.field_uuid
-                AND ST_Intersects(p.property_geometry, fbi.field_bnbo_geometry)
+            FROM _bnbo_candidates
+            WHERE ST_Intersects(property_geometry, field_bnbo_geometry)
         """)
+        self.conn.execute("DROP TABLE IF EXISTS _bnbo_candidates")
 
         # Step 2: Create property × BNBO × water intersections
         # (water-covered BNBO within properties)
         self.log.info("📦 Step 2: Creating property_bnbo_water_intersections")
         self.conn.execute("""
-            CREATE OR REPLACE TABLE property_bnbo_water_intersections AS
+            CREATE OR REPLACE TABLE _bnbo_water_candidates AS
             SELECT
-                p.field_uuid,
-                p.bfe_number,
-                fbwi.field_id,
-                fbwi.block_id,
-                fbwi.cvr_number,
-                fbwi.year,
-                fbwi.bnbo_id,
-                fbwi.status_category,
-                fbwi.project_id,
-                ST_Intersection(p.property_geometry, fbwi.field_bnbo_water_geometry) as
-                    property_bnbo_water_geometry
+                p.field_uuid, p.bfe_number, p.property_geometry,
+                fbwi.field_id, fbwi.block_id, fbwi.cvr_number, fbwi.year,
+                fbwi.bnbo_id, fbwi.status_category, fbwi.project_id,
+                fbwi.field_bnbo_water_geometry
             FROM field_property_intersections p
             JOIN stage3a_field_bnbo_water_intersections fbwi ON p.field_uuid = fbwi.field_uuid
-                AND ST_Intersects(p.property_geometry, fbwi.field_bnbo_water_geometry)
         """)
+        self.conn.execute("""
+            CREATE OR REPLACE TABLE property_bnbo_water_intersections AS
+            SELECT
+                field_uuid, bfe_number, field_id, block_id, cvr_number, year,
+                bnbo_id, status_category, project_id,
+                TRY(ST_Intersection(property_geometry, field_bnbo_water_geometry)) as
+                    property_bnbo_water_geometry
+            FROM _bnbo_water_candidates
+            WHERE ST_Intersects(property_geometry, field_bnbo_water_geometry)
+        """)
+        self.conn.execute("DROP TABLE IF EXISTS _bnbo_water_candidates")
 
         # Get result statistics
         property_bnbo_count = self.conn.execute(

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/final_grukos.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/final_grukos.py
@@ -99,23 +99,29 @@ class FinalGrukosAnalysis(FieldAnalysisStageBase):
         self.log.info("Using existing geometries from Stage 2C - No complex recalculations")
 
         # Create property × grukos intersections
+        # NOTE: Two-step join to work around DuckDB SPATIAL_JOIN bug where same-named
+        # columns (field_uuid) on both sides cause "Failed to bind column reference".
         self.log.info("Creating property_grukos_intersections")
+        self.conn.execute("""
+            CREATE OR REPLACE TABLE _grukos_candidates AS
+            SELECT
+                p.field_uuid, p.bfe_number, p.property_geometry,
+                fgi.field_id, fgi.block_id, fgi.cvr_number, fgi.year,
+                fgi.grukos_id, fgi.field_grukos_geometry
+            FROM field_property_intersections p
+            JOIN field_grukos_intersections fgi ON p.field_uuid = fgi.field_uuid
+        """)
         self.conn.execute("""
             CREATE OR REPLACE TABLE property_grukos_intersections AS
             SELECT
-                p.field_uuid,
-                p.bfe_number,
-                fgi.field_id,
-                fgi.block_id,
-                fgi.cvr_number,
-                fgi.year,
-                fgi.grukos_id,
-                ST_Intersection(p.property_geometry, fgi.field_grukos_geometry) as
+                field_uuid, bfe_number, field_id, block_id, cvr_number, year,
+                grukos_id,
+                TRY(ST_Intersection(property_geometry, field_grukos_geometry)) as
                     property_grukos_geometry
-            FROM field_property_intersections p
-            JOIN field_grukos_intersections fgi ON p.field_uuid = fgi.field_uuid
-                AND ST_Intersects(p.property_geometry, fgi.field_grukos_geometry)
+            FROM _grukos_candidates
+            WHERE ST_Intersects(property_geometry, field_grukos_geometry)
         """)
+        self.conn.execute("DROP TABLE IF EXISTS _grukos_candidates")
 
         # Get result statistics
         property_grukos_count = self.conn.execute(

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/final_wetland.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/final_wetland.py
@@ -103,46 +103,54 @@ class FinalWetlandAnalysis(FieldAnalysisStageBase):
         self.log.info("🔧 Using existing geometries from Stage 2B - No complex recalculations")
 
         # Step 1: Create property × wetland intersections (total wetlands within properties)
+        # NOTE: Two-step join to work around DuckDB SPATIAL_JOIN bug where same-named
+        # columns (field_uuid) on both sides cause "Failed to bind column reference".
         self.log.info("📦 Step 1: Creating property_wetland_intersections")
+        self.conn.execute("""
+            CREATE OR REPLACE TABLE _wetland_candidates AS
+            SELECT
+                p.field_uuid, p.bfe_number, p.property_geometry,
+                fwi.field_id, fwi.block_id, fwi.cvr_number, fwi.year,
+                fwi.wetland_id, fwi.toerv_pct, fwi.field_wetland_geometry
+            FROM field_property_intersections p
+            JOIN field_wetland_intersections fwi ON p.field_uuid = fwi.field_uuid
+        """)
         self.conn.execute("""
             CREATE OR REPLACE TABLE property_wetland_intersections AS
             SELECT
-                p.field_uuid,
-                p.bfe_number,
-                fwi.field_id,
-                fwi.block_id,
-                fwi.cvr_number,
-                fwi.year,
-                fwi.wetland_id,
-                fwi.toerv_pct,
-                ST_Intersection(p.property_geometry, fwi.field_wetland_geometry) as
+                field_uuid, bfe_number, field_id, block_id, cvr_number, year,
+                wetland_id, toerv_pct,
+                TRY(ST_Intersection(property_geometry, field_wetland_geometry)) as
                     property_wetland_geometry
-            FROM field_property_intersections p
-            JOIN field_wetland_intersections fwi ON p.field_uuid = fwi.field_uuid
-                AND ST_Intersects(p.property_geometry, fwi.field_wetland_geometry)
+            FROM _wetland_candidates
+            WHERE ST_Intersects(property_geometry, field_wetland_geometry)
         """)
+        self.conn.execute("DROP TABLE IF EXISTS _wetland_candidates")
 
         # Step 2: Create property × wetland × water intersections
         # (water-covered wetlands within properties)
         self.log.info("📦 Step 2: Creating property_wetland_water_intersections")
         self.conn.execute("""
-            CREATE OR REPLACE TABLE property_wetland_water_intersections AS
+            CREATE OR REPLACE TABLE _wetland_water_candidates AS
             SELECT
-                p.field_uuid,
-                p.bfe_number,
-                fwwi.field_id,
-                fwwi.block_id,
-                fwwi.cvr_number,
-                fwwi.year,
-                fwwi.wetland_id,
-                fwwi.toerv_pct,
-                fwwi.project_id,
-                ST_Intersection(p.property_geometry, fwwi.field_wetland_water_geometry) as
-                    property_wetland_water_geometry
+                p.field_uuid, p.bfe_number, p.property_geometry,
+                fwwi.field_id, fwwi.block_id, fwwi.cvr_number, fwwi.year,
+                fwwi.wetland_id, fwwi.toerv_pct, fwwi.project_id,
+                fwwi.field_wetland_water_geometry
             FROM field_property_intersections p
             JOIN stage3b_field_wetland_water_intersections fwwi ON p.field_uuid = fwwi.field_uuid
-                AND ST_Intersects(p.property_geometry, fwwi.field_wetland_water_geometry)
         """)
+        self.conn.execute("""
+            CREATE OR REPLACE TABLE property_wetland_water_intersections AS
+            SELECT
+                field_uuid, bfe_number, field_id, block_id, cvr_number, year,
+                wetland_id, toerv_pct, project_id,
+                TRY(ST_Intersection(property_geometry, field_wetland_water_geometry)) as
+                    property_wetland_water_geometry
+            FROM _wetland_water_candidates
+            WHERE ST_Intersects(property_geometry, field_wetland_water_geometry)
+        """)
+        self.conn.execute("DROP TABLE IF EXISTS _wetland_water_candidates")
 
         # Get result statistics
         property_wetland_count = self.conn.execute(


### PR DESCRIPTION
## Summary
- All 3 Stage 3 jobs fail with DuckDB SPATIAL_JOIN bug: `Failed to bind column reference "field_uuid"` when `field_uuid` appears on both sides of a `JOIN ... ON equality AND ST_Intersects()`
- Stage 3B (wetlands) also hits `TopologyException: side location conflict` on invalid geometries
- Fix: split each spatial query into two steps (equality join → spatial filter), same pattern used in Stage 2A
- Added `TRY()` wrap on all `ST_Intersection` calls for TopologyException resilience

## Changes
- `stage3/final_bnbo.py` — 2 queries split into two-step joins
- `stage3/final_grukos.py` — 1 query split into two-step join
- `stage3/final_wetland.py` — 2 queries split into two-step joins

## Test plan
- [ ] Re-run field area analysis pipeline — verify all Stage 3 jobs pass
- [ ] Verify Stage 4 consolidation completes (depends on Stage 3 outputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)