### PR TITLE
feat(frontend): neutral pesticidkort labels & explore field details panel

### DIFF
--- a/frontend/src/components/pesticidkort/ExploreFieldPanel.tsx
+++ b/frontend/src/components/pesticidkort/ExploreFieldPanel.tsx
@@ -47,12 +47,12 @@ export function ExploreFieldPanel({ field, onClose }: ExploreFieldPanelProps) {
 
       <div className="mb-3 flex flex-wrap items-center gap-2">
         {field.is_organic && (
-          <span className="bg-success/10 text-success rounded-full px-2 py-0.5 text-[10px] font-medium">
+          <span className="bg-success/10 text-success rounded-full px-1.5 py-0.5 text-[10px] leading-none font-medium">
             Økologisk
           </span>
         )}
         {hasPfas && (
-          <span className="bg-warning/10 text-warning rounded-full px-2 py-0.5 text-[10px] font-medium">
+          <span className="bg-warning/10 text-warning rounded-full px-1.5 py-0.5 text-[10px] leading-none font-medium">
             PFAS
           </span>
         )}

--- a/frontend/src/components/pesticidkort/ExploreFieldPanel.tsx
+++ b/frontend/src/components/pesticidkort/ExploreFieldPanel.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { X } from 'lucide-react';
+import type { NearbyFieldSummary } from '@/components/pesticidkort/types';
+import {
+  getCropEmoji,
+  formatBurden,
+} from '@/components/pesticidkort/field-utils';
+import {
+  FieldProximity,
+  FieldProducts,
+} from '@/components/pesticidkort/FieldCardDetails';
+
+interface ExploreFieldPanelProps {
+  field: NearbyFieldSummary;
+  onClose: () => void;
+}
+
+export function ExploreFieldPanel({ field, onClose }: ExploreFieldPanelProps) {
+  const burden = field.total_pesticide_belastning;
+  const hasPfas = field.pfas_applications > 0;
+
+  return (
+    <div
+      data-testid="explore-field-panel"
+      className="bg-background/95 absolute inset-x-0 bottom-0 z-30 max-h-[60vh] overflow-y-auto rounded-t-2xl px-4 pt-4 pb-6 shadow-lg backdrop-blur-sm md:inset-x-auto md:top-48 md:right-4 md:bottom-auto md:max-h-[calc(100vh-13rem)] md:w-80 md:rounded-xl"
+    >
+      <div className="mb-3 flex items-start justify-between">
+        <div>
+          <p className="text-foreground text-sm font-medium">
+            {getCropEmoji(field.crop_name)} {field.crop_name}
+          </p>
+          <p className="text-muted-foreground text-xs">
+            {field.area_hectares.toFixed(1)} ha
+            {field.kommune ? ` · ${field.kommune}` : ''}
+          </p>
+        </div>
+        <button
+          onClick={onClose}
+          data-testid="explore-field-panel-close-button"
+          aria-label="Luk"
+          className="text-muted-foreground hover:text-foreground -mt-1 -mr-1 p-1"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        {field.is_organic && (
+          <span className="bg-success/10 text-success rounded-full px-2 py-0.5 text-[10px] font-medium">
+            Økologisk
+          </span>
+        )}
+        {hasPfas && (
+          <span className="bg-warning/10 text-warning rounded-full px-2 py-0.5 text-[10px] font-medium">
+            PFAS
+          </span>
+        )}
+        <span className="text-muted-foreground text-xs tabular-nums">
+          {burden > 0 ? formatBurden(burden) : 'Ingen pesticider'}
+        </span>
+      </div>
+
+      <FieldProximity field={field} />
+      <FieldProducts field={field} />
+    </div>
+  );
+}

--- a/frontend/src/components/pesticidkort/ExploreMapInner.tsx
+++ b/frontend/src/components/pesticidkort/ExploreMapInner.tsx
@@ -12,6 +12,11 @@ import {
 } from '@/components/pesticidkort/map-layers';
 import type { ChemicalFilter } from '@/components/pesticidkort/map-layers';
 import { registerPmtilesProtocol } from '@/components/pesticidkort/pmtiles-protocol';
+import { setupFieldClickHandlers } from '@/components/pesticidkort/map-events';
+import { highlightField } from '@/components/pesticidkort/map-highlight';
+import { FieldHoverTooltip } from '@/components/pesticidkort/FieldHoverTooltip';
+import { useFieldHover } from '@/components/pesticidkort/useFieldHover';
+import type { NearbyFieldSummary } from '@/components/pesticidkort/types';
 import type { MapInstance } from '@/components/field-analysis/map-constants';
 
 const DENMARK_CENTER = { longitude: 10.4, latitude: 56.0 };
@@ -21,18 +26,25 @@ interface ExploreMapInnerProps {
   year: number;
   activeFilter?: ChemicalFilter;
   onZoomChange?: (zoom: number) => void;
+  onFieldClick?: (fieldUuid: string, fieldData: NearbyFieldSummary) => void;
+  selectedFieldUuid?: string | null;
 }
 
 export function ExploreMapInner({
   year,
   activeFilter = 'none',
   onZoomChange,
+  onFieldClick,
+  selectedFieldUuid,
 }: ExploreMapInnerProps) {
   const { mapStyle } = useMapTheme();
   const mapRef = useRef<MapRef>(null);
   const [pmtilesUrl, setPmtilesUrl] = useState<string | null>(null);
   const [overviewUrl, setOverviewUrl] = useState<string | null>(null);
   const [mapReady, setMapReady] = useState(false);
+  const { hoverData, attachHover } = useFieldHover();
+  const onFieldClickRef = useRef(onFieldClick);
+  onFieldClickRef.current = onFieldClick;
 
   useEffect(() => {
     pmtilesCacheService.getFieldAnalysisUrls(year).then((urls) => {
@@ -52,7 +64,10 @@ export function ExploreMapInner({
     if (overviewUrl)
       addOverviewLayers(map as unknown as MapInstance, overviewUrl);
     setMapReady(true);
-  }, [pmtilesUrl, overviewUrl]);
+
+    setupFieldClickHandlers(map, 0, 0, onFieldClickRef);
+    attachHover(map);
+  }, [pmtilesUrl, overviewUrl, attachHover]);
 
   useEffect(() => {
     if (!mapRef.current || !pmtilesUrl) return;
@@ -69,14 +84,17 @@ export function ExploreMapInner({
     if (overviewUrl) setSourceUrl('fields-overview', overviewUrl);
   }, [pmtilesUrl, overviewUrl]);
 
-  // Apply chemical filter when it changes
   useEffect(() => {
     if (!mapRef.current || !mapReady) return;
     const map = mapRef.current.getMap() as unknown as MapInstance;
     applyChemicalFilter(map, activeFilter);
   }, [activeFilter, mapReady]);
 
-  // Track zoom level
+  useEffect(() => {
+    if (!mapReady) return;
+    highlightField(mapRef.current, selectedFieldUuid ?? null);
+  }, [selectedFieldUuid, mapReady]);
+
   const handleZoom = useCallback(() => {
     if (!mapRef.current || !onZoomChange) return;
     onZoomChange(mapRef.current.getMap().getZoom());
@@ -85,20 +103,23 @@ export function ExploreMapInner({
   if (!pmtilesUrl) return null;
 
   return (
-    <Map
-      ref={mapRef}
-      initialViewState={{
-        longitude: DENMARK_CENTER.longitude,
-        latitude: DENMARK_CENTER.latitude,
-        zoom: DENMARK_ZOOM,
-      }}
-      mapStyle={mapStyle}
-      onLoad={handleMapLoad}
-      onZoom={handleZoom}
-      attributionControl={false}
-      data-testid="explore-map"
-    >
-      <NavigationControl position="top-right" />
-    </Map>
+    <>
+      <Map
+        ref={mapRef}
+        initialViewState={{
+          longitude: DENMARK_CENTER.longitude,
+          latitude: DENMARK_CENTER.latitude,
+          zoom: DENMARK_ZOOM,
+        }}
+        mapStyle={mapStyle}
+        onLoad={handleMapLoad}
+        onZoom={handleZoom}
+        attributionControl={false}
+        data-testid="explore-map"
+      >
+        <NavigationControl position="top-right" />
+      </Map>
+      {hoverData && <FieldHoverTooltip {...hoverData} />}
+    </>
   );
 }

--- a/frontend/src/components/pesticidkort/ExploreMapView.tsx
+++ b/frontend/src/components/pesticidkort/ExploreMapView.tsx
@@ -7,8 +7,12 @@ import { YearTimeline } from '@/components/pesticidkort/YearTimeline';
 import { MapLegend } from '@/components/pesticidkort/MapLegend';
 import { MapOnboardingHint } from '@/components/pesticidkort/MapOnboardingHint';
 import { ChemicalFilterPills } from '@/components/pesticidkort/ChemicalFilterPills';
+import { ExploreFieldPanel } from '@/components/pesticidkort/ExploreFieldPanel';
 import type { ChemicalFilter } from '@/components/pesticidkort/map-layers';
-import type { AddressResult } from '@/components/pesticidkort/types';
+import type {
+  AddressResult,
+  NearbyFieldSummary,
+} from '@/components/pesticidkort/types';
 
 const ExploreMap = dynamic(
   () =>
@@ -45,12 +49,22 @@ export function ExploreMapView({
   const [searchOpen, setSearchOpen] = useState(true);
   const [chemFilter, setChemFilter] = useState<ChemicalFilter>('none');
   const [zoomLevel, setZoomLevel] = useState(7);
+  const [selectedField, setSelectedField] = useState<NearbyFieldSummary | null>(
+    null
+  );
 
   const handleSelect = useCallback(
     (result: AddressResult) => {
       onAddressSelect(result);
     },
     [onAddressSelect]
+  );
+
+  const handleFieldClick = useCallback(
+    (_uuid: string, data: NearbyFieldSummary) => {
+      setSelectedField(data);
+    },
+    []
   );
 
   return (
@@ -60,6 +74,8 @@ export function ExploreMapView({
           year={year}
           activeFilter={chemFilter}
           onZoomChange={setZoomLevel}
+          onFieldClick={handleFieldClick}
+          selectedFieldUuid={selectedField?.field_uuid ?? null}
         />
       </div>
 
@@ -103,6 +119,13 @@ export function ExploreMapView({
           />
         </div>
       </div>
+
+      {selectedField && (
+        <ExploreFieldPanel
+          field={selectedField}
+          onClose={() => setSelectedField(null)}
+        />
+      )}
     </main>
   );
 }

--- a/frontend/src/components/pesticidkort/PesticideProximityScore.tsx
+++ b/frontend/src/components/pesticidkort/PesticideProximityScore.tsx
@@ -91,8 +91,8 @@ export function PesticideProximityScore({
         })}
       </div>
       <div className="text-muted-foreground mt-1.5 flex justify-between text-[10px]">
-        <span>A (tryg)</span>
-        <span>E (farlig)</span>
+        <span>A (lavest)</span>
+        <span>E (højest)</span>
       </div>
     </div>
   );

--- a/frontend/src/components/pesticidkort/useFieldHover.ts
+++ b/frontend/src/components/pesticidkort/useFieldHover.ts
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import type { FieldHoverData } from '@/components/pesticidkort/types';
 import { setupFieldHoverHandlers } from '@/components/pesticidkort/map-events';
 import type { Map as MaplibreMap } from 'maplibre-gl';
@@ -8,9 +8,9 @@ export function useFieldHover() {
   const hoverRef = useRef(setHoverData);
   hoverRef.current = setHoverData;
 
-  const attachHover = (map: MaplibreMap) => {
+  const attachHover = useCallback((map: MaplibreMap) => {
     setupFieldHoverHandlers(map, hoverRef);
-  };
+  }, []);
 
   return { hoverData, attachHover };
 }

--- a/frontend/src/lib/pesticide-score.ts
+++ b/frontend/src/lib/pesticide-score.ts
@@ -27,27 +27,27 @@ const GRADE_THRESHOLDS: { max: number; grade: PesticideGrade }[] = [
 
 const GRADE_DEFINITIONS: Record<PesticideGrade, Omit<GradeInfo, 'grade'>> = {
   A: {
-    label: 'Meget lav eksponering',
+    label: 'Meget under landsgennemsnit',
     description:
       'Der sprøjtes markant mindre med pesticider nær din adresse end de fleste steder i Danmark',
   },
   B: {
-    label: 'Lav eksponering',
+    label: 'Under landsgennemsnit',
     description:
       'Der sprøjtes mindre med pesticider nær din adresse end landsgennemsnittet',
   },
   C: {
-    label: 'Moderat eksponering',
+    label: 'Omkring landsgennemsnit',
     description:
       'Pesticidbrugen nær din adresse svarer til et typisk dansk landbrugsområde',
   },
   D: {
-    label: 'Høj eksponering',
+    label: 'Over landsgennemsnit',
     description:
       'Der sprøjtes mere med pesticider nær din adresse end landsgennemsnittet',
   },
   E: {
-    label: 'Meget høj eksponering',
+    label: 'Meget over landsgennemsnit',
     description:
       'Der sprøjtes markant mere med pesticider nær din adresse end de fleste steder i Danmark',
   },


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- Replace subjective pesticidkort scale labels with neutral, data-anchored terms verified against Bekæmpelsesmiddelstatistik 2023 (Miljøstyrelsen, April 2025):
  - Grade labels: "Meget lav/høj eksponering" → "Meget under/over landsgennemsnit" (anchored to national avg 2,15 B/ha)
  - Scale endpoints: "tryg"/"farlig" → "lavest"/"højest"
- Add field click support to the explore map view with a floating detail panel showing crop info, burden, proximity data and pesticide products (reuses existing `FieldProximity`, `FieldProducts`, hover tooltip, and highlight utilities from the report view)

## ✅ How to Do Self-Test
1. `cd frontend && npm run lint && npm run test:smoke`
2. Visit `/pesticidkort` → search an address → verify proximity score shows "Under landsgennemsnit" style labels and scale shows "A (lavest)" / "E (højest)"
3. Visit `/pesticidkort` → click "Udforsk kort" → zoom into fields → click a field → verify detail panel appears with crop name, burden, proximity info, and pesticide products. Click another field to switch. Close with X button.

## 📝 Additional Notes
Grade thresholds verified against official Miljøstyrelsen data (Tabel 7.3 & 8.3, Bekæmpelsesmiddelstatistik 2023). National average fladebelastning: 2,15 B/ha.