### PR TITLE
refactor(backend): use shared logging utility across all pipelines

### DIFF
--- a/backend/pipelines/api_export/exporters/base.py
+++ b/backend/pipelines/api_export/exporters/base.py
@@ -1,14 +1,14 @@
 """Base class for API exporters that generate JSON files for R2."""
 
 import json
-import logging
 import os
 from pathlib import Path
 
 import duckdb
 import s3fs
+from common.logging_utils import get_pipeline_logger
 
-logger = logging.getLogger("api_export")
+logger = get_pipeline_logger("api_export")
 
 
 class BaseExporter:

--- a/backend/pipelines/api_export/exporters/company_profiles.py
+++ b/backend/pipelines/api_export/exporters/company_profiles.py
@@ -20,16 +20,17 @@ Data sources (R2):
 - silver/subsidies/20260322_074339/Landbrugsstoette_2023.parquet — 2023 subsidies
 """
 
-import logging
 import os
 import subprocess
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
+from common.logging_utils import get_pipeline_logger
+
 from exporters.base import BaseExporter
 
-logger = logging.getLogger("api_export.company_profiles")
+logger = get_pipeline_logger("api_export.company_profiles")
 
 BUCKET = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET") or "landbruget-data"
 

--- a/backend/pipelines/api_export/exporters/drift_exposure.py
+++ b/backend/pipelines/api_export/exporters/drift_exposure.py
@@ -20,13 +20,14 @@ Data sources (R2):
 - silver/dagi_kommuner/{ts}/data.parquet  (for kommunekode spatial join)
 """
 
-import logging
 import os
 import re
 
+from common.logging_utils import get_pipeline_logger
+
 from exporters.base import BaseExporter
 
-logger = logging.getLogger("api_export.drift_exposure")
+logger = get_pipeline_logger("api_export.drift_exposure")
 
 BUCKET = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET") or "landbruget-data"
 

--- a/backend/pipelines/api_export/exporters/homepage.py
+++ b/backend/pipelines/api_export/exporters/homepage.py
@@ -18,14 +18,15 @@ Actual R2 data sources:
 - gold/work_permits/*/work_permits.parquet — work permits (8.7k rows)
 """
 
-import logging
 import os
 from collections.abc import Callable
 from datetime import UTC, datetime
 
+from common.logging_utils import get_pipeline_logger
+
 from exporters.base import BaseExporter
 
-logger = logging.getLogger("api_export.homepage")
+logger = get_pipeline_logger("api_export.homepage")
 
 BUCKET = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET") or "landbruget-data"
 

--- a/backend/pipelines/api_export/exporters/municipalities.py
+++ b/backend/pipelines/api_export/exporters/municipalities.py
@@ -14,14 +14,15 @@ Data sources (R2):
 - gold/pesticide_disaggregation_2023_2024/*/pesticide_disaggregation_2023_2024.parquet (columns: cvr_number, municipality, AllocatedArea)
 """
 
-import logging
 import os
 from datetime import UTC, datetime
 from urllib.parse import quote
 
+from common.logging_utils import get_pipeline_logger
+
 from exporters.base import BaseExporter
 
-logger = logging.getLogger("api_export.municipalities")
+logger = get_pipeline_logger("api_export.municipalities")
 
 BUCKET = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET") or "landbruget-data"
 

--- a/backend/pipelines/api_export/exporters/pesticides.py
+++ b/backend/pipelines/api_export/exporters/pesticides.py
@@ -12,14 +12,15 @@ Data source: gold/pesticide_disaggregation_{year}_{year+1}/*/pesticide_disaggreg
 Columns: cvr_number, PesticideName, DosageQuantity, DosageUnit, AllocatedArea, municipality
 """
 
-import logging
 import os
 import re
 from datetime import UTC, datetime
 
+from common.logging_utils import get_pipeline_logger
+
 from exporters.base import BaseExporter
 
-logger = logging.getLogger("api_export.pesticides")
+logger = get_pipeline_logger("api_export.pesticides")
 
 BUCKET = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET") or "landbruget-data"
 

