### PR TITLE
Preserve BNBO metadata and add date rollups

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/config.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/config.py
@@ -17,7 +17,7 @@ class FieldAreaAnalysisConfig(BaseModel):
     # Dataset names - using consistent naming from silver layer
     properties_dataset: str = "property_cadastral_merged"
     soil_types_dataset: str = "soil_types"
-    bnbo_status_dataset: str = "bnbo_status_dissolved"
+    bnbo_status_dataset: str = "bnbo_status"
     wetlands_dataset: str = "wetlands_dissolved"  # Use dissolved wetlands - now preserves
     # toerv_pct AND eliminates overlaps
     water_projects_dataset: str = "water_projects_dissolved"

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/bnbo_prefilter.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/bnbo_prefilter.py
@@ -1,9 +1,10 @@
 """Stage 0B: BNBO Pre-filtering
 
 Reduce BNBO polygons to only those that intersect with agricultural fields.
-Smaller dataset but still important for memory optimization.
+Now loads individual features (not dissolved) to preserve per-BNBO metadata
+(dates, well IDs, waterworks names, municipality).
 
-EXPECTED REDUCTION: 3.7K → ~1K BNBO polygons (estimated 70% reduction)
+EXPECTED REDUCTION: 5.4K → ~1K BNBO polygons (estimated 70-80% reduction)
 PERFORMANCE IMPACT: Reduces Stage 2 BNBO processing complexity significantly
 """
 
@@ -12,6 +13,19 @@ from typing import Any
 
 from ..config import CONFIG
 from .base import PreFilteringStageBase
+
+# Metadata columns from WFS source to carry through the pipeline
+BNBO_METADATA_COLS = [
+    "datoaend",  # Date status was last changed (approval/completion date)
+    "oprettet",  # Date BNBO record was first created
+    "systid_fra",  # System valid-from (version tracking)
+    "status_bnbo",  # Original detailed status text
+    "dgunr",  # Well ID (DGU number)
+    "anlaegsnav",  # Waterworks name
+    "kommunenav",  # Municipality name
+    "bek",  # Regulation year
+    "anlaegid",  # Facility ID
+]
 
 
 class BNBOPreFilter(PreFilteringStageBase):
@@ -234,37 +248,57 @@ class BNBOPreFilter(PreFilteringStageBase):
 
             self.log.warning(f"   Traceback: {traceback.format_exc()}")
 
+        # Detect which metadata columns are available in the loaded dataset
+        raw_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'bnbo_status_raw'"
+            ).fetchall()
+        ]
+        self.log.info(f"📋 BNBO raw columns: {raw_columns}")
+
+        available_meta = [c for c in BNBO_METADATA_COLS if c in raw_columns]
+        self.log.info(f"📋 BNBO metadata columns to carry: {available_meta}")
+        meta_select = ", ".join(available_meta) + ", " if available_meta else ""
+
+        # Determine geometry column: prefer geometry_spatial (GEOMETRY type) over geometry (WKT)
+        geom_col = "geometry_spatial" if "geometry_spatial" in raw_columns else "geometry"
+        self.log.info(f"📍 Using geometry column: {geom_col}")
+
         # Geometry may be GEOMETRY('OGC:CRS84') from GeoParquet or BLOB - handle both
         try:
