### PR TITLE
fix(chr-pipeline): add missing --chr-group CLI option

### DIFF
--- a/backend/pipelines/chr_pipeline/main.py
+++ b/backend/pipelines/chr_pipeline/main.py
@@ -1022,6 +1022,12 @@ def run_bronze_step(step: str, context: dict[str, Any]) -> dict[str, Any]:
     is_flag=True,
     help="Skip running dependency steps (for parallel job execution)",
 )
+@click.option(
+    "--chr-group",
+    type=int,
+    default=None,
+    help="CHR group number for parallel processing (1-4)",
+)
 def main(
     steps,
     test_species_codes,
@@ -1033,6 +1039,7 @@ def main(
     start_date,
     end_date,
     skip_dependencies,
+    chr_group,
 ):
     """CHR Data Pipeline."""
     # Record start time for execution tracking
@@ -1070,6 +1077,7 @@ def main(
         "start_date": start_date,
         "end_date": end_date,
         "skip_dependencies": skip_dependencies,
+        "chr_group": chr_group,
     }
 
     setup_logging(args["log_level"])


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- [x] Added the missing `--chr-group` Click CLI option to `main.py` so the CHR pipeline can be invoked with `--chr-group N` for parallel VetStat processing
- [x] The downstream code (`create_chr_groups()`, `filter_chr_by_group()`, `context["args"]["chr_group"]`) already existed — only the CLI entry point was missing

Note: This PR also includes the gs:// prefix fix (see #784 for details) since the commits were made on this branch.

## ✅ How to Do Self-Test
```bash
cd backend/pipelines/chr_pipeline
python main.py --help  # Should list --chr-group option
```