### PR TITLE
fix(pesticidkort): redesign mobile year picker as scroll-snap chip strip

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -551,4 +551,14 @@
       color 0.3s ease,
       border-color 0.3s ease;
   }
+
+  /* Pesticidkort explore map: sit the zoom/compass control below the
+     top overlay (back + search + year timeline + chemical filter pills)
+     so it stays fully visible across mobile and desktop, and clear of
+     the ExploreFieldPanel (right side on desktop, bottom sheet on mobile)
+     and MapLegend (bottom-left). Match the sibling PesticidkortMap's
+     top-left placement for consistency within the feature. */
+  [data-testid='explore-map'] .maplibregl-ctrl-top-left {
+    top: calc(env(safe-area-inset-top, 0px) + 10rem);
+  }
 }

--- a/frontend/src/components/pesticidkort/ExploreMapInner.tsx
+++ b/frontend/src/components/pesticidkort/ExploreMapInner.tsx
@@ -117,7 +117,7 @@ export function ExploreMapInner({
         attributionControl={false}
         data-testid="explore-map"
       >
-        <NavigationControl position="top-right" />
+        <NavigationControl position="top-left" />
       </Map>
       {hoverData && <FieldHoverTooltip {...hoverData} />}
     </>

--- a/frontend/src/components/pesticidkort/ExploreMapView.tsx
+++ b/frontend/src/components/pesticidkort/ExploreMapView.tsx
@@ -108,9 +108,9 @@ export function ExploreMapView({
           )}
         </div>
 
-        <div className="mx-auto mt-2 flex max-w-md flex-col items-center gap-2">
-          <div className="bg-background/90 w-full max-w-xs min-w-[200px] rounded-full px-5 py-1 backdrop-blur-sm">
-            <YearTimeline year={year} onChange={onYearChange} compact />
+        <div className="mx-auto mt-2 flex max-w-lg flex-col items-center gap-2">
+          <div className="bg-background/90 w-full max-w-xs min-w-[200px] rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:px-3">
+            <YearTimeline year={year} onChange={onYearChange} />
           </div>
           <ChemicalFilterPills
             active={chemFilter}

--- a/frontend/src/components/pesticidkort/ReportControls.tsx
+++ b/frontend/src/components/pesticidkort/ReportControls.tsx
@@ -19,7 +19,7 @@ export function ReportControls({
   return (
     <div className="bg-background/95 border-border border-t px-5 py-3 backdrop-blur-sm">
       <ModeToggle mode={mode} onChange={onModeChange} />
-      <YearTimeline year={year} onChange={onYearChange} compact />
+      <YearTimeline year={year} onChange={onYearChange} />
     </div>
   );
 }

--- a/frontend/src/components/pesticidkort/ReportMapView.tsx
+++ b/frontend/src/components/pesticidkort/ReportMapView.tsx
@@ -116,8 +116,8 @@ export function ReportMapView({
 
       {/* Floating map controls: year + chemical pills */}
       <div className="pointer-events-none absolute inset-x-0 bottom-[55%] z-40 flex flex-col items-center gap-2 px-4 md:right-[420px] md:bottom-6">
-        <div className="bg-background/90 pointer-events-auto max-w-xs min-w-[200px] self-stretch rounded-full px-5 py-1 backdrop-blur-sm md:min-w-[280px] md:self-auto">
-          <YearTimeline year={year} onChange={onYearChange} compact />
+        <div className="bg-background/90 pointer-events-auto max-w-xs min-w-[200px] self-stretch rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-auto md:px-3">
+          <YearTimeline year={year} onChange={onYearChange} />
         </div>
         <ChemicalFilterPills
           active={chemFilter}

--- a/frontend/src/components/pesticidkort/YearTimeline.tsx
+++ b/frontend/src/components/pesticidkort/YearTimeline.tsx
@@ -1,7 +1,7 @@
-/* oxlint-disable landbruget/max-component-size */
 'use client';
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const YEARS = [
@@ -13,35 +13,33 @@ const LAST = YEARS[YEARS.length - 1];
 interface YearTimelineProps {
   year: number;
   onChange: (year: number) => void;
-  compact?: boolean;
 }
 
-export function YearTimeline({ year, onChange, compact }: YearTimelineProps) {
-  const trackRef = useRef<HTMLDivElement>(null);
+export function YearTimeline({ year, onChange }: YearTimelineProps) {
+  const stripRef = useRef<HTMLDivElement>(null);
+  const activeIdx = YEARS.indexOf(year as (typeof YEARS)[number]);
 
-  const handleTrackClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (!trackRef.current) return;
-      const rect = trackRef.current.getBoundingClientRect();
-      const fraction = Math.max(
-        0,
-        Math.min(1, (e.clientX - rect.left) / rect.width)
-      );
-      const idx = Math.round(fraction * (YEARS.length - 1));
-      onChange(YEARS[idx]);
-    },
-    [onChange]
-  );
+  useEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    const activeChip = strip.querySelector<HTMLElement>(
+      `[data-year="${year}"]`
+    );
+    activeChip?.scrollIntoView({
+      behavior: 'smooth',
+      inline: 'center',
+      block: 'nearest',
+    });
+  }, [year]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      const idx = YEARS.indexOf(year as (typeof YEARS)[number]);
-      if (e.key === 'ArrowRight' && idx < YEARS.length - 1) {
+      if (e.key === 'ArrowRight' && activeIdx < YEARS.length - 1) {
         e.preventDefault();
-        onChange(YEARS[idx + 1]);
-      } else if (e.key === 'ArrowLeft' && idx > 0) {
+        onChange(YEARS[activeIdx + 1]);
+      } else if (e.key === 'ArrowLeft' && activeIdx > 0) {
         e.preventDefault();
-        onChange(YEARS[idx - 1]);
+        onChange(YEARS[activeIdx - 1]);
       } else if (e.key === 'Home') {
         e.preventDefault();
         onChange(FIRST);
@@ -50,111 +48,72 @@ export function YearTimeline({ year, onChange, compact }: YearTimelineProps) {
         onChange(LAST);
       }
     },
-    [year, onChange]
+    [activeIdx, onChange]
   );
-
-  const activeIdx = YEARS.indexOf(year as (typeof YEARS)[number]);
-  const progressWidths = [
-    'w-0',
-    'w-[11.111111%]',
-    'w-[22.222222%]',
-    'w-[33.333333%]',
-    'w-[44.444444%]',
-    'w-[55.555556%]',
-    'w-[66.666667%]',
-    'w-[77.777778%]',
-    'w-[88.888889%]',
-    'w-full',
-  ] as const;
 
   return (
     <div
-      className={cn('select-none', compact ? 'pt-2 pb-5' : 'py-4')}
+      className="flex items-center gap-0.5 select-none"
       data-testid="year-timeline"
+      role="slider"
+      aria-label="Vælg sprøjteår"
+      aria-valuemin={FIRST}
+      aria-valuemax={LAST}
+      aria-valuenow={year}
+      aria-valuetext={`${year}`}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
     >
-      {!compact && (
-        <div className="text-muted-foreground mb-3 flex items-baseline justify-between">
-          <span className="text-xs font-medium tracking-wider uppercase">
-            Sprøjteår
-          </span>
-          <span className="text-foreground text-sm font-semibold tabular-nums">
-            {year}
-          </span>
-        </div>
-      )}
+      <button
+        type="button"
+        onClick={() => activeIdx > 0 && onChange(YEARS[activeIdx - 1])}
+        disabled={activeIdx <= 0}
+        aria-label="Forrige år"
+        data-testid="year-prev-button"
+        className="text-muted-foreground hover:text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-30"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
 
       <div
-        ref={trackRef}
-        role="slider"
-        aria-label="Vælg sprøjteår"
-        aria-valuemin={FIRST}
-        aria-valuemax={LAST}
-        aria-valuenow={year}
-        aria-valuetext={`${year}`}
-        tabIndex={0}
-        onKeyDown={handleKeyDown}
-        onClick={handleTrackClick}
-        className={cn(
-          'relative cursor-pointer',
-          compact ? 'h-6' : 'h-8',
-          'focus-visible:outline-primary rounded focus-visible:outline-2 focus-visible:outline-offset-4'
-        )}
+        ref={stripRef}
+        className="flex min-w-0 flex-1 snap-x snap-mandatory gap-0.5 overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
-        {/* Track background */}
-        <div className="bg-border absolute top-1/2 right-0 left-0 h-px -translate-y-1/2" />
-
-        {/* Active fill */}
-        <div
-          className={cn(
-            'bg-primary/40 absolute top-1/2 left-0 h-px -translate-y-1/2 transition-[width] duration-200',
-            progressWidths[activeIdx]
-          )}
-        />
-
-        {/* Year dots */}
-        <div className="absolute inset-0 grid grid-cols-10">
-          {YEARS.map((y) => {
-            const isActive = y === year;
-            return (
-              <button
-                key={y}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onChange(y);
-                }}
-                data-testid={`year-${y}-button`}
-                aria-label={`${y}`}
-                aria-current={isActive ? 'true' : undefined}
-                tabIndex={-1}
-                className="group relative flex h-full w-full items-center justify-center"
-              >
-                <div
-                  className={cn(
-                    'rounded-full transition-all duration-200',
-                    isActive
-                      ? 'bg-primary h-3.5 w-3.5 shadow-sm'
-                      : 'bg-border hover:bg-muted-foreground/50 h-2 w-2'
-                  )}
-                />
-                {(!compact || isActive) && (
-                  <span
-                    data-testid={`year-dot-${y}`}
-                    className={cn(
-                      'absolute left-1/2 -translate-x-1/2 tabular-nums transition-opacity',
-                      'top-full mt-1 text-[10px]',
-                      isActive
-                        ? 'text-foreground font-semibold opacity-100'
-                        : 'text-muted-foreground opacity-0 group-hover:opacity-100 sm:opacity-60'
-                    )}
-                  >
-                    {y}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
+        {YEARS.map((y) => {
+          const isActive = y === year;
+          return (
+            <button
+              key={y}
+              type="button"
+              data-year={y}
+              data-testid={`year-${y}-button`}
+              aria-current={isActive ? 'true' : undefined}
+              onClick={() => onChange(y)}
+              className={cn(
+                'shrink-0 snap-center rounded-full px-2.5 py-1.5 text-xs font-medium tabular-nums transition-colors',
+                isActive
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+              )}
+            >
+              {y}
+            </button>
+          );
+        })}
       </div>
+
+      <button
+        type="button"
+        onClick={() =>
+          activeIdx < YEARS.length - 1 && onChange(YEARS[activeIdx + 1])
+        }
+        disabled={activeIdx >= YEARS.length - 1}
+        aria-label="Næste år"
+        data-testid="year-next-button"
+        className="text-muted-foreground hover:text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-30"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
     </div>
   );
 }

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-11T08:09:41.155155Z"
+exclude-newer = "2026-04-12T06:51:20.205647Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -232,7 +232,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "landbruget-common", editable = "backend/common" },
     { name = "loguru", specifier = ">=0.7.0" },
-    { name = "numpy", specifier = ">=1.24.0" },
+    { name = "numpy", specifier = ">=2.4.4" },
     { name = "playwright", specifier = ">=1.40.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pydantic" },
@@ -2856,6 +2856,7 @@ dependencies = [
     { name = "s3fs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "scikit-learn", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "scipy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "shapely", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "simple-singleton", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tabulate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2894,6 +2895,7 @@ requires-dist = [
     { name = "s3fs" },
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "scipy", specifier = ">=1.11.0" },
+    { name = "shapely", specifier = ">=2.0.0" },
     { name = "simple-singleton", specifier = ">=2.0.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tenacity", specifier = ">=9.1.2" },


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked. The mobile year picker on the pesticide map (`ReportMapView`, `ExploreMapView`, `ReportControls`) rendered as a cramped row of 8px dots where only the active year was labeled, with the label clipping the pill edge on the rightmost year.

## 💡 Solution
- Rewrote `YearTimeline.tsx` as a horizontal scroll-snap chip strip: each year is a tappable pill with `snap-center` auto-scrolling to the active chip; prev/next chevrons step year-by-year and disable at endpoints; `role="slider"` semantics, keyboard handlers (arrows/Home/End), and `data-testid` hooks preserved.
- Widened the desktop pill containers in `ReportMapView`/`ExploreMapView` (`md:max-w-md md:min-w-[480px]`) so all 10 chips + chevrons fit without scrolling; mobile keeps `max-w-xs` for scroll behavior. Dropped the now-unused `compact` prop across the three call sites.
- Repositioned MapLibre `NavigationControl` in `ExploreMapInner` from `top-right` → `top-left` and added a `globals.css` offset so the zoom controls clear the year/filter overlay.
- Bundles an unrelated backend `uv.lock` refresh (numpy → `>=2.4.4`, shapely pin added).

## ✅ How to Do Self-Test
1. `cd frontend && npm run lint` — passes (0 warnings).
2. `cd frontend && npm run test:smoke` — passes (ran via pre-commit hook).
3. Manual: open `/pesticidkort` on a 390px viewport, search `Stensby Mark 4, 4773 Stensved`, confirm the year pill shows `‹ 2015 … 2024 ›`, active chip centers on tap, chevrons step and disable at endpoints.

## 📷 Screenshots
Before: `.context/attachments/Screenshot 2026-04-19 at 08.51.05.png` (in workspace).

## 📝 Additional Notes
`YearTimeline.tsx` is now 120 lines (under the 150-line oxlint cap) — the `/* oxlint-disable landbruget/max-component-size */` pragma has been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)