### PR TITLE
fix(pesticidkort): restore overview tiles + scroll-into-view via refs

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/uploader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/uploader.py
@@ -419,8 +419,10 @@ class CloudflareR2Uploader:
             current_r2_keys = set(current_files.keys())
 
             for layer_type, files in layer_files.items():
-                if layer_type == "field_analysis":
-                    # For year-specific files, keep the most recent versions
+                if layer_type.startswith("field_analysis"):
+                    # Year-versioned families (field_analysis, field_analysis_overview).
+                    # Keep retention per family — runs that don't upload them (e.g.
+                    # --environmental-only) must NOT delete the existing versions.
                     files.sort(key=lambda x: x[0], reverse=True)  # Sort by year, newest first
 
                     # Skip files that are being uploaded in this run

--- a/backend/pipelines/unified_pipeline/tests/gold/test_pmtiles_generator.py
+++ b/backend/pipelines/unified_pipeline/tests/gold/test_pmtiles_generator.py
@@ -369,6 +369,40 @@ class TestCloudflareR2Uploader:
             assert mock_delete.call_count >= 2
 
     @pytest.mark.asyncio
+    async def test_cleanup_preserves_overview_during_environmental_only(self, test_config):
+        """Environmental-only runs must not delete field_analysis_overview tiles.
+
+        Regression test: filenames like field_analysis_overview_2024.pmtiles were
+        being misclassified as year-independent layers, so any run that didn't
+        upload them (e.g. --environmental-only) wiped every year. That made the
+        overview layers serving the < zoom 12 view of pesticidkort disappear.
+        """
+        uploader = CloudflareR2Uploader(test_config)
+
+        existing_files = [
+            "pmtiles/field_analysis_overview_2023.pmtiles",
+            "pmtiles/field_analysis_overview_2024.pmtiles",
+            "pmtiles/field_analysis_overview_2025.pmtiles",
+            "pmtiles/bnbo_areas.pmtiles",
+        ]
+
+        # Simulate an --environmental-only upload: only env layers in current_files.
+        current_files = {
+            "pmtiles/bnbo_areas.pmtiles": "/tmp/bnbo_areas.pmtiles",
+        }
+
+        with (
+            patch.object(uploader, "list_existing_pmtiles", return_value=existing_files),
+            patch.object(uploader, "delete_pmtiles", return_value=True) as mock_delete,
+        ):
+            await uploader.cleanup_old_pmtiles(current_files, keep_versions=3)
+
+            deleted = {call.args[0] for call in mock_delete.call_args_list}
+            for path in existing_files:
+                if "field_analysis_overview" in path:
+                    assert path not in deleted, f"Overview tile {path} was deleted"
+
+    @pytest.mark.asyncio
     async def test_upload_with_cleanup(self, test_config):
         """Test upload with automatic cleanup."""
         uploader = CloudflareR2Uploader(test_config)

--- a/frontend/src/components/pesticidkort/FieldCard.tsx
+++ b/frontend/src/components/pesticidkort/FieldCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, forwardRef } from 'react';
 import { cn } from '@/lib/utils';
 import { ChevronDown } from 'lucide-react';
 import type { NearbyFieldSummary } from '@/components/pesticidkort/types';
@@ -21,103 +21,101 @@ interface FieldCardProps {
   onSelect?: () => void;
 }
 
