### PR TITLE
fix(frontend): sidebar empty space, scroll-to-field & auto-expand

### DIFF
--- a/frontend/src/components/pesticidkort/DesktopSidebar.tsx
+++ b/frontend/src/components/pesticidkort/DesktopSidebar.tsx
@@ -8,7 +8,7 @@ interface DesktopSidebarProps {
 export function DesktopSidebar({ children, controls }: DesktopSidebarProps) {
   return (
     <div className="pointer-events-none absolute inset-y-0 right-0 hidden w-[420px] md:block">
-      <div className="bg-background/95 pointer-events-auto flex h-full flex-col border-l pt-14 backdrop-blur-sm">
+      <div className="bg-background/95 pointer-events-auto flex h-full flex-col border-l backdrop-blur-sm">
         <div
           className="flex-1 overflow-y-auto"
           role="region"

--- a/frontend/src/components/pesticidkort/FieldCard.tsx
+++ b/frontend/src/components/pesticidkort/FieldCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { ChevronDown } from 'lucide-react';
 import type { NearbyFieldSummary } from '@/components/pesticidkort/types';
@@ -37,12 +37,10 @@ export function FieldCard({
     field.glyphosate_products_detail ||
     field.other_products_detail;
 
-  const prevSelectedRef = useRef(isSelected);
   useEffect(() => {
-    if (isSelected && !prevSelectedRef.current && hasProducts) {
+    if (isSelected && hasProducts) {
       setExpanded(true);
     }
-    prevSelectedRef.current = isSelected;
   }, [isSelected, hasProducts]);
 
   return (

--- a/frontend/src/components/pesticidkort/FieldList.tsx
+++ b/frontend/src/components/pesticidkort/FieldList.tsx
@@ -49,20 +49,14 @@ export function FieldList({
     );
     if (idx >= INITIAL_VISIBLE && !showAll) {
       setShowAll(true);
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          document
-            .getElementById(selectedFieldUuid)
-            ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        });
-      });
-      return;
     }
-    requestAnimationFrame(() => {
+    // Allow DOM to settle (expand animation, show-all list) before scrolling
+    const timer = setTimeout(() => {
       document
         .getElementById(selectedFieldUuid)
-        ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-    });
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 80);
+    return () => clearTimeout(timer);
   }, [selectedFieldUuid, sortedFields, showAll]);
 
   return (


### PR DESCRIPTION
## Summary
- **Remove empty rectangle** at top of desktop sidebar (`pt-14` padding was clearing a header that doesn't overlap the sidebar)
- **Scroll to selected field** — use `block:'center'` with 80ms delay so the selected card is reliably centered in the sidebar
- **Auto-expand accordion** — simplify to always expand when selected, removing fragile ref-based transition detection

## Test plan
- [ ] Open pesticidkort report view on desktop — no empty space at top of sidebar
- [ ] Click a field on the map — sidebar scrolls to center the field card
- [ ] Clicked field card auto-expands its pesticide products section

🤖 Generated with [Claude Code](https://claude.com/claude-code)