--- a/backend/pipelines/api_export/exporters/search_index.py
+++ b/backend/pipelines/api_export/exporters/search_index.py
@@ -8,12 +8,13 @@ Frontend loads this once into memory and filters client-side with Fuse.js,
 which is faster than the current 300ms debounce + server round-trip.
 """
 
-import logging
 import os
+
+from common.logging_utils import get_pipeline_logger
 
 from exporters.base import BaseExporter
 
-logger = logging.getLogger("api_export.search")
+logger = get_pipeline_logger("api_export.search")
 
 BUCKET = os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET") or "landbruget-data"
 

--- a/backend/pipelines/api_export/main.py
+++ b/backend/pipelines/api_export/main.py
@@ -23,6 +23,7 @@ import time
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 from dotenv import load_dotenv
 
 # Add backend root to path for common imports
@@ -40,7 +41,7 @@ from exporters.search_index import SearchIndexExporter
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
-logger = logging.getLogger("api_export")
+logger = get_pipeline_logger("api_export")
 
 EXPORTERS = {
     "homepage": HomepageExporter,

--- a/backend/pipelines/arbejdstilsynet_inspections/main.py
+++ b/backend/pipelines/arbejdstilsynet_inspections/main.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 from common.cli import PipelineRun, common_options, resolve_bucket, stage_options
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 
 import bronze.export
@@ -40,7 +41,7 @@ def main(stage, start_date, end_date, storage_bucket, log_level):
         level=getattr(logging, log_level),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
-    logger = logging.getLogger(__name__)
+    logger = get_pipeline_logger(__name__)
     logger.info(f"Starting pipeline (stage={stage}, start_date={start_date}, end_date={end_date})")
 
     # Initialize pipeline metadata tracking

--- a/backend/pipelines/arbejdstilsynet_inspections/silver/transform.py
+++ b/backend/pipelines/arbejdstilsynet_inspections/silver/transform.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 # Add CVR collection import
 try:
@@ -158,7 +159,7 @@ class SilverPipeline:
             level=getattr(logging, log_level),
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
-        self.logger = logging.getLogger("SilverPipeline")
+        self.logger = get_pipeline_logger("SilverPipeline")
 
         # Store parameters
         self.start_date = start_date
@@ -911,11 +912,11 @@ if __name__ == "__main__":
         # Logger might not be configured if __main__ is run and SilverPipeline init fails before logger setup
         # So, print to stderr as well
         logging.error(f"Silver Pipeline ERROR: {e}")
-        logging.getLogger(__name__).error(f"Silver Pipeline execution failed: {e}", exc_info=True)
+        get_pipeline_logger(__name__).error(f"Silver Pipeline execution failed: {e}", exc_info=True)
         exit(1)
     except Exception as e:
         logging.error(f"Silver Pipeline UNEXPECTED ERROR: {e}")
-        logging.getLogger(__name__).error(
+        get_pipeline_logger(__name__).error(
             f"Unexpected error in silver pipeline __main__: {e}", exc_info=True
         )
         exit(1)

--- a/backend/pipelines/bbr_buildings/bronze/bulk_geodanmark_fetcher.py
+++ b/backend/pipelines/bbr_buildings/bronze/bulk_geodanmark_fetcher.py
@@ -15,13 +15,14 @@ from pathlib import Path
 
 import duckdb
 import requests
+from common.logging_utils import get_pipeline_logger
 from requests.adapters import HTTPAdapter
 from tqdm import tqdm
 from urllib3.util.retry import Retry
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class BulkGeoDanmarkFetcher:

--- a/backend/pipelines/bbr_buildings/bronze/bulk_geodanmark_graphql_fetcher.py
+++ b/backend/pipelines/bbr_buildings/bronze/bulk_geodanmark_graphql_fetcher.py
@@ -25,12 +25,13 @@ from pathlib import Path
 
 import duckdb
 import requests
+from common.logging_utils import get_pipeline_logger
 from requests.adapters import HTTPAdapter
 from tqdm import tqdm
 from urllib3.util.retry import Retry
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # Fields to fetch — covers all useful attributes from GEODKV_Bygning
 BUILDING_FIELDS = """

--- a/backend/pipelines/bbr_buildings/utils/logger.py
+++ b/backend/pipelines/bbr_buildings/utils/logger.py
@@ -2,11 +2,10 @@
 Logging utilities for the BBR Buildings Pipeline.
 """
 
-import logging
-import sys
+from common.logging_utils import setup_pipeline_logger
 
 
-def setup_logger(name: str = "bbr_buildings", level: str = "INFO") -> logging.Logger:
+def setup_logger(name: str = "bbr_buildings", level: str = "INFO"):
     """
     Set up a logger with the specified name and level.
 
