### PR TITLE
fix(geus-pipeline): register missing GEUS source keys and free DataFrames

### DIFF
--- a/backend/common/data_source_registry.py
+++ b/backend/common/data_source_registry.py
@@ -715,6 +715,57 @@ DATA_SOURCE_REGISTRY: dict[str, DataSourceInfo] = {
         display_name="PFAS Eksponeringsanalyse",
         display_description="Rumlig analyse af PFAS-forureningseksponering ved hjælp af H3-gridsystem",
     ),
+    # ========================================
+    # GEUS DATAVERSE PESTICIDES PIPELINE
+    # ========================================
+    "geus_dataverse_pesticides": DataSourceInfo(
+        source_authority="GEUS (De Nationale Geologiske Undersøgelser for Danmark og Grønland)",
+        source_url="https://dataverse.geus.dk/",
+        data_acquisition_method="HTTP API (Dataverse)",
+        data_description="Groundwater pesticide analyses from GEUS Dataverse (633 substances, 4.2M+ analyses, 1981-2025)",
+        update_frequency="Monthly",
+        pipeline_name="geus_dataverse_pesticides",
+        data_format="RDS/Parquet",
+        data_source_type=DataSourceType.API,
+        display_name="GEUS Grundvandspesticider",
+        display_description="Pesticidfund i grundvand fra GEUS Dataverse (633 stoffer, 4,2M+ analyser, 1981-2025)",
+    ),
+    "geus_dataverse_pfas": DataSourceInfo(
+        source_authority="GEUS (De Nationale Geologiske Undersøgelser for Danmark og Grønland)",
+        source_url="https://dataverse.geus.dk/",
+        data_acquisition_method="HTTP API (Dataverse)",
+        data_description="Groundwater PFAS analyses from GEUS Dataverse (26 substances, 2012-2025)",
+        update_frequency="Monthly",
+        pipeline_name="geus_dataverse_pesticides",
+        data_format="RDS/Parquet",
+        data_source_type=DataSourceType.API,
+        display_name="GEUS Grundvands-PFAS",
+        display_description="PFAS-fund i grundvand fra GEUS Dataverse (26 stoffer, 2012-2025)",
+    ),
+    "geus_clean_pesticides": DataSourceInfo(
+        source_authority="GEUS (De Nationale Geologiske Undersøgelser for Danmark og Grønland)",
+        source_url="https://dataverse.geus.dk/",
+        data_acquisition_method="HTTP API (Dataverse)",
+        data_description="Sample-level clean groundwater pesticide dataset from GEUS Dataverse (Deliverable 2, ~9.4M analyses)",
+        update_frequency="Monthly",
+        pipeline_name="geus_dataverse_pesticides",
+        data_format="RDS/Parquet",
+        data_source_type=DataSourceType.API,
+        display_name="GEUS Rene Grundvandspesticider",
+        display_description="Prøveniveau grundvandspesticiddata fra GEUS Dataverse (Leverance 2, ~9,4M analyser)",
+    ),
+    "geus_clean_all": DataSourceInfo(
+        source_authority="GEUS (De Nationale Geologiske Undersøgelser for Danmark og Grønland)",
+        source_url="https://dataverse.geus.dk/",
+        data_acquisition_method="HTTP API (Dataverse)",
+        data_description="Sample-level clean groundwater dataset from GEUS Dataverse (all parameter groups: pesticides, PFAS, nitrate, etc.)",
+        update_frequency="Monthly",
+        pipeline_name="geus_dataverse_pesticides",
+        data_format="RDS/Parquet",
+        data_source_type=DataSourceType.API,
+        display_name="GEUS Rent Grundvand (alle parametre)",
+        display_description="Prøveniveau grundvandsdata fra GEUS Dataverse (alle parametergrupper: pesticider, PFAS, nitrat m.fl.)",
+    ),
     # ADD MORE SOURCES HERE AS NEEDED
     # 🚨 MANUAL INPUT NEEDED: Review all entries above and fill in missing information
 }

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_dataverse_pesticides.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/geus_dataverse_pesticides.py
@@ -696,6 +696,7 @@ class GEUSDataversePesticidesSilver(
                 tmp_pest_path = self._download_rds_from_storage(pest_rds_path)
                 pest_df = self._convert_rds_to_dataframe(tmp_pest_path)
                 pest_table = self._transform_data(pest_df)
+                del pest_df
                 self._validate_geometries(pest_table)
 
                 # Get pesticide statistics
@@ -725,6 +726,7 @@ class GEUSDataversePesticidesSilver(
                     tmp_pfas_path = self._download_rds_from_storage(pfas_rds_path)
                     pfas_df = self._convert_rds_to_dataframe(tmp_pfas_path)
                     pfas_table = self._transform_pfas_data(pfas_df)
+                    del pfas_df
                     self._validate_geometries(pfas_table)
 
                     # Get PFAS statistics
@@ -757,6 +759,7 @@ class GEUSDataversePesticidesSilver(
                     tmp_clean_path = self._download_rds_from_storage(clean_rds_path)
                     clean_df = self._convert_rds_to_dataframe(tmp_clean_path)
                     clean_pest_table, clean_all_table = self._transform_clean_data(clean_df)
+                    del clean_df
                     self._validate_geometries(clean_pest_table)
                     self._validate_geometries(clean_all_table)
 


### PR DESCRIPTION
## Summary

- Adds 4 missing source keys to `DATA_SOURCE_REGISTRY`: `geus_dataverse_pesticides`, `geus_dataverse_pfas`, `geus_clean_pesticides`, `geus_clean_all`
- Pipeline metadata creation was logging `ERROR` on every run because these keys were absent from the registry
- Frees each pandas DataFrame (`del pest_df`, `del pfas_df`, `del clean_df`) immediately after converting to DuckDB to reduce peak memory when processing the three large RDS files (26 MB + 2.3 MB + 92.1 MB)

## Root cause

Job [71997448005](https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/24623163210/job/71997448005) logged `ERROR: Source key 'geus_dataverse_pesticides' not found in registry` at both bronze and silver stages. The runner was subsequently killed mid-way through reading `clean_dataset.rds` (92.1 MB, ~9.4M rows), likely due to memory pressure from three large DataFrames coexisting in memory.

## Test plan

- [ ] Re-run `geus_dataverse_pesticides` pipeline job in CI and confirm no registry ERROR logs
- [ ] Confirm silver stage completes without OOM kill on `clean_dataset.rds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)