-            self.conn.execute("""
+            self.conn.execute(f"""
                 CREATE OR REPLACE TABLE bnbo_status_full AS
                 SELECT
                     status_category,
-                    UNNEST(ST_Dump(geometry)).geom as geometry
+                    {meta_select}
+                    UNNEST(ST_Dump({geom_col})).geom as geometry
                 FROM bnbo_status_raw
-                WHERE geometry IS NOT NULL
+                WHERE {geom_col} IS NOT NULL
             """)
         except Exception as e:
             self.log.warning(f"⚠️ Failed with direct geometry approach: {e}")
             self.log.info("🔄 Trying with type-safe CASE statement...")
 
             # Fallback: Use type-safe approach with explicit type checking
-            self.conn.execute("""
+            self.conn.execute(f"""
                 CREATE OR REPLACE TABLE bnbo_status_full AS
                 SELECT
                     status_category,
+                    {meta_select}
                     UNNEST(ST_Dump(
                         CASE
-                            WHEN typeof(geometry) = 'VARCHAR' AND geometry != '' THEN
-                                ST_GeomFromText(geometry)
-                            WHEN typeof(geometry) = 'BLOB' THEN
-                                ST_GeomFromWKB(geometry)
+                            WHEN typeof({geom_col}) = 'VARCHAR' AND {geom_col} != '' THEN
+                                ST_GeomFromText({geom_col})
+                            WHEN typeof({geom_col}) = 'BLOB' THEN
+                                ST_GeomFromWKB({geom_col})
                             ELSE
-                                geometry
+                                {geom_col}
                         END
                     )).geom as geometry
                 FROM bnbo_status_raw
-                WHERE geometry IS NOT NULL
+                WHERE {geom_col} IS NOT NULL
             """)
 
         # Log dataset sizes
@@ -292,12 +326,24 @@ class BNBOPreFilter(PreFilteringStageBase):
         total_bnbo = self.conn.execute("SELECT COUNT(*) FROM bnbo_status_full").fetchone()[0]
         self.log.info(f"🚀 Pre-filtering {total_bnbo:,} BNBO polygons against {600000:,} fields")
 
+        # Detect available metadata columns in bnbo_status_full
+        full_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'bnbo_status_full'"
+            ).fetchall()
+        ]
+        available_meta = [c for c in BNBO_METADATA_COLS if c in full_columns]
+        meta_select_b = ", ".join(f"b.{c}" for c in available_meta)
+        meta_select_b = f", {meta_select_b}" if meta_select_b else ""
+
         # DuckDB Spatial v1.2.2 COMPLIANT: Single spatial predicate (ST_Intersects only)
         self.log.info("Filtering BNBO polygons that intersect with agricultural fields...")
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE bnbo_intersecting AS
             SELECT DISTINCT
-                b.status_category,
+                b.status_category{meta_select_b},
                 b.geometry
             FROM fields_for_filtering f
             JOIN bnbo_status_full b ON ST_Intersects(f.geometry, b.geometry)
@@ -307,9 +353,21 @@ class BNBOPreFilter(PreFilteringStageBase):
             0
         ]
 
+        # Detect available metadata in bnbo_intersecting
+        intersecting_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'bnbo_intersecting'"
+            ).fetchall()
+        ]
+        available_meta_final = [c for c in BNBO_METADATA_COLS if c in intersecting_columns]
+        meta_select_plain = ", ".join(available_meta_final)
+        meta_select_plain = f",\n                {meta_select_plain}" if meta_select_plain else ""
+
         # Add unique IDs with spatial ordering (ST_Dump already done in _load_input_data)
         self.log.info("Adding unique IDs to filtered BNBO polygons...")
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE bnbo_filtered AS
             SELECT
                 ROW_NUMBER() OVER (
@@ -317,7 +375,7 @@ class BNBOPreFilter(PreFilteringStageBase):
                              ST_X(ST_Centroid(geometry)),
                              ST_Y(ST_Centroid(geometry))
                 ) as bnbo_id,
-                status_category,
+                status_category{meta_select_plain},
                 geometry,
                 ST_Area_Spheroid(geometry) as bnbo_area_m2
             FROM bnbo_intersecting

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/water_projects_bnbo.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/water_projects_bnbo.py
@@ -48,14 +48,11 @@ class WaterProjectsBNBOIntersection(FieldAnalysisStageBase):
         )
 
         # Stage 0 already decomposed with ST_Dump and assigned bnbo_id
