### PR TITLE
fix(pipeline): replace ST_SRID with bounds-based CRS detection

### DIFF
--- a/backend/common/crs_utils.py
+++ b/backend/common/crs_utils.py
@@ -47,7 +47,7 @@ DENMARK_BOUNDS_WGS84 = {
 
 DENMARK_BOUNDS_UTM = {
     "min_x": 400000,  # min easting
-    "max_x": 900000,  # max easting
+    "max_x": 950000,  # max easting (includes Bornholm ~915k in UTM 32N)
     "min_y": 6000000,  # min northing
     "max_y": 6500000,  # max northing
 }

--- a/backend/common/tests/test_crs_utils.py
+++ b/backend/common/tests/test_crs_utils.py
@@ -74,7 +74,7 @@ class TestDenmarkBounds:
         """UTM bounds should represent Denmark's projected extent."""
         # Easting values for UTM Zone 32N in Denmark
         assert DENMARK_BOUNDS_UTM["min_x"] == 400000
-        assert DENMARK_BOUNDS_UTM["max_x"] == 900000
+        assert DENMARK_BOUNDS_UTM["max_x"] == 950000
         # Northing values for UTM Zone 32N in Denmark
         assert DENMARK_BOUNDS_UTM["min_y"] == 6000000
         assert DENMARK_BOUNDS_UTM["max_y"] == 6500000
@@ -167,6 +167,13 @@ class TestDetectCRSFromBounds:
         """Should detect UTM Zone 32N for Danish easting/northing coordinates."""
         # Copenhagen in UTM: easting ~723626, northing ~6176067
         crs, order = detect_crs_from_bounds(500000, 800000, 6100000, 6400000)
+        assert crs == DANISH_UTM
+        assert order == "easting_northing"
+
+    def test_detect_utm_bornholm_area(self):
+        """Should detect UTM Zone 32N for Bornholm-area coordinates (easting >900k)."""
+        # Bornholm projects to ~915k easting in UTM 32N
+        crs, order = detect_crs_from_bounds(419288, 915280, 6037373, 6424480)
         assert crs == DANISH_UTM
         assert order == "easting_northing"
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_drift_exposure.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_drift_exposure.py
@@ -29,6 +29,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from common.crs_utils import (
+    DANISH_UTM,
+    detect_crs_from_bounds,
+    sql_transform_to_processing_crs,
+)
 from loguru import logger
 from pydantic import ConfigDict, Field
 from tqdm import tqdm
@@ -311,27 +316,40 @@ class PesticideDriftExposureGold(BaseSource[PesticideDriftExposureGoldConfig], G
         bldg_table = f"data_{self.config.buildings_dataset}_silver"
         radius = self.config.drift_search_radius_m
 
-        # Detect field geometry CRS and transform to EPSG:25832 if needed
-        field_srid = self.conn.execute(
-            f"SELECT ST_SRID(geometry) FROM {field_table} WHERE geometry IS NOT NULL LIMIT 1"
+        # Detect field geometry CRS via bounds and transform to EPSG:25832 if needed
+        # Note: DuckDB spatial has no ST_SRID — use bounds-based detection from crs_utils
+        field_bounds = self.conn.execute(
+            f"""SELECT MIN(ST_XMin(geometry)), MAX(ST_XMax(geometry)),
+                       MIN(ST_YMin(geometry)), MAX(ST_YMax(geometry))
+                FROM {field_table} WHERE geometry IS NOT NULL"""
         ).fetchone()
-        field_srid = field_srid[0] if field_srid else 0
-        if field_srid in (0, 25832):
+        if field_bounds and field_bounds[0] is not None:
+            field_crs, _ = detect_crs_from_bounds(*field_bounds)
+        else:
+            field_crs = DANISH_UTM
+        if field_crs == DANISH_UTM or field_crs is None:
             field_geom_expr = "f.geometry"
         else:
-            field_geom_expr = f"ST_Transform(f.geometry, 'EPSG:{field_srid}', 'EPSG:25832')"
-            self.log.info(f"🔄 Field geometry is EPSG:{field_srid}, transforming to EPSG:25832")
+            field_geom_expr = sql_transform_to_processing_crs("f.geometry", field_crs)
+            self.log.info(f"🔄 Field geometry detected as {field_crs}, transforming to EPSG:25832")
 
-        # Detect building geometry CRS and transform to EPSG:25832 if needed
-        bldg_srid = self.conn.execute(
-            f"SELECT ST_SRID(geometry) FROM {bldg_table} WHERE geometry IS NOT NULL LIMIT 1"
+        # Detect building geometry CRS via bounds and transform to EPSG:25832 if needed
+        bldg_bounds = self.conn.execute(
+            f"""SELECT MIN(ST_XMin(geometry)), MAX(ST_XMax(geometry)),
+                       MIN(ST_YMin(geometry)), MAX(ST_YMax(geometry))
+                FROM {bldg_table} WHERE geometry IS NOT NULL"""
         ).fetchone()
-        bldg_srid = bldg_srid[0] if bldg_srid else 0
-        if bldg_srid in (0, 25832):
+        if bldg_bounds and bldg_bounds[0] is not None:
+            bldg_crs, _ = detect_crs_from_bounds(*bldg_bounds)
+        else:
+            bldg_crs = DANISH_UTM
+        if bldg_crs == DANISH_UTM or bldg_crs is None:
             bldg_geom_expr = "geometry"
         else:
-            bldg_geom_expr = f"ST_Transform(geometry, 'EPSG:{bldg_srid}', 'EPSG:25832')"
-            self.log.info(f"🔄 Building geometry is EPSG:{bldg_srid}, transforming to EPSG:25832")
+            bldg_geom_expr = sql_transform_to_processing_crs("geometry", bldg_crs)
+            self.log.info(
+                f"🔄 Building geometry detected as {bldg_crs}, transforming to EPSG:25832"
+            )
 
         # Step 1: Create field centroids with pesticide data
         self.conn.execute(f"""


### PR DESCRIPTION
## Summary

- Replaces two `ST_SRID()` calls in `pesticide_drift_exposure.py` with bounds-based CRS detection from `crs_utils`
- `ST_SRID()` is a PostGIS function that **does not exist** in DuckDB's spatial extension
- Uses the same `detect_crs_from_bounds()` pattern already proven in `pesticide_proximity.py`

## Context

After merging #923 (Bornholm bounds fix), the pipeline hit a second error:
```
CatalogException: Scalar Function with name st_srid does not exist!
Did you mean "st_setcrs"?
```

DuckDB geometries don't carry SRID metadata — CRS must be inferred from coordinate bounds.

## Test plan

- [x] No `ST_SRID` calls remain in the codebase (verified via grep)
- [x] Linting passes
- [ ] CI pesticide pipeline passes for all years

🤖 Generated with [Claude Code](https://claude.com/claude-code)