### PR TITLE
fix(pesticidkort): force always_xy for ST_Transform so drift-exposure joins match

### DIFF
--- a/backend/common/crs_utils.py
+++ b/backend/common/crs_utils.py
@@ -328,6 +328,10 @@ def sql_transform_to_utm(geometry_expr: str, source_crs: str = WGS84) -> str:
     """
     Generate SQL to transform geometry to Danish UTM for metric operations.
 
+    Uses ``always_xy := true`` so EPSG:4326 is interpreted as (lon, lat) regardless
+    of DuckDB's session default — PROJ's canonical axis order for 4326 is (lat, lon)
+    and relying on the default has silently produced garbage UTM coords.
+
     Args:
         geometry_expr: SQL expression for geometry
         source_crs: Source CRS (default WGS84)
@@ -335,12 +339,15 @@ def sql_transform_to_utm(geometry_expr: str, source_crs: str = WGS84) -> str:
     Returns:
         SQL expression for transformed geometry
     """
-    return f"ST_Transform({geometry_expr}, '{source_crs}', '{DANISH_UTM}')"
+    return f"ST_Transform({geometry_expr}, '{source_crs}', '{DANISH_UTM}', always_xy := true)"
 
 
 def sql_transform_to_wgs84(geometry_expr: str, source_crs: str = DANISH_UTM) -> str:
     """
     Generate SQL to transform geometry to WGS84 for storage.
+
+    Uses ``always_xy := true`` to emit (lon, lat) — what PostGIS/Supabase and our
+    R2 JSON consumers expect.
 
     Args:
         geometry_expr: SQL expression for geometry
@@ -349,7 +356,7 @@ def sql_transform_to_wgs84(geometry_expr: str, source_crs: str = DANISH_UTM) -> 
     Returns:
         SQL expression for transformed geometry
     """
-    return f"ST_Transform({geometry_expr}, '{source_crs}', '{WGS84}')"
+    return f"ST_Transform({geometry_expr}, '{source_crs}', '{WGS84}', always_xy := true)"
 
 
 def sql_buffer_meters(geometry_expr: str, meters: float, source_crs: str = WGS84) -> str:
@@ -368,7 +375,7 @@ def sql_buffer_meters(geometry_expr: str, meters: float, source_crs: str = WGS84
 
     Example:
         >>> sql_buffer_meters("geometry", 100)
-        "ST_Transform(ST_Buffer(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832'), 100), 'EPSG:25832', 'EPSG:4326')"
+        "ST_Transform(ST_Buffer(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832', always_xy := true), 100), 'EPSG:25832', 'EPSG:4326', always_xy := true)"
     """
     if source_crs == DANISH_UTM:
         # Already in UTM, just buffer
@@ -376,8 +383,8 @@ def sql_buffer_meters(geometry_expr: str, meters: float, source_crs: str = WGS84
     # Transform to UTM, buffer, transform back
     return (
         f"ST_Transform("
-        f"ST_Buffer(ST_Transform({geometry_expr}, '{source_crs}', '{DANISH_UTM}'), {meters}), "
-        f"'{DANISH_UTM}', '{source_crs}')"
+        f"ST_Buffer(ST_Transform({geometry_expr}, '{source_crs}', '{DANISH_UTM}', always_xy := true), {meters}), "
+        f"'{DANISH_UTM}', '{source_crs}', always_xy := true)"
     )
 
 
@@ -397,8 +404,8 @@ def sql_intersects_with_buffer_meters(geom1_expr: str, geom2_expr: str, meters: 
     if source_crs == DANISH_UTM:
         return f"ST_Intersects({geom1_expr}, ST_Buffer({geom2_expr}, {meters}))"
     # Transform both to UTM for the operation
-    geom1_utm = f"ST_Transform({geom1_expr}, '{source_crs}', '{DANISH_UTM}')"
-    geom2_utm = f"ST_Transform({geom2_expr}, '{source_crs}', '{DANISH_UTM}')"
+    geom1_utm = f"ST_Transform({geom1_expr}, '{source_crs}', '{DANISH_UTM}', always_xy := true)"
+    geom2_utm = f"ST_Transform({geom2_expr}, '{source_crs}', '{DANISH_UTM}', always_xy := true)"
     return f"ST_Intersects({geom1_utm}, ST_Buffer({geom2_utm}, {meters}))"
 
 
@@ -418,12 +425,12 @@ def sql_transform_for_supabase(geometry_expr: str, source_crs: str = DANISH_UTM)
 
     Example:
         >>> sql_transform_for_supabase("geometry")
-        "ST_Transform(geometry, 'EPSG:25832', 'EPSG:4326')"
+        "ST_Transform(geometry, 'EPSG:25832', 'EPSG:4326', always_xy := true)"
     """
     if source_crs == WGS84:
         # Already in WGS84, no transform needed
         return geometry_expr
-    return f"ST_Transform({geometry_expr}, '{source_crs}', '{WGS84}')"
+    return f"ST_Transform({geometry_expr}, '{source_crs}', '{WGS84}', always_xy := true)"
 
 
 def sql_transform_to_processing_crs(geometry_expr: str, source_crs: str) -> str:
@@ -442,9 +449,12 @@ def sql_transform_to_processing_crs(geometry_expr: str, source_crs: str) -> str:
 
     Example:
         >>> sql_transform_to_processing_crs("geometry", "EPSG:4326")
-        "ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')"
+        "ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832', always_xy := true)"
     """
     if source_crs == DANISH_UTM:
         # Already in processing CRS, no transform needed
         return geometry_expr
-    return f"ST_Transform({geometry_expr}, '{source_crs}', '{DANISH_UTM}')"
+    # always_xy := true forces (lon, lat) input semantics for EPSG:4326 — PROJ's
+    # canonical axis order for 4326 is (lat, lon), so without this flag UTM
+    # coords come out reflected and spatial joins silently return 0 matches.
+    return f"ST_Transform({geometry_expr}, '{source_crs}', '{DANISH_UTM}', always_xy := true)"

--- a/backend/pipelines/api_export/main.py
+++ b/backend/pipelines/api_export/main.py
@@ -58,6 +58,10 @@ def create_connection() -> duckdb.DuckDBPyConnection:
     conn = duckdb.connect()
     conn.execute("SET memory_limit = '4GB'")
     conn.execute("SET threads = 4")
+    # Spatial extension is required by exporters that do geometry filtering
+    # (e.g. drift_exposure uses ST_Within). Loading unconditionally is cheap.
+    conn.execute("INSTALL spatial")
+    conn.execute("LOAD spatial")
 
     if not setup_duckdb_cloud_auth(conn):
         logger.warning("No cloud auth configured — will only work with local files")

--- a/frontend/src/components/pesticidkort/PersonalReport.tsx
+++ b/frontend/src/components/pesticidkort/PersonalReport.tsx
@@ -38,11 +38,31 @@ export function PersonalReport({
       className="animate-fade-slide-up space-y-6 px-5 py-4 motion-reduce:animate-none"
     >
       <div className="bg-card rounded-xl p-5">
-        <PesticideProximityScore
-          grade={report.grade.grade}
-          label={report.grade.label}
-          description={report.grade.description}
-        />
+        {report.grade ? (
+          <PesticideProximityScore
+            grade={report.grade.grade}
+            label={report.grade.label}
+            description={report.grade.description}
+          />
+        ) : (
+          <div
+            data-testid="pesticide-proximity-score-empty"
+            aria-live="polite"
+            className="pt-6 pb-8"
+          >
+            <p className="text-muted-foreground mb-2 text-xs font-semibold tracking-widest uppercase">
+              Pesticideksponering
+            </p>
+            <p className="font-display text-foreground text-3xl leading-tight font-semibold tracking-tight sm:text-4xl">
+              Ingen data for denne adresse
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Vi fandt ingen bygning i BBR inden for 60 m af adressen og ingen
+              sprøjtede marker inden for {report.radius_m} m. Prøv en
+              nærliggende adresse for at se eksponering.
+            </p>
+          </div>
+        )}
         <div className="mt-4 flex items-center gap-3">
           <button
             onClick={() => handleShare(report)}

--- a/frontend/src/components/pesticidkort/ReportMapView.tsx
+++ b/frontend/src/components/pesticidkort/ReportMapView.tsx
@@ -64,7 +64,10 @@ export function ReportMapView({
   );
   const [chemFilter, setChemFilter] = useState<ChemicalFilter>('none');
   const histogram = useBurdenHistogram(year);
-  const { match: driftExposure } = useDriftExposure(lat, lng);
+  const { match: driftExposure, status: driftStatus } = useDriftExposure(
+    lat,
+    lng
+  );
   const { report, handleFieldsLoaded } = useReportBuilder({
     address,
     lat,
@@ -72,6 +75,7 @@ export function ReportMapView({
     radiusM,
     year,
     driftExposure,
+    driftStatus,
   });
 
   const handleMapFieldClick = useCallback(

--- a/frontend/src/components/pesticidkort/StoryMode.tsx
+++ b/frontend/src/components/pesticidkort/StoryMode.tsx
@@ -31,7 +31,7 @@ export function StoryMode({ report, onClose }: StoryModeProps) {
     fields_count: report.fields_count,
     pfas_count: report.pfas_fields_count,
     distance: Math.round(report.nearest_field_m),
-    grade: report.grade.grade,
+    grade: report.grade?.grade ?? 'UNKNOWN',
     total_burden: report.fields
       .reduce((sum, f) => sum + f.total_pesticide_belastning, 0)
       .toFixed(1),

--- a/frontend/src/components/pesticidkort/types.ts
+++ b/frontend/src/components/pesticidkort/types.ts
@@ -50,7 +50,7 @@ export interface PesticideReport {
   lng: number;
   radius_m: number;
   year: number;
-  grade: GradeInfo;
+  grade: GradeInfo | null;
   score: number;
   fields_count: number;
   pfas_fields_count: number;

--- a/frontend/src/components/pesticidkort/useReportBuilder.ts
+++ b/frontend/src/components/pesticidkort/useReportBuilder.ts
@@ -28,6 +28,8 @@ function computeExposure(
   };
 }
 
+type DriftStatus = 'idle' | 'loading' | 'ready' | 'no_match';
+
 interface UseReportBuilderOptions {
   address: string;
   lat: number;
@@ -35,6 +37,7 @@ interface UseReportBuilderOptions {
   radiusM: number;
   year: number;
   driftExposure: DriftExposureMatch | null;
+  driftStatus: DriftStatus;
 }
 
 export function useReportBuilder({
@@ -44,6 +47,7 @@ export function useReportBuilder({
   radiusM,
   year,
   driftExposure,
+  driftStatus,
 }: UseReportBuilderOptions) {
   const [report, setReport] = useState<PesticideReport | null>(null);
 
@@ -53,13 +57,20 @@ export function useReportBuilder({
         fields,
         radiusM
       );
-      const grade: GradeInfo = driftExposure
-        ? driftPercentileToGrade(
-            driftExposure.exposure_percentile,
-            driftExposure.drift_dose_kg,
-            driftExposure.national_avg_drift_dose_kg
-          )
-        : fallbackGrade;
+      // When drift-exposure has no BBR match AND we found no nearby sprayed
+      // fields, we genuinely have no signal — don't default to UNDER_AVG (the
+      // burden fallback returns that for fields.length === 0 and that misled
+      // users into thinking every address was below average).
+      const hasNoData = driftStatus === 'no_match' && fields.length === 0;
+      const grade: GradeInfo | null = hasNoData
+        ? null
+        : driftExposure
+          ? driftPercentileToGrade(
+              driftExposure.exposure_percentile,
+              driftExposure.drift_dose_kg,
+              driftExposure.national_avg_drift_dose_kg
+            )
+          : fallbackGrade;
       let pfasCount = 0;
       let totalBurden = 0;
       let hasBnbo = false;
@@ -90,7 +101,7 @@ export function useReportBuilder({
         exposure_1000m: computeExposure(fields, radiusM),
       });
     },
-    [address, lat, lng, radiusM, year, driftExposure]
+    [address, lat, lng, radiusM, year, driftExposure, driftStatus]
   );
 
   // If drift exposure lands after fields, upgrade the grade in place.
@@ -101,7 +112,7 @@ export function useReportBuilder({
       driftExposure.drift_dose_kg,
       driftExposure.national_avg_drift_dose_kg
     );
-    if (driftGrade.grade === report.grade.grade) return;
+    if (report.grade && driftGrade.grade === report.grade.grade) return;
     setReport({ ...report, grade: driftGrade });
   }, [driftExposure, report]);
 


### PR DESCRIPTION
## 🛠️ Issue Fix

The pesticidkort address report card showed **"Under gennemsnit" (1/6 segments)** for every Danish address, regardless of real exposure.

No issue linked.

## 💡 Solution

Root cause was a silent CRS axis-order bug in `common/crs_utils.py`. The EPSG:4326 → EPSG:25832 helper emitted `ST_Transform(geom, 'EPSG:4326', 'EPSG:25832')` without `always_xy := true`, so DuckDB applied PROJ's canonical (lat, lon) order to our (lon, lat) data, producing reflected UTM coords. `ST_DWithin` in the drift-exposure gold layer then matched 0 of 1.3M BBR buildings → every drift-exposure parquet was empty → `api_export` never produced the R2 JSON → the frontend fell back to `computePesticideScore`, which returns UNDER_AVG whenever `fields.length === 0`.

- **`backend/common/crs_utils.py`** — add `always_xy := true` to all six SQL transform helpers (processing, utm, wgs84, buffer, intersects, supabase) so axis order is deterministic regardless of DuckDB's default.
- **`backend/pipelines/api_export/main.py`** — `INSTALL + LOAD spatial` in `create_connection()`; `DriftExposureExporter` uses `ST_Within` and was crashing with `CatalogException` as soon as it ran.
- **Frontend hardening** — thread `useDriftExposure.status` through `ReportMapView` → `useReportBuilder`. When drift returns `no_match` AND no sprayed fields are within radius, set `grade = null` and render "Ingen data for denne adresse" in `PersonalReport` instead of silently defaulting to UNDER_AVG.

Trade-off: `always_xy := true` now applies to every pipeline that uses these helpers, not just drift-exposure. This is the correct behavior — our WGS84 data is stored as (lon, lat) across the board, matching PostGIS/OGC:CRS84 — but any consumer that was accidentally depending on the reflected output will change.

## ✅ How to Do Self-Test

1. Re-run `unified_pipeline` drift-exposure jobs and confirm `gold/pesticide_drift_exposure_*/…/*.parquet` has non-zero rows.
2. Re-run `api_export_pipeline` and verify `curl https://data.pesticidkortet.dk/api/v1/pesticides/drift-exposure/index.json` returns `pesticide_year` + `national_avg_drift_dose_kg`.
3. `cd frontend && npm run dev`, search a potato-heavy address in Jylland, and confirm the exposure bar lights past UNDER_AVG.
4. Central Copenhagen address should still show UNDER_AVG — but now backed by a real percentile, not a fallback.
5. An address in the middle of a lake or outside BBR coverage should now show "Ingen data for denne adresse" instead of a fake UNDER_AVG.

## 📝 Additional Notes

Shipping this requires re-running `unified_pipeline` (drift-exposure) and then `api_export_pipeline` so the R2 JSON keys actually exist — the code fix alone doesn't restore the UI until the data is re-computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)