@@ -17,24 +16,4 @@ def setup_logger(name: str = "bbr_buildings", level: str = "INFO") -> logging.Lo
     Returns:
         Configured logger instance
     """
-    logger = logging.getLogger(name)
-    logger.setLevel(getattr(logging, level.upper()))
-
-    # Remove existing handlers to avoid duplicates
-    for handler in logger.handlers[:]:
-        logger.removeHandler(handler)
-
-    # Create console handler
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(getattr(logging, level.upper()))
-
-    # Create formatter
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-    )
-    handler.setFormatter(formatter)
-
-    # Add handler to logger
-    logger.addHandler(handler)
-
-    return logger
+    return setup_pipeline_logger(name, level=level)

--- a/backend/pipelines/bmd_scraper/silver/transform.py
+++ b/backend/pipelines/bmd_scraper/silver/transform.py
@@ -4,15 +4,15 @@ Transform raw BMD Excel data into cleaned, structured Parquet format.
 
 import contextlib
 import json
-import logging
 import os
 from datetime import datetime
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 # Configure module logger
-logger = logging.getLogger("bmd_pipeline.silver.transform")
+logger = get_pipeline_logger("bmd_pipeline.silver.transform")
 
 
 def _get_optimized_storage_access():

--- a/backend/pipelines/chr_pipeline/bronze/animal_movements.py
+++ b/backend/pipelines/chr_pipeline/bronze/animal_movements.py
@@ -1,11 +1,11 @@
 """Main animal movement loading logic for CHR pipeline."""
 
-import logging
 import time
 from datetime import date, timedelta
 from typing import Any
 
 import requests
+from common.logging_utils import get_pipeline_logger
 from zeep.exceptions import Fault
 
 from .data_processing import aggregate_cattle_movements
@@ -14,7 +14,7 @@ from .utils import create_base_request
 from .volume_management import get_optimal_date_range
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.animal_movements")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.animal_movements")
 
 
 def load_animal_movements(

--- a/backend/pipelines/chr_pipeline/bronze/auth.py
+++ b/backend/pipelines/chr_pipeline/bronze/auth.py
@@ -1,12 +1,12 @@
 """Authentication and SOAP client creation for CHR pipeline."""
 
 import base64
-import logging
 import os
 from typing import Any
 
 import certifi
 import requests
+from common.logging_utils import get_pipeline_logger
 from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
 from dotenv import find_dotenv, load_dotenv
 from requests import Session
@@ -22,7 +22,7 @@ from common.secrets import init_secrets  # noqa: E402
 init_secrets()
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.auth")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.auth")
 
 # API Endpoints (WSDL URLs)
 ENDPOINTS = {

--- a/backend/pipelines/chr_pipeline/bronze/data_processing.py
+++ b/backend/pipelines/chr_pipeline/bronze/data_processing.py
@@ -1,13 +1,14 @@
 """Data processing and aggregation for CHR pipeline."""
 
-import logging
 from collections import defaultdict
 from typing import Any
+
+from common.logging_utils import get_pipeline_logger
 
 from .utils import parse_date
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.data_processing")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.data_processing")
 
 
 def aggregate_cattle_movements(response: Any, reporting_herd: int) -> dict:

--- a/backend/pipelines/chr_pipeline/bronze/export.py
+++ b/backend/pipelines/chr_pipeline/bronze/export.py
@@ -1,7 +1,6 @@
 """Module for exporting raw Bronze data (JSON/XML)."""
 
 import json
-import logging
 import os
 import shutil
 import sys
@@ -10,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 from zeep.helpers import serialize_object
 
@@ -38,7 +38,7 @@ except ImportError:
 load_dotenv(find_dotenv(usecwd=True))
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # Initialize storage paths and clients
 GCS_BUCKET = os.getenv("STORAGE_BUCKET") or os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")

--- a/backend/pipelines/chr_pipeline/bronze/herd_discovery.py
+++ b/backend/pipelines/chr_pipeline/bronze/herd_discovery.py
@@ -1,9 +1,10 @@
 """Herd volume discovery system for intelligent processing strategy."""
 
 import json
-import logging
 from datetime import date, timedelta
 from typing import Any
+
+from common.logging_utils import get_pipeline_logger
 
 # Import cloud storage access for persistent storage
 try:
@@ -17,7 +18,7 @@ except ImportError:
 from .utils import create_base_request
 from .volume_management import is_high_volume_herd
 
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.herd_discovery")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.herd_discovery")
 
 
 def discover_herd_volumes_for_year(

--- a/backend/pipelines/chr_pipeline/bronze/load_besaetning.py
+++ b/backend/pipelines/chr_pipeline/bronze/load_besaetning.py
@@ -2,9 +2,9 @@
 
 import contextlib
 import json
-import logging
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
 from zeep import Client
 from zeep.exceptions import Fault
 from zeep.helpers import serialize_object
@@ -15,7 +15,7 @@ from .export import save_raw_data
 from .utils import create_base_request
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.load_besaetning")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.load_besaetning")
 
 # --- Base Request Structure ---
 # Using shared utility from .utils

--- a/backend/pipelines/chr_pipeline/bronze/load_chr_dyr.py
+++ b/backend/pipelines/chr_pipeline/bronze/load_chr_dyr.py
@@ -4,10 +4,10 @@ This module provides the main interface for loading animal movement data from CH
 The functionality has been separated into focused modules for better maintainability.
 """
 
-import logging
 from datetime import date, timedelta
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 
 from .animal_movements import load_animal_movements, load_cattle_movement_summaries
@@ -26,7 +26,7 @@ except ImportError:
 load_dotenv(find_dotenv(usecwd=True))
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.load_chr_dyr")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.load_chr_dyr")
 
 
 def load_animal_movements_task(

--- a/backend/pipelines/chr_pipeline/bronze/load_diko.py
+++ b/backend/pipelines/chr_pipeline/bronze/load_diko.py
@@ -1,9 +1,9 @@
 """Module for loading DIKO (animal movements) data - Bronze Layer."""
 
 import json
-import logging
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
 from zeep import Client
 from zeep.helpers import serialize_object
 
@@ -13,7 +13,7 @@ from .export import save_raw_data
 from .utils import create_base_request
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.load_diko")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.load_diko")
 
 
 # Valid species codes for DIKO

--- a/backend/pipelines/chr_pipeline/bronze/load_ejendom.py
+++ b/backend/pipelines/chr_pipeline/bronze/load_ejendom.py
@@ -1,8 +1,8 @@
 """Module for loading CHR Ejendom data (Properties) - Bronze Layer."""
 
-import logging
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
 from zeep import Client
 
 # Import the exporter and auth
@@ -11,7 +11,7 @@ from .export import save_raw_data
 from .utils import create_base_request
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.load_ejendom")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.load_ejendom")
 
 # --- Generic SOAP Fetcher ---
 

--- a/backend/pipelines/chr_pipeline/bronze/load_spf_su.py
+++ b/backend/pipelines/chr_pipeline/bronze/load_spf_su.py
@@ -12,10 +12,11 @@ import os
 from typing import Any
 
 import aiohttp
+from common.logging_utils import get_pipeline_logger
 
 from bronze.export import save_raw_data
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 async def load_spf_su_data(

--- a/backend/pipelines/chr_pipeline/bronze/load_stamdata.py
+++ b/backend/pipelines/chr_pipeline/bronze/load_stamdata.py
@@ -1,9 +1,9 @@
 """Module for loading CHR stamdata (Species, Usage Types) - Bronze Layer."""
 
 import json
-import logging
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
 from zeep import Client
 from zeep.helpers import serialize_object
 
@@ -13,7 +13,7 @@ from .export import save_raw_data
 from .utils import create_base_request
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.load_stamdata")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.load_stamdata")
 
 # --- Generic SOAP Fetcher ---
 

