### PR TITLE
fix(unified_pipeline): add shapely as explicit dependency

### DIFF
--- a/backend/pipelines/unified_pipeline/pyproject.toml
+++ b/backend/pipelines/unified_pipeline/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "beautifulsoup4>=4.13.4",
     "scikit-learn>=1.3.0",
     "scipy>=1.11.0",
+    "shapely>=2.0.0",
     "tabulate>=0.9.0",
     "landbruget-common",
     "requests>=2.32.0",


### PR DESCRIPTION
## Summary
- Adds `shapely>=2.0.0` to `backend/pipelines/unified_pipeline/pyproject.toml`
- Fixes `ModuleNotFoundError: No module named 'shapely'` that has broken Field Production Matrix and Pesticide Drift Exposure since ~April 6

## Root cause
shapely was previously pulled in transitively. Recent dependency bumps dropped it. `backend/pipelines/unified_pipeline/src/unified_pipeline/silver/jordbrugsanalyser.py:23` does `from shapely import wkt`, so pipeline startup fails on any workflow that installs this package.

## Scope
One-line dep addition. No other changes. Unblocks Monday's cron.

## Test plan
- [ ] After merge, re-fire Field Production Matrix (`all` years) — confirm no import error
- [ ] After merge, re-fire Pesticide Drift Exposure (`all` years) — confirm no import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)