-        # Preserve the existing bnbo_id from Stage 0 output
+        # Preserve the existing bnbo_id and metadata from Stage 0 output
         self.log.info("Using Stage 0 bnbo_id (already decomposed and ID-assigned)...")
         self.conn.execute("""
             CREATE OR REPLACE TABLE bnbo_status AS
-            SELECT
-                bnbo_id,
-                status_category,
-                geometry
+            SELECT *
             FROM bnbo_status_raw
         """)
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage2/fields_bnbo_water.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage2/fields_bnbo_water.py
@@ -102,9 +102,23 @@ class FieldsBNBOWaterCoverage(FieldAnalysisStageBase):
         self.log.info("✅ GEOMETRY ONLY - All area calculations moved to Stage 4")
         self.log.info("🔧 SPATIAL_JOIN Compliance - Single spatial predicates in JOIN ON")
 
+        # Detect available BNBO metadata columns from stage0 output
+        bnbo_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'bnbo_prefiltered'"
+            ).fetchall()
+        ]
+        from ..stage0.bnbo_prefilter import BNBO_METADATA_COLS
+
+        available_meta = [c for c in BNBO_METADATA_COLS if c in bnbo_columns]
+        meta_select_b = "".join(f",\n                b.{c}" for c in available_meta)
+        self.log.info(f"📋 Carrying BNBO metadata columns: {available_meta}")
+
         # Step 1: Create 2-way field × BNBO intersections (Total BNBO in fields)
         self.log.info("📦 Step 1: Creating field_bnbo_intersections (2-way total BNBO)")
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE field_bnbo_intersections AS
             SELECT
                 f.field_uuid,
@@ -113,7 +127,7 @@ class FieldsBNBOWaterCoverage(FieldAnalysisStageBase):
                 f.cvr_number,
                 f.year,
                 b.bnbo_id,
-                b.status_category,
+                b.status_category{meta_select_b},
                 ST_Intersection(f.geometry, b.geometry) as field_bnbo_geometry
             FROM agricultural_fields f
             JOIN bnbo_prefiltered b ON ST_Intersects(f.geometry, b.geometry)
@@ -126,8 +140,20 @@ class FieldsBNBOWaterCoverage(FieldAnalysisStageBase):
         # ST_Intersects with bnbo_id from both tables triggers the buggy optimizer.
         self.log.info("📦 Step 2: Creating field_bnbo_water_intersections (3-way water-covered)")
 
+        # Build metadata column lists for water intersection queries
+        fbi_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'field_bnbo_intersections'"
+            ).fetchall()
+        ]
+        available_meta_fbi = [c for c in BNBO_METADATA_COLS if c in fbi_columns]
+        meta_select_fbi = "".join(f",\n                fbi.{c}" for c in available_meta_fbi)
+        meta_cols_plain = "".join(f", {c}" for c in available_meta_fbi)
+
         # Step 2a: Join on bnbo_id (no spatial predicate — avoids SPATIAL_JOIN optimizer)
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE field_bnbo_water_candidates AS
             SELECT
                 fbi.field_uuid,
@@ -136,7 +162,7 @@ class FieldsBNBOWaterCoverage(FieldAnalysisStageBase):
                 fbi.cvr_number,
                 fbi.year,
                 fbi.bnbo_id,
-                fbi.status_category,
+                fbi.status_category{meta_select_fbi},
                 wpbi.project_id,
                 fbi.field_bnbo_geometry,
                 wpbi.intersection_geometry
