### PR TITLE
fix(ci): add GCP auth to DMA pipeline + skip silver on bronze failure

### DIFF
--- a/.github/workflows/chr_pipeline.yml
+++ b/.github/workflows/chr_pipeline.yml
@@ -1296,7 +1296,7 @@ jobs:
         bronze-herd-details,
         bronze-parallel-group-2,
       ]
-    if: ${{ always() && !cancelled() && ((inputs.step || 'all') == 'all' || inputs.step == 'silver_processing' || startsWith(inputs.step, 'silver_')) }}
+    if: ${{ always() && !cancelled() && ((needs.bronze-foundation.result == 'success' && needs.bronze-herd-details.result == 'success') || inputs.step == 'silver_processing' || startsWith(inputs.step, 'silver_')) }}
 
     permissions:
       contents: "read"

--- a/.github/workflows/dma_pipeline.yml
+++ b/.github/workflows/dma_pipeline.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Authenticate to Google Cloud
+        uses: 'google-github-actions/auth@v3'
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
       - name: Create VM and run DMA pipeline
         run: |
           # Generate unique VM name with timestamp


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- [x] **DMA pipeline**: Added missing `google-github-actions/auth@v3` step before any `gcloud` commands. The workflow was failing immediately with `You do not currently have an active account selected` because it never authenticated with GCP.
- [x] **CHR pipeline**: Updated `silver-processing` job condition to require `bronze-foundation` and `bronze-herd-details` to succeed before running. Previously it used `always()` which meant silver always ran and always failed when required bronze files were missing (e.g. `besaetning_list.json`, `besaetning_details.json`). Direct silver invocation via `inputs.step` still works.

## ✅ How to Do Self-Test
- Trigger DMA pipeline manually — should now authenticate with GCP and proceed to VM creation
- Trigger CHR pipeline — if `bronze-herd-details` fails, silver should be skipped instead of running and failing

## 📝 Additional Notes
The CHR pipeline's `bronze-herd-details` job was cancelled mid-run in the last execution (42% through 50k herds at 51 min). Root cause is unclear — possibly a runner preemption. The silver guard prevents a cascading failure in this scenario.