### PR TITLE
fix(h3_pfas): tag kommune geometry as EPSG:25832 when loaded from silver

### DIFF
--- a/backend/pipelines/h3_pfas_exposure_pipeline/src/h3_pfas_exposure/gold/processor.py
+++ b/backend/pipelines/h3_pfas_exposure_pipeline/src/h3_pfas_exposure/gold/processor.py
@@ -864,7 +864,10 @@ class H3PFASProcessorRefactored:
                     # Use StorageAccess to create table directly from cloud storage
                     storage_access.create_table_from_storage("silver_kommuner_raw", latest_file)
 
-                    # Create the kommune_boundaries table from silver data
+                    # Create the kommune_boundaries table from silver data.
+                    # silver/dagi_kommuner parquet has EPSG:25832 coordinates but no CRS
+                    # in GeoParquet metadata, so DuckDB tags it OGC:CRS84. Use ST_SetCRS
+                    # to relabel without transforming — the numeric coords are already UTM.
                     self.conn.execute(f"""
                         CREATE OR REPLACE TABLE {kommune_table} AS
                         SELECT
@@ -872,9 +875,9 @@ class H3PFASProcessorRefactored:
                             name as kommune_name,
                             CAST(region_code AS INTEGER) as region_code,
                             'Unknown Region' as region_name,  -- Silver data might not have region name
-                            geometry,
+                            ST_SetCRS(geometry, 'EPSG:25832') as geometry,
                             area_m2 / 10000.0 as kommune_area_ha,
-                            ST_Centroid(geometry) as centroid
+                            ST_Centroid(ST_SetCRS(geometry, 'EPSG:25832')) as centroid
                         FROM silver_kommuner_raw
                         WHERE geometry IS NOT NULL
                     """)


### PR DESCRIPTION
## Summary
Fixes the CRS-mismatch binder error that has been failing every year of the H3 PFAS Exposure Analysis combined-analysis step. Kommune silver geometry ends up tagged `OGC:CRS84` despite actually being in UTM, so `ST_Intersects(field, kommune)` rejects the join.

## Root cause
`silver/dagi_kommuner/*/data.parquet` stores geometries with EPSG:25832 coordinates (verified: bbox ≈ 442k–893k / 6.05M–6.4M) but the GeoParquet `geo` metadata has no `crs` block. DuckDB 1.5 therefore labels reads as `OGC:CRS84`. Field geometries from `silver/fvm_marker_*` do declare EPSG:25832. The resulting `ST_Intersects(f.geometry, k.geometry)` fails the binder with:

> Cannot call function 'ST_Intersects' with geometries of different coordinate reference systems (CRS). First geometry type is in 'EPSG:25832' which is not compatible with 'OGC:CRS84'.

## Fix
In `H3PFASProcessorRefactored._load_kommune_boundaries`, wrap the silver geometry with `ST_SetCRS(geometry, 'EPSG:25832')` when creating `kommune_boundaries`. This is a label-only correction — no transform is performed, and the numeric UTM coordinates are preserved. The derived centroid uses the same wrapped expression so it's tagged consistently.

Verified locally against R2 data: same 1000-row fvm + full kommune set → `ST_Intersects` join now returns 1014 intersections instead of erroring.

## Out of scope / follow-up
Fixing the root issue (missing CRS in silver/dagi_kommuner GeoParquet metadata) is a silver-layer concern and belongs in a separate PR touching the bronze→silver dagi processor.

## Test plan
- [ ] After merge, re-fire `H3 PFAS Exposure Analysis` with `include_kommune=true` — confirm no binder error, kommune results written to gold

🤖 Generated with [Claude Code](https://claude.com/claude-code)