### PR TITLE
fix(frontend): reliable scroll-to-field for hidden fields

### DIFF
--- a/frontend/src/components/pesticidkort/FieldList.tsx
+++ b/frontend/src/components/pesticidkort/FieldList.tsx
@@ -49,14 +49,22 @@ export function FieldList({
     );
     if (idx >= INITIAL_VISIBLE && !showAll) {
       setShowAll(true);
+      return; // re-run after showAll flips and DOM has the element
     }
-    // Allow DOM to settle (expand animation, show-all list) before scrolling
-    const timer = setTimeout(() => {
-      document
-        .getElementById(selectedFieldUuid)
-        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }, 80);
-    return () => clearTimeout(timer);
+    // Poll until the element is in the DOM (handles expand + motion animation)
+    let frame: number;
+    let attempts = 0;
+    const tryScroll = () => {
+      const el = document.getElementById(selectedFieldUuid);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      } else if (attempts < 10) {
+        attempts++;
+        frame = requestAnimationFrame(tryScroll);
+      }
+    };
+    frame = requestAnimationFrame(tryScroll);
+    return () => cancelAnimationFrame(frame);
   }, [selectedFieldUuid, sortedFields, showAll]);
 
   return (


### PR DESCRIPTION
## Summary
- **Early return** after `setShowAll(true)` so the effect re-runs once the hidden fields are actually in the DOM
- **RAF retry loop** (up to 10 frames) replaces the blind 80ms timeout — polls until the element exists, then scrolls with `block: 'center'`
- Fixes scroll failing for fields behind the "Vis alle X marker" button

## Test plan
- [ ] Click a field on the map that's beyond the first 5 in the sidebar list
- [ ] Verify the "Vis alle" section expands and the card scrolls into view
- [ ] Verify fields in the initial 5 still scroll correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)