--- a/backend/pipelines/chr_pipeline/bronze/load_vetstat.py
+++ b/backend/pipelines/chr_pipeline/bronze/load_vetstat.py
@@ -2,7 +2,6 @@
 
 import base64
 import hashlib
-import logging
 import os
 import secrets
 import uuid
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import requests
+from common.logging_utils import get_pipeline_logger
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.serialization import Encoding
@@ -39,7 +39,7 @@ except ImportError:
         LandbrugsdataUUID = None
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.load_vetstat")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.load_vetstat")
 
 # Load environment variables (walks up to find root .env)
 load_dotenv(find_dotenv(usecwd=True))

--- a/backend/pipelines/chr_pipeline/bronze/persistence.py
+++ b/backend/pipelines/chr_pipeline/bronze/persistence.py
@@ -1,9 +1,9 @@
 """Persistence layer for CHR pipeline - handles problematic herds tracking."""
 
-import logging
 import os
 from datetime import datetime
 
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 
 # Import cloud storage access for persistent storage
@@ -19,7 +19,7 @@ except ImportError:
 load_dotenv(find_dotenv(usecwd=True))
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.persistence")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.persistence")
 
 # Global set to track problematic herds that consistently fail
 _PROBLEMATIC_HERDS: set[int] = set()

--- a/backend/pipelines/chr_pipeline/bronze/utils.py
+++ b/backend/pipelines/chr_pipeline/bronze/utils.py
@@ -1,8 +1,9 @@
 """Shared utilities for CHR pipeline bronze layer."""
 
-import logging
 from datetime import date, datetime
 from typing import Any
+
+from common.logging_utils import get_pipeline_logger
 
 # Import UUID utilities for deterministic TrackID generation
 try:
@@ -22,7 +23,7 @@ except ImportError:
         LandbrugsdataUUID = None
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.utils")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.utils")
 
 # Default Client ID for SOAP requests
 DEFAULT_CLIENT_ID = "LandbrugsData"

--- a/backend/pipelines/chr_pipeline/bronze/volume_management.py
+++ b/backend/pipelines/chr_pipeline/bronze/volume_management.py
@@ -1,10 +1,10 @@
 """Volume management for CHR pipeline - handles high-volume herds and chunking."""
 
-import logging
 import os
 from datetime import date, datetime, timedelta
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 from zeep import Client
 
@@ -21,7 +21,7 @@ except ImportError:
 load_dotenv(find_dotenv(usecwd=True))
 
 # Set up logging
-logger = logging.getLogger("backend.pipelines.chr_pipeline.bronze.volume_management")
+logger = get_pipeline_logger("backend.pipelines.chr_pipeline.bronze.volume_management")
 
 # Global dict to track herds that need special handling (smaller date ranges)
 _HIGH_VOLUME_HERDS: dict[str, dict] = {}

--- a/backend/pipelines/chr_pipeline/cleanup_temp_files.py
+++ b/backend/pipelines/chr_pipeline/cleanup_temp_files.py
@@ -11,9 +11,11 @@ import os
 import sys
 from pathlib import Path
 
+from common.logging_utils import get_pipeline_logger
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def cleanup_temp_files():

--- a/backend/pipelines/chr_pipeline/debug_chr_error.py
+++ b/backend/pipelines/chr_pipeline/debug_chr_error.py
@@ -9,6 +9,8 @@ import sys
 from datetime import date, timedelta
 from pathlib import Path
 
+from common.logging_utils import get_pipeline_logger
+
 # Add the backend directory to the path
 backend_path = os.path.join(os.path.dirname(__file__), "..", "..")
 sys.path.insert(0, backend_path)
@@ -17,7 +19,7 @@ sys.path.insert(0, backend_path)
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def load_env_credentials():

--- a/backend/pipelines/chr_pipeline/debug_paths.py
+++ b/backend/pipelines/chr_pipeline/debug_paths.py
@@ -5,11 +5,13 @@ import json
 import logging
 from pathlib import Path
 