@@ -146,11 +172,11 @@ class FieldsBNBOWaterCoverage(FieldAnalysisStageBase):
         """)
 
         # Step 2b: Spatial filter and intersection (single-table, no SPATIAL_JOIN)
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE field_bnbo_water_intersections AS
             SELECT
                 field_uuid, field_id, block_id, cvr_number, year,
-                bnbo_id, status_category, project_id,
+                bnbo_id, status_category{meta_cols_plain}, project_id,
                 ST_Intersection(field_bnbo_geometry, intersection_geometry) as field_bnbo_water_geometry
             FROM field_bnbo_water_candidates
             WHERE ST_Intersects(field_bnbo_geometry, intersection_geometry)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/final_bnbo.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/final_bnbo.py
@@ -102,24 +102,39 @@ class FinalBNBOAnalysis(FieldAnalysisStageBase):
         self.log.info("✅ GEOMETRY ONLY - All area calculations moved to Stage 4")
         self.log.info("🔧 Using existing geometries from Stage 2A - No complex recalculations")
 
+        # Detect available BNBO metadata columns from stage2 output
+        fbi_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'field_bnbo_intersections'"
+            ).fetchall()
+        ]
+        from ..stage0.bnbo_prefilter import BNBO_METADATA_COLS
+
+        available_meta = [c for c in BNBO_METADATA_COLS if c in fbi_columns]
+        meta_select_fbi = "".join(f", fbi.{c}" for c in available_meta)
+        meta_cols_plain = "".join(f", {c}" for c in available_meta)
+        self.log.info(f"📋 Carrying BNBO metadata columns: {available_meta}")
+
         # Step 1: Create property × BNBO intersections (total BNBO within properties)
         # NOTE: Two-step join to work around DuckDB SPATIAL_JOIN bug where same-named
         # columns (field_uuid) on both sides cause "Failed to bind column reference".
         self.log.info("📦 Step 1: Creating property_bnbo_intersections")
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE _bnbo_candidates AS
             SELECT
                 p.field_uuid, p.bfe_number, p.property_geometry,
                 fbi.field_id, fbi.block_id, fbi.cvr_number, fbi.year,
-                fbi.bnbo_id, fbi.status_category, fbi.field_bnbo_geometry
+                fbi.bnbo_id, fbi.status_category{meta_select_fbi}, fbi.field_bnbo_geometry
             FROM field_property_intersections p
             JOIN field_bnbo_intersections fbi ON p.field_uuid = fbi.field_uuid
         """)
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE property_bnbo_intersections AS
             SELECT
                 field_uuid, bfe_number, field_id, block_id, cvr_number, year,
-                bnbo_id, status_category,
+                bnbo_id, status_category{meta_cols_plain},
                 TRY(ST_Intersection(property_geometry, field_bnbo_geometry)) as
                     property_bnbo_geometry
             FROM _bnbo_candidates
@@ -127,24 +142,36 @@ class FinalBNBOAnalysis(FieldAnalysisStageBase):
         """)
         self.conn.execute("DROP TABLE IF EXISTS _bnbo_candidates")
 
+        # Detect metadata in water intersection table
+        fbwi_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'stage3a_field_bnbo_water_intersections'"
+            ).fetchall()
+        ]
+        available_meta_water = [c for c in BNBO_METADATA_COLS if c in fbwi_columns]
+        meta_select_fbwi = "".join(f", fbwi.{c}" for c in available_meta_water)
+        meta_cols_water = "".join(f", {c}" for c in available_meta_water)
+
         # Step 2: Create property × BNBO × water intersections
         # (water-covered BNBO within properties)
         self.log.info("📦 Step 2: Creating property_bnbo_water_intersections")
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE _bnbo_water_candidates AS
             SELECT
                 p.field_uuid, p.bfe_number, p.property_geometry,
                 fbwi.field_id, fbwi.block_id, fbwi.cvr_number, fbwi.year,
-                fbwi.bnbo_id, fbwi.status_category, fbwi.project_id,
+                fbwi.bnbo_id, fbwi.status_category{meta_select_fbwi}, fbwi.project_id,
                 fbwi.field_bnbo_water_geometry
             FROM field_property_intersections p
             JOIN stage3a_field_bnbo_water_intersections fbwi ON p.field_uuid = fbwi.field_uuid
         """)
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE property_bnbo_water_intersections AS
             SELECT
                 field_uuid, bfe_number, field_id, block_id, cvr_number, year,
-                bnbo_id, status_category, project_id,
+                bnbo_id, status_category{meta_cols_water}, project_id,
                 TRY(ST_Intersection(property_geometry, field_bnbo_water_geometry)) as
                     property_bnbo_water_geometry
             FROM _bnbo_water_candidates

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage4/consolidate_two_tables.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage4/consolidate_two_tables.py
@@ -251,8 +251,28 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
         # FIXED: Pre-aggregate each intersection type separately to avoid Cartesian product
         self.log.info("🔧 PRE-AGGREGATING intersection data to prevent JOIN explosion...")
 
