### PR TITLE
fix(pipeline): widen UTM bounds to include Bornholm

### DIFF
--- a/backend/common/crs_utils.py
+++ b/backend/common/crs_utils.py
@@ -47,7 +47,7 @@ DENMARK_BOUNDS_WGS84 = {
 
 DENMARK_BOUNDS_UTM = {
     "min_x": 400000,  # min easting
-    "max_x": 900000,  # max easting
+    "max_x": 950000,  # max easting (includes Bornholm ~915k in UTM 32N)
     "min_y": 6000000,  # min northing
     "max_y": 6500000,  # max northing
 }

--- a/backend/common/tests/test_crs_utils.py
+++ b/backend/common/tests/test_crs_utils.py
@@ -74,7 +74,7 @@ class TestDenmarkBounds:
         """UTM bounds should represent Denmark's projected extent."""
         # Easting values for UTM Zone 32N in Denmark
         assert DENMARK_BOUNDS_UTM["min_x"] == 400000
-        assert DENMARK_BOUNDS_UTM["max_x"] == 900000
+        assert DENMARK_BOUNDS_UTM["max_x"] == 950000
         # Northing values for UTM Zone 32N in Denmark
         assert DENMARK_BOUNDS_UTM["min_y"] == 6000000
         assert DENMARK_BOUNDS_UTM["max_y"] == 6500000
@@ -167,6 +167,13 @@ class TestDetectCRSFromBounds:
         """Should detect UTM Zone 32N for Danish easting/northing coordinates."""
         # Copenhagen in UTM: easting ~723626, northing ~6176067
         crs, order = detect_crs_from_bounds(500000, 800000, 6100000, 6400000)
+        assert crs == DANISH_UTM
+        assert order == "easting_northing"
+
+    def test_detect_utm_bornholm_area(self):
+        """Should detect UTM Zone 32N for Bornholm-area coordinates (easting >900k)."""
+        # Bornholm projects to ~915k easting in UTM 32N
+        crs, order = detect_crs_from_bounds(419288, 915280, 6037373, 6424480)
         assert crs == DANISH_UTM
         assert order == "easting_northing"
 


### PR DESCRIPTION
## Summary

- Increases `DENMARK_BOUNDS_UTM["max_x"]` from 900,000 to 950,000 in `backend/common/crs_utils.py`
- Fixes CRS detection failure for water typology data containing Bornholm-area features (~915k easting in UTM 32N)
- Adds test case for Bornholm-range coordinates

## Context

The pesticide proximity pipeline [failed in CI](https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/24275510052/job/70888623980) with:
```
Cannot detect CRS for data_water_typology_silver.ST_GeomFromText(geometry)
from bounds: X=[419288.043, 915280.698], Y=[6037373.400, 6424480.935]
```

Bornholm (~15°E) is east of UTM Zone 32N's natural range (6-12°E) but Denmark officially uses EPSG:25832 for all territory. Projecting Bornholm into Zone 32N produces valid eastings up to ~920k, exceeding the previous 900k cap.

## Test plan

- [x] Verified fix detects the exact failing bounds as EPSG:25832
- [x] Verified existing WGS84 and normal UTM detection still works
- [ ] CI should pass the pesticide proximity pipeline for year 2024

🤖 Generated with [Claude Code](https://claude.com/claude-code)