+from common.logging_utils import get_pipeline_logger
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # Test paths
 test_paths = [

--- a/backend/pipelines/chr_pipeline/gold/chr_gold_processing.py
+++ b/backend/pipelines/chr_pipeline/gold/chr_gold_processing.py
@@ -3,12 +3,14 @@
 import logging
 from pathlib import Path
 
+from common.logging_utils import get_pipeline_logger
+
 from .config import GOLD_BASE_DIR
 from .production_sites import process_production_sites
 from .transportation_analysis import process_transportation_analysis
 from .veterinary_timeline import process_veterinary_timeline
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def process_gold_data(

--- a/backend/pipelines/chr_pipeline/gold/production_sites.py
+++ b/backend/pipelines/chr_pipeline/gold/production_sites.py
@@ -8,10 +8,10 @@ Output columns match the Supabase production_sites table:
   location_geom, capacity, main_species_code
 """
 
-import logging
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 from .export import export_gold_table
 
@@ -23,7 +23,7 @@ except ImportError:
     STORAGE_AVAILABLE = False
     StorageAccess = None
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # Cloud storage glob patterns for silver CHR data
 DATA_PATTERNS = {

--- a/backend/pipelines/chr_pipeline/gold/transportation_analysis.py
+++ b/backend/pipelines/chr_pipeline/gold/transportation_analysis.py
@@ -1,9 +1,9 @@
 """CHR Transportation Analysis processing for Gold layer."""
 
-import logging
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 # Try to import cloud storage utilities
 try:
@@ -16,7 +16,7 @@ except ImportError:
     StorageAccess = None
     migrate_save_data_pattern = None
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def setup_database(conn: duckdb.DuckDBPyConnection) -> None:

--- a/backend/pipelines/chr_pipeline/gold/veterinary_timeline.py
+++ b/backend/pipelines/chr_pipeline/gold/veterinary_timeline.py
@@ -1,9 +1,9 @@
 """CHR Veterinary Timeline processing for Gold layer."""
 
-import logging
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 from .config import GOLD_BASE_DIR
 
@@ -19,7 +19,7 @@ except ImportError:
     migrate_save_data_pattern = None
 
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def reconstruct_stable_fires_from_table(con: duckdb.DuckDBPyConnection) -> bool:

--- a/backend/pipelines/chr_pipeline/run_gold_processing.py
+++ b/backend/pipelines/chr_pipeline/run_gold_processing.py
@@ -28,6 +28,8 @@ from pathlib import Path
 # Add the pipeline to the path
 sys.path.insert(0, str(Path(__file__).parent))
 
+from common.logging_utils import get_pipeline_logger
+
 from gold.chr_gold_processing import process_gold_data
 
 
@@ -79,7 +81,7 @@ Examples:
 
     # Setup logging
     setup_logging(args.log_level)
-    logger = logging.getLogger(__name__)
+    logger = get_pipeline_logger(__name__)
 
     logger.info("🥇 CHR Gold Processing - Standalone Mode")
     logger.info("=" * 50)

--- a/backend/pipelines/chr_pipeline/silver/animal_movements.py
+++ b/backend/pipelines/chr_pipeline/silver/animal_movements.py
@@ -12,11 +12,12 @@ import logging
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 # Import export module
 from . import export
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def create_chr_dyr_movement_summaries_table(

--- a/backend/pipelines/chr_pipeline/silver/chr_silver_processing.py
+++ b/backend/pipelines/chr_pipeline/silver/chr_silver_processing.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 
 # Import schema documentation
@@ -1767,7 +1768,7 @@ def process_chr_data(
                 connection=con,
                 pipeline_name="chr_pipeline",
                 pipeline_start_time=pipeline_start_time,
-                logger=logging.getLogger(__name__),
+                logger=get_pipeline_logger(__name__),
             )
 
             tables_query = "SHOW TABLES"

--- a/backend/pipelines/chr_pipeline/silver/spf_su.py
+++ b/backend/pipelines/chr_pipeline/silver/spf_su.py
@@ -15,10 +15,11 @@ import logging
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 from . import export
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def create_spf_su_herds_table(

--- a/backend/pipelines/dma_scraper/bronze/fetch_company_detail.py
+++ b/backend/pipelines/dma_scraper/bronze/fetch_company_detail.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import aiohttp
 from bs4 import BeautifulSoup
+from common.logging_utils import get_pipeline_logger
 
 # Configure logging
 logging.basicConfig(
@@ -12,7 +13,7 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 async def fetch(session, url):

--- a/backend/pipelines/dma_scraper/enhanced_dma_detail_scraper.py
+++ b/backend/pipelines/dma_scraper/enhanced_dma_detail_scraper.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import aiohttp
 from bs4 import BeautifulSoup
+from common.logging_utils import get_pipeline_logger
 from tqdm.asyncio import tqdm
 
 # Configure logging
@@ -19,7 +20,7 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 async def fetch(session, url):

--- a/backend/pipelines/dma_scraper/prototypes/dma_environmental_permits_analysis_prototype.py
+++ b/backend/pipelines/dma_scraper/prototypes/dma_environmental_permits_analysis_prototype.py
@@ -55,6 +55,7 @@ from datetime import datetime
 from pathlib import Path
 
 import vertexai
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 from vertexai.generative_models import GenerativeModel, Part
 
@@ -62,7 +63,7 @@ from vertexai.generative_models import GenerativeModel, Part
 load_dotenv(find_dotenv(usecwd=True))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # PDF processing
 try:

--- a/backend/pipelines/drive_data_pipeline/silver/duckdb_base.py
+++ b/backend/pipelines/drive_data_pipeline/silver/duckdb_base.py
@@ -16,9 +16,10 @@ try:
     logger = get_logger()
 except ImportError:
     # Fallback for standalone usage
-    import logging
 
-    logger = logging.getLogger(__name__)
+    from common.logging_utils import get_pipeline_logger
+
+    logger = get_pipeline_logger(__name__)
 
     # Fallback connection for standalone usage
     def get_duckdb_with_r2() -> duckdb.DuckDBPyConnection:

--- a/backend/pipelines/drive_data_pipeline/silver/models/schema_adapter.py
+++ b/backend/pipelines/drive_data_pipeline/silver/models/schema_adapter.py
@@ -8,8 +8,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     from silver.duckdb_base import DuckDBProcessor
 from .schema import ColumnSchema, DataType, TableSchema

--- a/backend/pipelines/drive_data_pipeline/silver/parquet_manager.py
+++ b/backend/pipelines/drive_data_pipeline/silver/parquet_manager.py
@@ -17,8 +17,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     DriveStorageManager = None
 from .duckdb_base import DuckDBProcessor

--- a/backend/pipelines/drive_data_pipeline/silver/storage.py
+++ b/backend/pipelines/drive_data_pipeline/silver/storage.py
@@ -14,8 +14,10 @@ except ImportError:
     import logging
     import time
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     def generate_timestamp() -> int:
         return int(time.time())

--- a/backend/pipelines/drive_data_pipeline/silver/transformers/advanced_pdf_transformer.py
+++ b/backend/pipelines/drive_data_pipeline/silver/transformers/advanced_pdf_transformer.py
@@ -18,8 +18,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
 
 from .pdf_transformer import PDFTransformer

--- a/backend/pipelines/drive_data_pipeline/silver/transformers/base.py
+++ b/backend/pipelines/drive_data_pipeline/silver/transformers/base.py
@@ -14,8 +14,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     FileMetadata = None
 

--- a/backend/pipelines/drive_data_pipeline/silver/transformers/csv_transformer.py
+++ b/backend/pipelines/drive_data_pipeline/silver/transformers/csv_transformer.py
@@ -13,8 +13,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     from silver.duckdb_base import DuckDBProcessor
     from silver.transformers.base import BaseTransformer, FileMetadata, TransformResult

--- a/backend/pipelines/drive_data_pipeline/silver/transformers/excel_transformer.py
+++ b/backend/pipelines/drive_data_pipeline/silver/transformers/excel_transformer.py
@@ -16,8 +16,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     from silver.duckdb_base import DuckDBProcessor
     from silver.transformers.base import BaseTransformer, FileMetadata, TransformResult

--- a/backend/pipelines/drive_data_pipeline/silver/transformers/fertiliser_transformer.py
+++ b/backend/pipelines/drive_data_pipeline/silver/transformers/fertiliser_transformer.py
@@ -10,13 +10,13 @@ Refactored to use vanilla DuckDB instead of pandas.
 """
 
 import contextlib
-import logging
 import os
 import tempfile
 from pathlib import Path
 from typing import Any
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 from ..models.schema import ColumnSchema, DataType, TableSchema
 from .base import BaseTransformer, TransformResult
@@ -36,7 +36,7 @@ except ImportError:
         return conn
 
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class FertiliserTransformer(BaseTransformer):

--- a/backend/pipelines/drive_data_pipeline/silver/transformers/pdf_transformer.py
+++ b/backend/pipelines/drive_data_pipeline/silver/transformers/pdf_transformer.py
@@ -13,8 +13,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     from silver.duckdb_base import DuckDBProcessor
 from .base import BaseTransformer, TransformResult

--- a/backend/pipelines/drive_data_pipeline/silver/validators/base.py
+++ b/backend/pipelines/drive_data_pipeline/silver/validators/base.py
@@ -11,8 +11,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
 
 # Get logger

--- a/backend/pipelines/drive_data_pipeline/silver/validators/geo_validator.py
+++ b/backend/pipelines/drive_data_pipeline/silver/validators/geo_validator.py
@@ -15,8 +15,10 @@ try:
 except ImportError:
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     from silver.duckdb_base import DuckDBProcessor
 from .base import BaseValidator, ValidationResult

--- a/backend/pipelines/drive_data_pipeline/silver/validators/pii_validator.py
+++ b/backend/pipelines/drive_data_pipeline/silver/validators/pii_validator.py
@@ -11,8 +11,10 @@ except ImportError:
     # Fallback for standalone usage
     import logging
 
+    from common.logging_utils import get_pipeline_logger
+
     def get_logger() -> logging.Logger:
-        return logging.getLogger(__name__)
+        return get_pipeline_logger(__name__)
 
     from silver.duckdb_base import DuckDBProcessor
 from .base import BaseValidator, ValidationResult

--- a/backend/pipelines/drive_data_pipeline/utils/logging.py
+++ b/backend/pipelines/drive_data_pipeline/utils/logging.py
@@ -4,8 +4,10 @@ import logging
 import sys
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
+
 # Create a custom logger
-logger = logging.getLogger("drive_data_pipeline")
+logger = get_pipeline_logger("drive_data_pipeline")
 
 # Define ANSI color codes for different log levels and components
 COLORS = {

--- a/backend/pipelines/migrate_secrets_to_env.py
+++ b/backend/pipelines/migrate_secrets_to_env.py
@@ -10,6 +10,7 @@ Requires:
 import logging
 import os
 
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 from github import Github
 from github.Repository import Repository
@@ -17,7 +18,7 @@ from google.cloud import secretmanager
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def get_google_secrets(project_id: str) -> dict[str, str]:

--- a/backend/pipelines/svineflytning_pipeline/bronze/export.py
+++ b/backend/pipelines/svineflytning_pipeline/bronze/export.py
@@ -1,7 +1,6 @@
 """Module for exporting pig movement data."""
 
 import json
-import logging
 import os
 from collections.abc import Iterator
 from datetime import date, datetime
@@ -9,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import ijson  # Add this import for streaming JSON parsing
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 
 # Import the unified cloud storage access layer
@@ -38,7 +38,7 @@ class DateTimeEncoder(json.JSONEncoder):
 load_dotenv(find_dotenv(usecwd=True))
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # Initialize storage paths and clients
 GCS_BUCKET = os.getenv("STORAGE_BUCKET") or os.getenv("R2_BUCKET") or os.getenv("GCS_BUCKET")

--- a/backend/pipelines/svineflytning_pipeline/bronze/load_svineflytning.py
+++ b/backend/pipelines/svineflytning_pipeline/bronze/load_svineflytning.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import certifi
+from common.logging_utils import get_pipeline_logger
 from requests import Session
 from tenacity import (
     before_log,
@@ -28,7 +29,7 @@ from zeep.wsse.username import UsernameToken
 
 from .export import DateTimeEncoder, export_movements_optimized
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # Constants
 ENDPOINTS = {

--- a/backend/pipelines/svineflytning_pipeline/silver/main.py
+++ b/backend/pipelines/svineflytning_pipeline/silver/main.py
@@ -11,9 +11,11 @@ import os
 from datetime import datetime
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
+
 from .transform import process_svineflytning_silver
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def get_latest_bronze_data_path() -> str | None:

--- a/backend/pipelines/svineflytning_pipeline/silver/transform.py
+++ b/backend/pipelines/svineflytning_pipeline/silver/transform.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 
 # Import DateTimeEncoder for JSON serialization
@@ -23,7 +24,7 @@ from dotenv import find_dotenv, load_dotenv
 load_dotenv(find_dotenv(usecwd=True))
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # Initialize storage configuration
 GCS_BUCKET = os.getenv("R2_BUCKET", "landbruget-data")

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/cadastral.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/cadastral.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import logging
 import os
 import time
 import xml.etree.ElementTree as ET
@@ -9,13 +8,14 @@ from datetime import datetime
 from typing import ClassVar
 
 import aiohttp
+from common.logging_utils import get_pipeline_logger
 from dotenv import find_dotenv, load_dotenv
 from pydantic import ConfigDict
 
 # ✅ MIGRATION: Removed shapely imports - using pure coordinate-based WKT generation
 from unified_pipeline.common.base import BaseJobConfig, BaseSource, BronzeJobInterface
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def clean_value(value):

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/common/uuid_utils.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/common/uuid_utils.py
@@ -6,11 +6,12 @@ data integrity and proper relationships between entities.
 """
 
 import hashlib
-import logging
 import os
 import uuid
 
-logger = logging.getLogger(__name__)
+from common.logging_utils import get_pipeline_logger
+
+logger = get_pipeline_logger(__name__)
 
 
 class LandbrugsdataUUID:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/core/incremental_processing.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/core/incremental_processing.py
@@ -14,14 +14,15 @@ Author: CHR Incremental Processing Implementation
 Date: 2025-09-14
 """
 
-import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
+
 from .gcs_data_access import StorageAccess
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 @dataclass

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/agricultural_pattern_matcher.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/agricultural_pattern_matcher.py
@@ -14,13 +14,14 @@ Author: Analysis Team
 Date: January 2025
 """
 
-import logging
 import time
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
+
 from unified_pipeline.common.base import BaseJobConfig, BaseSource, GoldJobInterface
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class AgriculturalPatternMatcherConfig(BaseJobConfig):

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/arbejdstilsynet_inspections.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/arbejdstilsynet_inspections.py
@@ -6,11 +6,11 @@ Refactored to use vanilla DuckDB instead of pandas for better performance
 and consistency with the unified pipeline architecture.
 """
 
-import logging
 import os
 from datetime import datetime
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
 from common.storage import StorageAccess
 
 from unified_pipeline.common.base import BaseJobConfig, BaseSource, GoldJobInterface
@@ -42,7 +42,7 @@ class ArbjdstilsynetInspectionsGold(
     def __init__(self, config: ArbjdstilsynetInspectionsGoldConfig):
         super().__init__(config)
         self.storage = StorageAccess()
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = get_pipeline_logger(self.__class__.__name__)
 
     async def run(self, silver_data: dict[str, Any] | None = None) -> bool:
         """

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/carbon_emissions/batch_processor.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/carbon_emissions/batch_processor.py
@@ -6,14 +6,14 @@ Processes a subset of CVRs and writes results to parquet files.
 """
 
 import json
-import logging
 from datetime import datetime
 from pathlib import Path
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 # Setup logging
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class BatchProcessor:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/carbon_emissions/climate_calculator.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/carbon_emissions/climate_calculator.py
@@ -14,6 +14,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from common.logging_utils import get_pipeline_logger
+
 # Import data structures from transformer
 from .data_transformer import (
     FertilizerSummary,
@@ -45,7 +47,7 @@ from .formulas.svin.ammoniak import calculate_nh3_emissions_svin
 # Import standardfaktorer module for feed intake lookups
 from .standardfaktorer import lookup_cattle_ts, lookup_pig_fe
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 @dataclass

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/carbon_emissions/data_transformer.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/carbon_emissions/data_transformer.py
@@ -24,8 +24,9 @@ if TYPE_CHECKING:
     from .farm_data import FarmData
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 # Species mapping: Danish to English

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_compliance.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_compliance.py
@@ -49,13 +49,13 @@ CRITICAL: This implementation uses the exact logic from the proven analysis
 that detected 668 clear violations, ensuring regulatory accuracy.
 """
 
-import logging
 import os
 from datetime import datetime
 from typing import Any
 
 import duckdb
 import requests
+from common.logging_utils import get_pipeline_logger
 from common.storage import StorageAccess
 from pydantic import ConfigDict, Field
 from requests.auth import HTTPBasicAuth
@@ -65,7 +65,7 @@ from unified_pipeline.gold.pesticide_unit_sanitization import PesticideUnitSanit
 from unified_pipeline.util.log_util import Logger
 from unified_pipeline.util.timing import timed
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class PlanteITAPI:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_disaggregation.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_disaggregation.py
@@ -47,19 +47,19 @@ without any "enhancements" that could break the proven 92% coverage approach.
 """
 
 import contextlib
-import logging
 import os
 import re
 from typing import Any
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 from pydantic import ConfigDict, Field
 
 from unified_pipeline.common.base import BaseJobConfig, BaseSource, GoldJobInterface
 from unified_pipeline.util.log_util import Logger
 from unified_pipeline.util.timing import timed
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class PesticideDisaggregationGoldConfig(BaseJobConfig):

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_unit_sanitization.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_unit_sanitization.py
@@ -50,13 +50,12 @@ CRITICAL: This implementation uses the exact statistical thresholds from our
 analysis that identified unit errors vs. legitimate formulation differences.
 """
 
-import logging
-
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 from unified_pipeline.util.log_util import Logger
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class PesticideUnitSanitizer:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/buildings_generator.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/buildings_generator.py
@@ -1,16 +1,16 @@
 """Buildings Proximity PMTiles Generator."""
 
 import asyncio
-import logging
 import os
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 from .config import PMTilesGeneratorConfig
 from .data_loader import PMTilesDataLoader
 from .utils import FileManager, GeoJSONWriter, TippecanoeRunner
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # CRS Strategy: All input data (BBR buildings, agricultural fields) is now in EPSG:25832 (Danish UTM).
 # Processing is done in EPSG:25832 (meters work directly for buffers/distances).

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/data_loader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/data_loader.py
@@ -1,14 +1,14 @@
 """Data loading utilities for PMTiles generation."""
 
 import asyncio
-import logging
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 from common.storage import StorageAccess
 
 from .config import PMTilesGeneratorConfig
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class PMTilesDataLoader:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/environmental_generator.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/environmental_generator.py
@@ -1,16 +1,16 @@
 """Environmental Layers PMTiles Generator."""
 
-import logging
 import os
 from datetime import datetime
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 from .config import PMTilesGeneratorConfig
 from .data_loader import PMTilesDataLoader
 from .utils import FileManager, GeoJSONWriter, TippecanoeRunner
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # CRS Strategy: With silver/gold layers now in EPSG:25832, we need to transform to
 # EPSG:4326 (WGS84) for PMTiles/GeoJSON output (required for map display)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/field_analysis_generator.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/field_analysis_generator.py
@@ -1,16 +1,16 @@
 """Field Analysis PMTiles Generator."""
 
 import asyncio
-import logging
 import os
 
 import duckdb
+from common.logging_utils import get_pipeline_logger
 
 from .config import PMTilesGeneratorConfig
 from .data_loader import PMTilesDataLoader
 from .utils import FileManager, GeoJSONWriter, TippecanoeRunner
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # CRS Strategy: With silver/gold layers now in EPSG:25832, we need to transform to
 # EPSG:4326 (WGS84) for PMTiles/GeoJSON output (required for map display)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/main.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/main.py
@@ -6,6 +6,8 @@ import logging
 import os
 import sys
 
+from common.logging_utils import get_pipeline_logger
+
 from unified_pipeline.common.base import BaseSource
 
 from .buildings_generator import BuildingsProximityPMTilesGenerator
@@ -16,7 +18,7 @@ from .field_analysis_generator import FieldAnalysisPMTilesGenerator
 from .uploader import CloudflareR2Uploader
 from .year_detector import DataSourceYearDetector
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class PMTilesGeneratorPipeline(BaseSource[PMTilesGeneratorConfig]):

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/uploader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/uploader.py
@@ -2,13 +2,14 @@
 
 import asyncio
 import json
-import logging
 import os
 import subprocess
 
+from common.logging_utils import get_pipeline_logger
+
 from .config import PMTilesGeneratorConfig
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 class CloudflareR2Uploader:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/utils.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/utils.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import logging
 import os
 import shutil
 import subprocess
@@ -10,7 +9,9 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from common.logging_utils import get_pipeline_logger
+
+logger = get_pipeline_logger(__name__)
 
 
 class TippecanoeRunner:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/year_detector.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/year_detector.py
@@ -1,14 +1,14 @@
 """Dynamic year detection for PMTiles data sources."""
 
 import asyncio
-import logging
 import re
 
+from common.logging_utils import get_pipeline_logger
 from common.storage import StorageAccess
 
 from .config import PMTilesGeneratorConfig
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 
 def _normalize_path(path: str) -> str:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cadastral.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/cadastral.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from typing import Any
 
@@ -6,6 +5,7 @@ from common.geometry_validator import (
     validate_and_normalize_to_utm,
     validate_and_transform_geometries_duckdb,
 )
+from common.logging_utils import get_pipeline_logger
 
 # ✅ MIGRATION: Removed pandas import - using DuckDB for data operations
 from dotenv import find_dotenv, load_dotenv
@@ -13,7 +13,7 @@ from pydantic import ConfigDict
 
 from unified_pipeline.common.base import BaseJobConfig, BaseSource, SilverJobInterface
 
-logger = logging.getLogger(__name__)
+logger = get_pipeline_logger(__name__)
 
 # CRS Strategy: Use EPSG:25832 for processing, transform to EPSG:4326 only at Supabase upload
 USE_UTM_PROCESSING = True


### PR DESCRIPTION
## 🛠️ Issue Fix

No issue linked

## 💡 Solution

- [x] Replaced all direct `logging.getLogger()` calls in 82 pipeline files with `get_pipeline_logger()` from `common/logging_utils.py`
- [x] Removed a duplicate `setup_logger()` implementation in `bbr_buildings/utils/logger.py`, replacing it with a thin wrapper around `setup_pipeline_logger()` from common
- [x] Third-party logger suppressions (`zeep`, `urllib3`, `google`, `requests`) are intentionally left using stdlib `logging.getLogger` as they configure noise suppression, not pipeline loggers

## ✅ How to Do Self-Test

```bash
cd backend && source venv/bin/activate && python -m pytest common/tests/test_logging_utils.py -v
```

Verify pipelines import correctly: `python -c "from common.logging_utils import get_pipeline_logger; print('OK')"` from any pipeline directory.

## 📝 Additional Notes

Legitimate remaining uses of `logging.getLogger` exist in `chr_pipeline/main.py` and `svineflytning_pipeline/main.py` for third-party level suppression and child-logger level configuration — these are correct and intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)