+        # Detect available BNBO metadata columns for date aggregation
+        fbi_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'field_bnbo_intersections'"
+            ).fetchall()
+        ]
+        has_datoaend = "datoaend" in fbi_columns
+        has_oprettet = "oprettet" in fbi_columns
+        date_agg_sql = ""
+        if has_datoaend:
+            date_agg_sql += """,
+                MIN(datoaend) as bnbo_earliest_status_change,
+                MAX(datoaend) as bnbo_latest_status_change"""
+        if has_oprettet:
+            date_agg_sql += """,
+                MIN(oprettet) as bnbo_earliest_created,
+                MAX(oprettet) as bnbo_latest_created"""
+
         # Pre-aggregate BNBO intersections by field
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE bnbo_field_aggregates AS
             SELECT
                 field_uuid,
@@ -265,7 +285,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                     as bnbo_action_required_hectares,
                 SUM(CASE WHEN status_category = 'Completed'
                     THEN ST_Area_Spheroid(field_bnbo_geometry) ELSE 0 END) / 10000.0
-                    as bnbo_completed_hectares
+                    as bnbo_completed_hectares{date_agg_sql}
             FROM field_bnbo_intersections
             GROUP BY field_uuid
         """)
@@ -350,8 +370,19 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
 
         self.log.info("✅ Pre-aggregation completed - no more Cartesian products!")
 
+        # Build date column references for the final field-level query
+        field_date_cols = ""
+        if has_datoaend:
+            field_date_cols += """
+                ba.bnbo_earliest_status_change,
+                ba.bnbo_latest_status_change,"""
+        if has_oprettet:
+            field_date_cols += """
+                ba.bnbo_earliest_created,
+                ba.bnbo_latest_created,"""
+
         # Create the final table using pre-aggregated data (NO CARTESIAN PRODUCT)
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE field_environmental_analysis_fields AS
             SELECT
                 f.field_uuid,
@@ -409,6 +440,8 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                 COALESCE(bwa.bnbo_completed_water_covered_hectares, 0) as
                     bnbo_completed_water_covered_hectares,
 
+                -- BNBO Date Analysis (from pre-aggregated data, if available)
+                {field_date_cols}
                 -- Wetland Analysis (using pre-aggregated data)
                 COALESCE(wa.field_wetland_total_m2, 0) as field_wetland_total_m2,
                 COALESCE(wwa.field_wetland_water_covered_m2, 0) as field_wetland_water_covered_m2,
@@ -502,8 +535,28 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
         # OPTIMIZATION: Pre-aggregate property intersection data to prevent JOIN explosion
         self.log.info("🔧 PRE-AGGREGATING property intersection data to prevent JOIN explosion...")
 
+        # Detect available BNBO metadata columns in property tables
+        pbi_columns = [
+            col[0]
+            for col in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'property_bnbo_intersections'"
+            ).fetchall()
+        ]
+        prop_has_datoaend = "datoaend" in pbi_columns
+        prop_has_oprettet = "oprettet" in pbi_columns
+        prop_date_agg_sql = ""
+        if prop_has_datoaend:
+            prop_date_agg_sql += """,
+                MIN(datoaend) as property_bnbo_earliest_status_change,
+                MAX(datoaend) as property_bnbo_latest_status_change"""
+        if prop_has_oprettet:
+            prop_date_agg_sql += """,
+                MIN(oprettet) as property_bnbo_earliest_created,
+                MAX(oprettet) as property_bnbo_latest_created"""
+
         # Pre-aggregate property BNBO intersections by (field_uuid, bfe_number)
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE property_bnbo_aggregates AS
             SELECT
                 field_uuid,
@@ -517,7 +570,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                     as property_bnbo_action_required_hectares,
                 SUM(CASE WHEN status_category = 'Completed'
                     THEN ST_Area_Spheroid(property_bnbo_geometry) ELSE 0 END) / 10000.0
-                    as property_bnbo_completed_hectares
+                    as property_bnbo_completed_hectares{prop_date_agg_sql}
             FROM property_bnbo_intersections
             GROUP BY field_uuid, bfe_number
         """)