-export function FieldCard({
-  field,
-  histogram,
-  isSelected,
-  onSelect,
-}: FieldCardProps) {
-  const [expanded, setExpanded] = useState(false);
-  const burden = field.total_pesticide_belastning;
-  const hasPfas = field.pfas_applications > 0;
-  const isZeroBurden = burden === 0;
-  const hasProducts =
-    field.pfas_products_detail ||
-    field.diquat_products_detail ||
-    field.glyphosate_products_detail ||
-    field.other_products_detail;
+export const FieldCard = forwardRef<HTMLDivElement, FieldCardProps>(
+  function FieldCard({ field, histogram, isSelected, onSelect }, ref) {
+    const [expanded, setExpanded] = useState(false);
+    const burden = field.total_pesticide_belastning;
+    const hasPfas = field.pfas_applications > 0;
+    const isZeroBurden = burden === 0;
+    const hasProducts =
+      field.pfas_products_detail ||
+      field.diquat_products_detail ||
+      field.glyphosate_products_detail ||
+      field.other_products_detail;
 
-  const prevSelectedRef = useRef(isSelected);
-  useEffect(() => {
-    if (isSelected && !prevSelectedRef.current && hasProducts) {
-      setExpanded(true);
-    }
-    prevSelectedRef.current = isSelected;
-  }, [isSelected, hasProducts]);
+    const prevSelectedRef = useRef(isSelected);
+    useEffect(() => {
+      if (isSelected && !prevSelectedRef.current && hasProducts) {
+        setExpanded(true);
+      }
+      prevSelectedRef.current = isSelected;
+    }, [isSelected, hasProducts]);
 
-  return (
-    <div
-      id={field.field_uuid}
-      data-testid={`field-card-${field.field_uuid}`}
-      className={cn(
-        'bg-card mb-2 rounded-xl px-4 py-3 transition-all duration-200 hover:shadow-md hover:-translate-y-1',
-        isSelected && 'ring-primary ring-2',
-        field.is_organic && !isSelected && 'border-success/40 border-l-2'
-      )}
-    >
-      <button
-        onClick={onSelect}
-        data-testid={`field-select-${field.field_uuid}-button`}
-        className="w-full text-left"
+    return (
+      <div
+        ref={ref}
+        data-testid={`field-card-${field.field_uuid}`}
+        className={cn(
+          'bg-card mb-2 rounded-xl px-4 py-3 transition-all duration-200 hover:shadow-md hover:-translate-y-1',
+          isSelected && 'ring-primary ring-2',
+          field.is_organic && !isSelected && 'border-success/40 border-l-2'
+        )}
       >
-        <div className="flex items-center gap-2 text-sm">
-          <span className="text-foreground font-medium">
-            {Math.round(field.distance_m)} m fra dig
-          </span>
-          <span className="text-muted-foreground text-xs">
-            · {field.area_hectares.toFixed(1)} ha
-          </span>
-          {hasPfas && (
-            <span className="bg-warning/10 text-warning rounded-full px-1.5 py-0.5 text-[10px] leading-none font-medium">
-              PFAS
+        <button
+          onClick={onSelect}
+          data-testid={`field-select-${field.field_uuid}-button`}
+          className="w-full text-left"
+        >
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-foreground font-medium">
+              {Math.round(field.distance_m)} m fra dig
             </span>
-          )}
-        </div>
+            <span className="text-muted-foreground text-xs">
+              · {field.area_hectares.toFixed(1)} ha
+            </span>
+            {hasPfas && (
+              <span className="bg-warning/10 text-warning rounded-full px-1.5 py-0.5 text-[10px] leading-none font-medium">
+                PFAS
+              </span>
+            )}
+          </div>
 
-        {!isZeroBurden && (
-          <div className="mt-2.5 flex items-center gap-2">
-            <BurdenScale burden={burden} histogram={histogram} />
-            <span className="text-muted-foreground shrink-0 text-[11px] tabular-nums">
-              {formatBurden(burden)}
-            </span>
+          {!isZeroBurden && (
+            <div className="mt-2.5 flex items-center gap-2">
+              <BurdenScale burden={burden} histogram={histogram} />
+              <span className="text-muted-foreground shrink-0 text-[11px] tabular-nums">
+                {formatBurden(burden)}
+              </span>
+            </div>
+          )}
+        </button>
+
+        <FieldProximity field={field} />
+
+        {hasProducts && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            data-testid={`field-expand-${field.field_uuid}-button`}
+            aria-expanded={expanded}
+            className="text-muted-foreground mt-1 flex min-h-[44px] items-center gap-1 text-xs hover:underline"
+          >
+            <ChevronDown
+              className={cn(
+                'h-3 w-3 transition-transform',
+                expanded && 'rotate-180'
+              )}
+            />
+            {expanded ? 'Skjul pesticider' : 'Vis pesticider'}
+          </button>
+        )}
+
+        {hasProducts && (
+          <div
+            className={cn(
+              'grid transition-[grid-template-rows,opacity] duration-300 ease-[cubic-bezier(0.25,1,0.5,1)]',
+              expanded
+                ? 'grid-rows-[1fr] opacity-100'
+                : 'grid-rows-[0fr] opacity-0'
+            )}
+            aria-hidden={!expanded}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <FieldProducts field={field} />
+            </div>
           </div>
         )}
-      </button>
-
-      <FieldProximity field={field} />
-
-      {hasProducts && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          data-testid={`field-expand-${field.field_uuid}-button`}
-          aria-expanded={expanded}
-          className="text-muted-foreground mt-1 flex min-h-[44px] items-center gap-1 text-xs hover:underline"
-        >
-          <ChevronDown
-            className={cn(
-              'h-3 w-3 transition-transform',
-              expanded && 'rotate-180'
-            )}
-          />
-          {expanded ? 'Skjul pesticider' : 'Vis pesticider'}
-        </button>
-      )}
-
-      {hasProducts && (
-        <div
-          className={cn(
-            'grid transition-[grid-template-rows,opacity] duration-300 ease-[cubic-bezier(0.25,1,0.5,1)]',
-            expanded
-              ? 'grid-rows-[1fr] opacity-100'
-              : 'grid-rows-[0fr] opacity-0'
-          )}
-          aria-hidden={!expanded}
-        >
-          <div className="min-h-0 overflow-hidden">
-            <FieldProducts field={field} />
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
+      </div>
+    );
+  }
+);
+FieldCard.displayName = 'FieldCard';

--- a/frontend/src/components/pesticidkort/FieldList.tsx
+++ b/frontend/src/components/pesticidkort/FieldList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import { FieldCard } from '@/components/pesticidkort/FieldCard';
@@ -26,6 +26,7 @@ export function FieldList({
 }: FieldListProps) {
   const reducedMotion = useReducedMotion();
   const [showAll, setShowAll] = useState(false);
+  const cardRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
 
   const sortedFields = useMemo(
     () => [...fields].sort((a, b) => a.distance_m - b.distance_m),
@@ -51,16 +52,16 @@ export function FieldList({
       setShowAll(true);
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          document
-            .getElementById(selectedFieldUuid)
+          cardRefs.current
+            .get(selectedFieldUuid)
             ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         });
       });
       return;
     }
     requestAnimationFrame(() => {
-      document
-        .getElementById(selectedFieldUuid)
+      cardRefs.current
+        .get(selectedFieldUuid)
         ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     });
   }, [selectedFieldUuid, sortedFields, showAll]);
@@ -83,6 +84,9 @@ export function FieldList({
             }}
           >
             <FieldCard
+              ref={(el) => {
+                cardRefs.current.set(field.field_uuid, el);
+              }}
               field={field}
               histogram={histogram}
               isSelected={field.field_uuid === selectedFieldUuid}
@@ -110,6 +114,9 @@ export function FieldList({
             Uden for dit nærområde — indgår ikke i din score
           </p>
           <FieldCard
+            ref={(el) => {
+              cardRefs.current.set(clickedField.field_uuid, el);
+            }}
             field={clickedField}
             histogram={histogram}
             isSelected


### PR DESCRIPTION
## Summary

Two pesticidkort fixes shipped together:

### 1. Restore zoomed-out field visibility (cleanup bug)

`cleanup_old_pmtiles` in the PMTiles uploader misclassified files like `field_analysis_overview_2024.pmtiles` as a year-independent layer. Any run that didn't upload them — notably `--environmental-only` — deleted **every year** of overview tiles. The 2026-04-18 env-only Generate PMTiles run wiped overviews for 2008–2022.

The pesticidkort frontend uses two layers (see `frontend/src/components/pesticidkort/map-layers.ts`):
- `fields-fill` / `fields-outline` — full data, `minzoom: 12`
- `fields-overview-fill` / `fields-overview-outline` — 3 properties, `maxzoom: 12`, sourced from the deleted overview file

With the overview source missing and detail layers gated to zoom 12+, the map looked empty when zoomed out. Treating `field_analysis_overview` as part of the year-versioned `field_analysis*` family means partial runs leave it alone and `keep_versions` retention applies. Regression test added.

### 2. Field card scroll-into-view via refs

`FieldList` was scrolling the selected card into view by `document.getElementById(field_uuid)` — fragile when ids collide with other DOM elements or when the list re-renders. Switched `FieldCard` to `forwardRef` and keep refs in a `Map` keyed by `field_uuid`.

## Follow-up (post-merge, not in this PR)

After merge, trigger Generate PMTiles with `years_range=2008-2025` to regenerate overview tiles for the full FVM range (pesticide data goes back to 2010, fields to 2008). The matrix path uses `--target-year` and skips cleanup, so it won't touch anything else.

## Test plan

- [x] Backend: `pytest tests/gold/test_pmtiles_generator.py -k cleanup` — 3/3 pass, including new regression test that asserts overview tiles survive an env-only-style cleanup
- [x] Backend: ruff clean
- [x] Frontend: `npm run lint` clean
- [x] Frontend: `npm run test:smoke` passes
- [ ] Manual: after re-running Generate PMTiles, verify field polygons render across Denmark at zoom 7 in `/pesticidkort/explore` and stay visible across the 11→12→13 boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)