@@ -576,9 +629,20 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
 
         self.log.info("✅ Property pre-aggregation completed - no more massive JOINs!")
 
+        # Build property date column references for the final query
+        prop_date_cols = ""
+        if prop_has_datoaend:
+            prop_date_cols += """
+                pba.property_bnbo_earliest_status_change,
+                pba.property_bnbo_latest_status_change,"""
+        if prop_has_oprettet:
+            prop_date_cols += """
+                pba.property_bnbo_earliest_created,
+                pba.property_bnbo_latest_created,"""
+
         # Create the final table using pre-aggregated data (NO CARTESIAN PRODUCT)
         # NOTE: fp.intersection_geometry is stored as native GEOMETRY type (verified in GCS)
-        self.conn.execute("""
+        self.conn.execute(f"""
             CREATE OR REPLACE TABLE field_environmental_analysis_properties AS
             SELECT
                 fp.field_uuid,
@@ -609,6 +673,7 @@ class ConsolidateResultsTwoTables(FieldAnalysisStageBase):
                 COALESCE(pbwa.property_bnbo_completed_water_covered_hectares, 0)
                     as property_bnbo_completed_water_covered_hectares,
 
+                {prop_date_cols}
                 -- Grukos Analysis (groundwater action areas - indsatsområder)
                 COALESCE(pga.property_grukos_total_m2, 0) as property_grukos_total_m2
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/bnbo_status.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/bnbo_status.py
@@ -419,6 +419,22 @@ class BNBOStatusSilver(BaseSource[BNBOStatusSilverConfig], SilverJobInterface):
         feature_count = self.conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]
         self.log.info(f"Created DuckDB table '{table_name}' with {feature_count:,} features")
 
+        # Cast date columns from VARCHAR to TIMESTAMP for proper typing
+        date_columns = ["datoaend", "oprettet", "systid_fra", "systid_til"]
+        existing_columns = [
+            col[0]
+            for col in self.conn.execute(
+                f"SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}'"
+            ).fetchall()
+        ]
+        for col in date_columns:
+            if col in existing_columns:
+                self.conn.execute(f"""
+                    ALTER TABLE {table_name} ALTER COLUMN {col}
+                    SET DATA TYPE TIMESTAMP USING TRY_CAST({col} AS TIMESTAMP)
+                """)
+                self.log.info(f"Cast column '{col}' to TIMESTAMP")
+
         # Clean up temporary table
         self.conn.execute("DROP TABLE IF EXISTS bnbo_features_raw")
 


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- Switched field-area analysis BNBO input from dissolved BNBO to feature-level `bnbo_status` so per-feature metadata is preserved.
- Carried BNBO metadata columns through Stage 0-3 joins and added optional date aggregations (`datoaend`, `oprettet`) into Stage 4 field/property outputs.
- Cast BNBO date fields to `TIMESTAMP` in silver processing to support consistent downstream MIN/MAX date aggregations.

## ✅ How to Do Self-Test
- `source venv/bin/activate`
- `python -m py_compile backend/pipelines/unified_pipeline/src/unified_pipeline/silver/bnbo_status.py backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/*.py backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage0/*.py backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage1/*.py backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage2/*.py backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage3/*.py backend/pipelines/unified_pipeline/src/unified_pipeline/gold/field_area_analysis/stage4/*.py`
- Run unified pipeline stages that produce `field_environmental_analysis_fields` and `field_environmental_analysis_properties`, then verify BNBO date columns are present when source columns exist.

## 📷 Screenshots (if applicable)
- Not applicable (backend pipeline changes)

## 📝 Additional Notes
- Metadata/date propagation is schema-aware: queries only select/aggregate columns that actually exist in upstream tables.
