### PR TITLE
fix(pesticidkort): harden map UX and pesticide exports

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -36,7 +36,7 @@ Automate pull request creation with comprehensive description and proper linking
 ```bash
 # 1. Verify tests pass
 cd frontend && npm test
-cd ../backend && python -m pytest
+cd .. && uv run --all-packages --group dev pytest
 
 # 2. Verify lint passes
 cd frontend && npm run lint

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -65,7 +65,7 @@ def test_acceptance_criterion_1():
 cd frontend && npm test -- --grep "Feature Name"
 
 # Backend
-cd backend && pytest tests/test_feature.py -v
+uv run --all-packages --group dev pytest backend/tests/test_feature.py -v
 ```
 
 **IMPORTANT**: Tests MUST fail before implementation. If they pass, the test is invalid.
@@ -84,7 +84,7 @@ Write only the code needed to make tests pass:
 cd frontend && npm test
 
 # Backend
-cd backend && pytest
+uv run --all-packages --group dev pytest
 ```
 
 ### 6. Verify Acceptance Criteria
@@ -105,7 +105,7 @@ cd frontend && npm run build
 
 # All tests
 cd frontend && npm test
-cd backend && pytest
+uv run --all-packages --group dev pytest
 ```
 
 ### 8. Update Spec
@@ -143,9 +143,9 @@ Every `/implement` must pass these gates:
 | Gate | Command | Required |
 |------|---------|----------|
 | Tests written first | - | Yes |
-| Tests fail initially | `npm test` / `pytest` | Yes |
+| Tests fail initially | `npm test` / `uv run --all-packages --group dev pytest` | Yes |
 | Implementation complete | - | Yes |
-| Tests pass | `npm test` / `pytest` | Yes |
+| Tests pass | `npm test` / `uv run --all-packages --group dev pytest` | Yes |
 | Lint passes | `npm run lint` | Yes |
 | No regressions | Full test suite | Yes |
 | Spec criteria met | Manual check | Yes |

--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -31,9 +31,8 @@ npm test
 
 **Backend Tests:**
 ```bash
-cd $CLAUDE_PROJECT_DIR/backend
-source venv/bin/activate
-python -m pytest -v
+cd $CLAUDE_PROJECT_DIR
+uv run --all-packages --group dev pytest -v
 ```
 
 **Smoke Tests (fast):**
@@ -96,7 +95,7 @@ For each failure, report:
 cd frontend && npm test
 
 # Backend only
-cd backend && source venv/bin/activate && pytest -v
+uv run --all-packages --group dev pytest -v
 
 # Smoke tests (< 30 seconds)
 cd frontend && npm run test:smoke

--- a/.github/workflows/api_export_pipeline.yml
+++ b/.github/workflows/api_export_pipeline.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       only:
-        description: 'Run only specific exporters (comma-separated: homepage,search,municipalities,pesticides,companies)'
+        description: 'Run only specific exporters (comma-separated: homepage,search,municipalities,drift_exposure,pesticides,companies)'
         required: false
         type: string
   workflow_call:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,7 @@ cd frontend && npm test              # Playwright E2E
 cd frontend && npm run lint          # oxlint
 
 # Backend
-cd backend && source venv/bin/activate
-python -m pytest                     # Run tests
+uv run --all-packages --group dev pytest  # Run backend tests
 cd pipelines/<name> && python main.py  # Run pipeline
 
 # Database
@@ -47,7 +46,7 @@ supabase db push                     # Push migrations
 
 ```bash
 cd frontend && npm test && npm run lint
-cd backend && python -m pytest
+uv run --all-packages --group dev pytest
 ```
 
 ## Conventions
@@ -99,7 +98,7 @@ Before any commit, run:
 
 ```bash
 cd frontend && npm test && npm run lint   # Playwright E2E + oxlint
-cd backend && python -m pytest            # Python tests
+uv run --all-packages --group dev pytest  # Python tests
 ```
 
 Confirm:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,7 @@ cd frontend && npm test              # Playwright E2E
 cd frontend && npm run lint          # oxlint
 
 # Backend
-cd backend && source venv/bin/activate
-python -m pytest                     # Run tests
+uv run --all-packages --group dev pytest  # Run backend tests
 cd pipelines/<name> && python main.py  # Run pipeline
 
 # Data Export (R2 CDN)
@@ -40,7 +39,7 @@ cd pipelines/api_export && python main.py  # Export all JSON to R2
 
 ```bash
 cd frontend && npm test && npm run lint
-cd backend && python -m pytest
+uv run --all-packages --group dev pytest
 ```
 
 **Fix pre-existing test failures, don't ignore them.** If `npm test` or `pytest` surfaces a failure that predates your branch (stale testids, renamed components, broken selectors), fix it in the same PR. Never dismiss it as "unrelated" or "upstream flakiness" — the cost of leaving broken tests compounds because future agents assume they're baseline noise. See `.claude/rules/testing.md` for details.

--- a/README.md
+++ b/README.md
@@ -64,12 +64,10 @@ npm run dev                       # http://localhost:3000
 ### Backend Pipelines
 
 ```bash
-cd backend
-python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
+uv sync --all-packages --group dev
 
 # Run a specific pipeline
-cd pipelines/unified_pipeline
+cd backend/pipelines/unified_pipeline
 python -m unified_pipeline bronze --source cadastral
 ```
 
@@ -139,9 +137,9 @@ cd frontend && npm test         # Playwright E2E
 cd frontend && npm run lint     # oxlint
 
 # Backend
-cd backend && source venv/bin/activate
-python -m pytest                # pytest
-ruff check . && ruff format .   # Lint + format
+uv run --all-packages --group dev pytest   # pytest
+uv run --all-packages --group dev ruff check backend
+uv run --all-packages --group dev ruff format backend
 ```
 
 ### Branch Naming
@@ -162,8 +160,8 @@ Examples: `feat(frontend): add interactive map view`, `fix(pipeline): correct CH
 
 1. Create a branch from `main` following the naming convention above
 2. Make your changes
-3. Run all tests (`npm test` + `pytest`)
-4. Run linters (`npm run lint` + `ruff check .`)
+3. Run all tests (`npm test` + `uv run --all-packages --group dev pytest`)
+4. Run linters (`npm run lint` + `uv run --all-packages --group dev ruff check backend`)
 5. Open a pull request — all PRs require review before merge
 
 ## License

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,12 +30,11 @@ backend/
 ## Quick Start
 
 ```bash
-cd backend
-python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
+# From repo root
+uv sync --all-packages --group dev
 
 # Run a pipeline
-cd pipelines/chr_pipeline && python main.py --step bronze
+cd backend/pipelines/chr_pipeline && python main.py --step bronze
 ```
 
 ## Stack
@@ -129,9 +128,8 @@ DuckDB is the primary processor. Key DuckDB 1.5 considerations:
 ## Testing
 
 ```bash
-source venv/bin/activate
-python -m pytest                      # All tests
-python -m pytest -v -k test_name      # Specific test
+uv run --all-packages --group dev pytest                              # All tests
+uv run --package api-export --group dev pytest -v -k test_name        # Specific test
 ```
 
 - Each pipeline has its own `tests/` and `conftest.py`

--- a/backend/pipelines/api_export/exporters/base.py
+++ b/backend/pipelines/api_export/exporters/base.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from decimal import Decimal
 from pathlib import Path
 
 import duckdb
@@ -9,6 +10,16 @@ import s3fs
 from common.logging_utils import get_pipeline_logger
 
 logger = get_pipeline_logger("api_export")
+
+
+def _to_json_safe(value):
+    if isinstance(value, Decimal):
+        return int(value) if value == value.to_integral_value() else float(value)
+    if isinstance(value, dict):
+        return {key: _to_json_safe(inner) for key, inner in value.items()}
+    if isinstance(value, list):
+        return [_to_json_safe(item) for item in value]
+    return value
 
 
 class BaseExporter:
@@ -46,7 +57,7 @@ class BaseExporter:
             data: JSON-serializable data
             path: Relative path under api/v1/, e.g. "homepage/statistics.json"
         """
-        json_str = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+        json_str = json.dumps(_to_json_safe(data), ensure_ascii=False, separators=(",", ":"))
 
         if self.output_dir:
             # Local mode for testing

--- a/backend/pipelines/api_export/exporters/pesticides.py
+++ b/backend/pipelines/api_export/exporters/pesticides.py
@@ -80,11 +80,9 @@ class PesticidesExporter(BaseExporter):
             stats["files_written"] += 1
 
         # Per-company
-        company_count = self._per_company(period)
-        stats["files_written"] += company_count
-        stats["company_files"] = company_count
-
-        # Burden histograms for all available years
+        # Burden histograms for all available years. Generate these before the
+        # expensive per-company export so report-mode dependencies are
+        # published even if long-tail company files take much longer.
         bmd_path = f"r2://{BUCKET}/silver/bmd/20260301_042330/pesticide_products.parquet"
         try:
             self.load_parquet_table(bmd_path, "bmd_products")
@@ -93,6 +91,11 @@ class PesticidesExporter(BaseExporter):
             stats["histogram_years"] = sorted(year_paths.keys())
         except Exception:
             logger.warning("Could not load BMD data for burden histogram")
+
+        # Per-company
+        company_count = self._per_company(period)
+        stats["files_written"] += company_count
+        stats["company_files"] = company_count
 
         return stats
 
@@ -272,46 +275,54 @@ class PesticidesExporter(BaseExporter):
         """Generate per-company pesticide detail files. Returns count of files written."""
         count = 0
         try:
-            # Get all companies with pesticide data
             companies = self.query_to_dicts("""
                 SELECT DISTINCT p.cvr_number, c.company_name, c.current_municipality_name AS municipality
                 FROM pesticides p
                 LEFT JOIN companies c ON p.cvr_number = c.cvr_number::VARCHAR
                 ORDER BY p.cvr_number
             """)
+            if not companies:
+                return 0
 
-            for comp in companies:
-                cvr = comp["cvr_number"]
-                details = self.query_to_dicts(f"""
+            summaries = {}
+            for row in self.query_to_dicts("""
                     SELECT
-                        PesticideName AS pesticide_name,
-                        DosageQuantity AS dosage_quantity,
-                        DosageUnit AS dosage_unit,
-                        AllocatedArea AS allocated_area_ha,
-                        AllocationMethod AS allocation_method,
-                        municipality
-                    FROM pesticides
-                    WHERE cvr_number = '{cvr}'
-                    ORDER BY PesticideName
-                """)
-
-                summary = self.query_to_dicts(f"""
-                    SELECT
+                        cvr_number,
                         COUNT(*) AS total_applications,
                         COUNT(DISTINCT PesticideName) AS unique_pesticides,
                         ROUND(SUM(AllocatedArea), 1) AS total_treated_area_ha,
                         ROUND(SUM(DosageQuantity), 2) AS total_dosage
                     FROM pesticides
-                    WHERE cvr_number = '{cvr}'
-                """)
+                    GROUP BY cvr_number
+                """):
+                cvr = str(row.pop("cvr_number"))
+                summaries[cvr] = row
+            details_by_cvr: dict[str, list[dict]] = {}
+            for row in self.query_to_dicts("""
+                SELECT
+                    cvr_number,
+                    PesticideName AS pesticide_name,
+                    DosageQuantity AS dosage_quantity,
+                    DosageUnit AS dosage_unit,
+                    AllocatedArea AS allocated_area_ha,
+                    AllocationMethod AS allocation_method,
+                    municipality
+                FROM pesticides
+                ORDER BY cvr_number, PesticideName
+            """):
+                cvr = row.pop("cvr_number")
+                details_by_cvr.setdefault(str(cvr), []).append(row)
+
+            for comp in companies:
+                cvr = str(comp["cvr_number"])
 
                 self.write_json(
                     {
                         "cvr_number": cvr,
                         "company_name": comp.get("company_name"),
                         "municipality": comp.get("municipality"),
-                        "summary": summary[0] if summary else {},
-                        "applications": details,
+                        "summary": summaries.get(cvr, {}),
+                        "applications": details_by_cvr.get(cvr, []),
                         "metadata": {
                             "generated_at": datetime.now(UTC).isoformat(),
                             "period": period,

--- a/backend/pipelines/api_export/main.py
+++ b/backend/pipelines/api_export/main.py
@@ -47,8 +47,8 @@ EXPORTERS = {
     "homepage": HomepageExporter,
     "search": SearchIndexExporter,
     "municipalities": MunicipalitiesExporter,
-    "pesticides": PesticidesExporter,
     "drift_exposure": DriftExposureExporter,
+    "pesticides": PesticidesExporter,
     "companies": CompanyProfilesExporter,
 }
 

--- a/backend/pipelines/api_export/tests/test_pesticides.py
+++ b/backend/pipelines/api_export/tests/test_pesticides.py
@@ -1,0 +1,134 @@
+"""Tests for PesticidesExporter."""
+
+import json
+from pathlib import Path
+
+import duckdb
+
+from exporters.pesticides import PesticidesExporter
+
+
+def _seed_tables(conn: duckdb.DuckDBPyConnection) -> None:
+    conn.execute("""
+        CREATE TABLE pesticides AS
+        SELECT * FROM (VALUES
+            ('11111111', 'Alpha', 1.0, 'L', 10.0, 'area_match', 'Aarhus'),
+            ('11111111', 'Beta',  2.5, 'kg', 8.0,  'area_match', 'Aarhus'),
+            ('22222222', 'Gamma', 3.0, 'L', 12.0, 'area_match', 'Odense')
+        ) AS t(cvr_number, PesticideName, DosageQuantity, DosageUnit, AllocatedArea, AllocationMethod, municipality)
+    """)
+    conn.execute("""
+        CREATE TABLE companies AS
+        SELECT * FROM (VALUES
+            ('11111111', 'Farm One', 'Aarhus'),
+            ('22222222', 'Farm Two', 'Odense')
+        ) AS t(cvr_number, company_name, current_municipality_name)
+    """)
+
+
+def _legacy_per_company_payloads(conn: duckdb.DuckDBPyConnection, period: str) -> dict[str, dict]:
+    """Replicate the pre-batching SQL shape for regression comparison."""
+    payloads: dict[str, dict] = {}
+    companies = conn.execute("""
+        SELECT DISTINCT p.cvr_number, c.company_name, c.current_municipality_name AS municipality
+        FROM pesticides p
+        LEFT JOIN companies c ON p.cvr_number = c.cvr_number::VARCHAR
+        ORDER BY p.cvr_number
+    """).fetchall()
+
+    for cvr, company_name, municipality in companies:
+        details_result = conn.execute(f"""
+            SELECT
+                PesticideName AS pesticide_name,
+                DosageQuantity AS dosage_quantity,
+                DosageUnit AS dosage_unit,
+                AllocatedArea AS allocated_area_ha,
+                AllocationMethod AS allocation_method,
+                municipality
+            FROM pesticides
+            WHERE cvr_number = '{cvr}'
+            ORDER BY PesticideName
+        """)
+        detail_columns = [desc[0] for desc in details_result.description]
+        details = [
+            dict(zip(detail_columns, row, strict=False)) for row in details_result.fetchall()
+        ]
+
+        summary_result = conn.execute(f"""
+            SELECT
+                COUNT(*) AS total_applications,
+                COUNT(DISTINCT PesticideName) AS unique_pesticides,
+                ROUND(SUM(AllocatedArea), 1) AS total_treated_area_ha,
+                ROUND(SUM(DosageQuantity), 2) AS total_dosage
+            FROM pesticides
+            WHERE cvr_number = '{cvr}'
+        """)
+        summary_columns = [desc[0] for desc in summary_result.description]
+        summary_rows = [
+            dict(zip(summary_columns, row, strict=False)) for row in summary_result.fetchall()
+        ]
+
+        payloads[str(cvr)] = {
+            "cvr_number": str(cvr),
+            "company_name": company_name,
+            "municipality": municipality,
+            "summary": summary_rows[0] if summary_rows else {},
+            "applications": details,
+            "metadata": {
+                "generated_at": "__dynamic__",
+                "period": period,
+            },
+        }
+
+    return payloads
+
+
+def test_per_company_writes_expected_json(tmp_path: Path) -> None:
+    conn = duckdb.connect(":memory:")
+    _seed_tables(conn)
+
+    exporter = PesticidesExporter(conn=conn, output_dir=str(tmp_path))
+
+    count = exporter._per_company("2024-2025")
+
+    assert count == 2
+
+    company_one = json.loads((tmp_path / "pesticides" / "companies" / "11111111.json").read_text())
+    assert company_one["company_name"] == "Farm One"
+    assert company_one["municipality"] == "Aarhus"
+    assert company_one["summary"] == {
+        "total_applications": 2,
+        "unique_pesticides": 2,
+        "total_treated_area_ha": 18.0,
+        "total_dosage": 3.5,
+    }
+    assert [entry["pesticide_name"] for entry in company_one["applications"]] == ["Alpha", "Beta"]
+
+    company_two = json.loads((tmp_path / "pesticides" / "companies" / "22222222.json").read_text())
+    assert company_two["summary"]["total_applications"] == 1
+    assert [entry["pesticide_name"] for entry in company_two["applications"]] == ["Gamma"]
+
+
+def test_per_company_matches_legacy_query_shape(tmp_path: Path) -> None:
+    conn = duckdb.connect(":memory:")
+    _seed_tables(conn)
+
+    exporter = PesticidesExporter(conn=conn, output_dir=str(tmp_path))
+    period = "2024-2025"
+
+    expected = _legacy_per_company_payloads(conn, period)
+
+    count = exporter._per_company(period)
+
+    assert count == len(expected)
+
+    for cvr, legacy_payload in expected.items():
+        written = json.loads((tmp_path / "pesticides" / "companies" / f"{cvr}.json").read_text())
+        assert written["cvr_number"] == legacy_payload["cvr_number"]
+        assert written["company_name"] == legacy_payload["company_name"]
+        assert written["municipality"] == legacy_payload["municipality"]
+        assert written["summary"] == legacy_payload["summary"]
+        assert written["applications"] == legacy_payload["applications"]
+        assert written["metadata"]["period"] == legacy_payload["metadata"]["period"]
+        assert isinstance(written["metadata"]["generated_at"], str)
+        assert written["metadata"]["generated_at"]

--- a/backend/pipelines/arbejdstilsynet_inspections/pyproject.toml
+++ b/backend/pipelines/arbejdstilsynet_inspections/pyproject.toml
@@ -14,8 +14,6 @@ dependencies = [
     "pyarrow>=14.0.0",
     "loguru>=0.7.3",
     "playwright>=1.40.0",
-    "fastapi>=0.136.0",
-    "uvicorn>=0.44.0",
     "pydantic",
     "numpy>=2.4.4",
     "duckdb",

--- a/frontend/src/app/api/burden-histogram/route.ts
+++ b/frontend/src/app/api/burden-histogram/route.ts
@@ -12,8 +12,10 @@ const CACHE_HEADERS = {
 
 export async function GET(request: NextRequest) {
   const year = Number(new URL(request.url).searchParams.get('year') ?? '2024');
-
-  const data = await getCachedBurdenHistogram(year);
-
-  return NextResponse.json(data, { headers: CACHE_HEADERS });
+  try {
+    const data = await getCachedBurdenHistogram(year);
+    return NextResponse.json(data, { headers: CACHE_HEADERS });
+  } catch {
+    return NextResponse.json([], { headers: CACHE_HEADERS });
+  }
 }

--- a/frontend/src/app/api/drift-exposure/route.ts
+++ b/frontend/src/app/api/drift-exposure/route.ts
@@ -13,12 +13,26 @@ const CACHE_HEADERS = {
   'Vercel-CDN-Cache-Control': 'public, max-age=604800',
 };
 
+const EMPTY_DRIFT_EXPOSURE_INDEX = {
+  pesticide_year: null,
+  national_avg_drift_dose_kg: null,
+  building_count: 0,
+  unmatched_count: 0,
+  kommunekoder: [],
+};
+
 export async function GET(request: NextRequest) {
   const kommunekode = new URL(request.url).searchParams.get('kommunekode');
 
   if (!kommunekode) {
-    const data = await getCachedDriftExposureIndex();
-    return NextResponse.json(data, { headers: CACHE_HEADERS });
+    try {
+      const data = await getCachedDriftExposureIndex();
+      return NextResponse.json(data, { headers: CACHE_HEADERS });
+    } catch {
+      return NextResponse.json(EMPTY_DRIFT_EXPOSURE_INDEX, {
+        headers: CACHE_HEADERS,
+      });
+    }
   }
 
   if (!/^\d{3,4}$/.test(kommunekode)) {

--- a/frontend/src/app/api/og/pesticidkort/route.tsx
+++ b/frontend/src/app/api/og/pesticidkort/route.tsx
@@ -1,25 +1,32 @@
 /* oxlint-disable landbruget/no-inline-styles */
 import { ImageResponse } from 'next/og';
 import type { NextRequest } from 'next/server';
+import {
+  GRADE_DEFINITIONS,
+  getGradeHexColor,
+  isPesticideGrade,
+} from '@/lib/pesticide-score';
+import type { PesticideGrade } from '@/components/pesticidkort/types';
 
 export const runtime = 'edge';
 
-const GRADE_COLORS: Record<string, string> = {
-  A: '#2d9a6e',
-  B: '#5aa85e',
-  C: '#c9a030',
-  D: '#c06a28',
-  E: '#b83a2a',
+const DEFAULT_ACCENT_COLOR = '#57534e';
+const DEFAULT_GRADE_META = {
+  label: 'Pesticideksponering',
+  description: 'Modelleret estimat baseret på offentlige data',
 };
 
-export async function GET(request: NextRequest) {
+export function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
-  const grade = searchParams.get('grade') ?? 'C';
+  const rawGrade = searchParams.get('grade');
+  const grade: PesticideGrade | null =
+    rawGrade && isPesticideGrade(rawGrade) ? rawGrade : null;
   const addr = searchParams.get('addr') ?? 'Din adresse';
   const fields = searchParams.get('fields') ?? '0';
   const pfas = searchParams.get('pfas') ?? '0';
   const dist = searchParams.get('dist') ?? '0';
-  const color = GRADE_COLORS[grade] ?? GRADE_COLORS.C;
+  const color = grade ? getGradeHexColor(grade) : DEFAULT_ACCENT_COLOR;
+  const gradeMeta = grade ? GRADE_DEFINITIONS[grade] : DEFAULT_GRADE_META;
 
   return new ImageResponse(
     <div
@@ -38,19 +45,48 @@ export async function GET(request: NextRequest) {
         <div
           style={{
             display: 'flex',
-            alignItems: 'center',
+            flexDirection: 'column',
             justifyContent: 'center',
-            width: '160px',
+            width: '320px',
             height: '160px',
             borderRadius: '24px',
-            backgroundColor: color,
-            color: '#fff',
-            fontSize: '96px',
-            fontWeight: 700,
-            lineHeight: 1,
+            backgroundColor: '#f5f5f4',
+            border: `3px solid ${color}`,
+            padding: '20px 24px',
           }}
         >
-          {grade}
+          <div
+            style={{
+              fontSize: '18px',
+              color: color,
+              marginBottom: '10px',
+              textTransform: 'uppercase' as const,
+              letterSpacing: '0.06em',
+              fontWeight: 700,
+            }}
+          >
+            Pesticideksponering
+          </div>
+          <div
+            style={{
+              fontSize: grade ? '34px' : '38px',
+              fontWeight: 700,
+              color: '#1c1917',
+              lineHeight: 1.15,
+              marginBottom: '8px',
+            }}
+          >
+            {gradeMeta.label}
+          </div>
+          <div
+            style={{
+              fontSize: '16px',
+              color: '#57534e',
+              lineHeight: 1.3,
+            }}
+          >
+            {gradeMeta.description}
+          </div>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
           <div

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,6 +1,10 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+:root {
+  --pesticidkort-footer-height: 0px;
+}
+
 @keyframes typing {
   from {
     width: 0;
@@ -462,6 +466,26 @@
       flex-wrap: wrap !important;
       gap: 0.5rem !important;
     }
+
+    [data-testid='year-timeline'],
+    [data-testid='year-timeline'] > div,
+    [data-testid='chemical-filter-pills'] {
+      flex-wrap: nowrap !important;
+    }
+
+    [data-testid='year-timeline'] {
+      overflow-x: visible !important;
+    }
+
+    [data-testid='year-timeline'] > div {
+      overflow-x: auto !important;
+    }
+
+    [data-testid='year-timeline'] button,
+    [data-testid^='chemical-filter-'] {
+      max-width: none !important;
+      white-space: nowrap !important;
+    }
   }
 
   /* Improve touch targets for mobile - WCAG 2.1 AA Compliance */
@@ -552,13 +576,20 @@
       border-color 0.3s ease;
   }
 
-  /* Pesticidkort explore map: sit the zoom/compass control below the
-     top overlay (back + search + year timeline + chemical filter pills)
-     so it stays fully visible across mobile and desktop, and clear of
-     the ExploreFieldPanel (right side on desktop, bottom sheet on mobile)
-     and MapLegend (bottom-left). Match the sibling PesticidkortMap's
-     top-left placement for consistency within the feature. */
-  [data-testid='explore-map'] .maplibregl-ctrl-top-left {
-    top: calc(env(safe-area-inset-top, 0px) + 10rem);
+  /* Pesticidkort map controls need to override the broad mobile layout
+     fallbacks above so the timeline/pills stay on one line and the
+     MapLibre zoom buttons sit clear of the page overlays. */
+  .pesticidkort-map-shell--explore .maplibregl-ctrl-top-left {
+    top: calc(env(safe-area-inset-top, 0px) + 10rem) !important;
+  }
+
+  .pesticidkort-map-shell--report .maplibregl-ctrl-top-left {
+    top: calc(env(safe-area-inset-top, 0px) + 4.5rem) !important;
+  }
+
+  @media (max-width: 768px) {
+    .pesticidkort-map-shell--explore .maplibregl-ctrl-top-left {
+      top: calc(env(safe-area-inset-top, 0px) + 12.5rem) !important;
+    }
   }
 }

--- a/frontend/src/components/pesticidkort/BottomSheet.tsx
+++ b/frontend/src/components/pesticidkort/BottomSheet.tsx
@@ -80,7 +80,7 @@ export function BottomSheet({
       role="region"
       aria-label="Pesticidrapport"
       className={cn(
-        'bg-background fixed inset-x-0 bottom-0 z-30 rounded-t-2xl shadow-2xl',
+        'bg-background fixed inset-x-0 bottom-[var(--pesticidkort-footer-height)] z-30 rounded-t-2xl shadow-2xl',
         'h-[var(--sheet-height,140px)]',
         'transition-[height] duration-300 ease-[cubic-bezier(0.25,1,0.5,1)]',
         dragStartRef.current && 'transition-none'

--- a/frontend/src/components/pesticidkort/DesktopSidebar.tsx
+++ b/frontend/src/components/pesticidkort/DesktopSidebar.tsx
@@ -7,7 +7,7 @@ interface DesktopSidebarProps {
 
 export function DesktopSidebar({ children, controls }: DesktopSidebarProps) {
   return (
-    <div className="pointer-events-none absolute inset-y-0 right-0 hidden w-[420px] md:block">
+    <div className="pointer-events-none absolute top-0 right-0 bottom-[var(--pesticidkort-footer-height)] hidden w-[420px] md:block">
       <div className="bg-background/95 pointer-events-auto flex h-full flex-col border-l pt-14 backdrop-blur-sm">
         <div
           className="flex-1 overflow-y-auto"

--- a/frontend/src/components/pesticidkort/DisclaimerFooter.tsx
+++ b/frontend/src/components/pesticidkort/DisclaimerFooter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { InfoIcon, XIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -18,9 +18,36 @@ const LINKS: { href: string; id: string; label: string }[] = [
 
 export function DisclaimerFooter() {
   const [expanded, setExpanded] = useState(false);
+  const footerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const footer = footerRef.current;
+    if (!footer) return;
+
+    const root = document.documentElement;
+    const syncFooterHeight = () => {
+      root.style.setProperty(
+        '--pesticidkort-footer-height',
+        `${footer.offsetHeight}px`
+      );
+    };
+
+    syncFooterHeight();
+
+    const observer = new ResizeObserver(syncFooterHeight);
+    observer.observe(footer);
+    window.addEventListener('resize', syncFooterHeight);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', syncFooterHeight);
+      root.style.setProperty('--pesticidkort-footer-height', '0px');
+    };
+  }, []);
 
   return (
     <div
+      ref={footerRef}
       data-testid="pesticidkort-disclaimer-footer"
       className="bg-background/90 border-border/60 pointer-events-auto fixed right-0 bottom-0 left-0 z-40 border-t backdrop-blur-sm"
     >

--- a/frontend/src/components/pesticidkort/DisclaimerModal.tsx
+++ b/frontend/src/components/pesticidkort/DisclaimerModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
   Dialog,
@@ -21,10 +21,14 @@ const BULLETS: string[] = [
 ];
 
 export function DisclaimerModal() {
-  const [open, setOpen] = useState(() => !localStorage.getItem(STORAGE_KEY));
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setOpen(!window.localStorage.getItem(STORAGE_KEY));
+  }, []);
 
   const handleAccept = () => {
-    localStorage.setItem(STORAGE_KEY, new Date().toISOString());
+    window.localStorage.setItem(STORAGE_KEY, new Date().toISOString());
     setOpen(false);
   };
 

--- a/frontend/src/components/pesticidkort/ExploreFieldPanel.tsx
+++ b/frontend/src/components/pesticidkort/ExploreFieldPanel.tsx
@@ -23,7 +23,7 @@ export function ExploreFieldPanel({ field, onClose }: ExploreFieldPanelProps) {
   return (
     <div
       data-testid="explore-field-panel"
-      className="bg-background/95 absolute inset-x-0 bottom-0 z-30 max-h-[60vh] overflow-y-auto rounded-t-2xl px-4 pt-4 pb-6 shadow-lg backdrop-blur-sm md:inset-x-auto md:top-48 md:right-4 md:bottom-auto md:max-h-[calc(100vh-13rem)] md:w-80 md:rounded-xl"
+      className="bg-background/95 absolute inset-x-0 bottom-[var(--pesticidkort-footer-height)] z-30 max-h-[60vh] overflow-y-auto rounded-t-2xl px-4 pt-4 pb-6 shadow-lg backdrop-blur-sm md:inset-x-auto md:top-48 md:right-4 md:bottom-auto md:max-h-[calc(100vh-13rem)] md:w-80 md:rounded-xl"
     >
       <div className="mb-3 flex items-start justify-between">
         <div>

--- a/frontend/src/components/pesticidkort/ExploreMapInner.tsx
+++ b/frontend/src/components/pesticidkort/ExploreMapInner.tsx
@@ -104,21 +104,23 @@ export function ExploreMapInner({
 
   return (
     <>
-      <Map
-        ref={mapRef}
-        initialViewState={{
-          longitude: DENMARK_CENTER.longitude,
-          latitude: DENMARK_CENTER.latitude,
-          zoom: DENMARK_ZOOM,
-        }}
-        mapStyle={mapStyle}
-        onLoad={handleMapLoad}
-        onZoom={handleZoom}
-        attributionControl={false}
-        data-testid="explore-map"
-      >
-        <NavigationControl position="top-left" />
-      </Map>
+      <div className="pesticidkort-map-shell pesticidkort-map-shell--explore h-full w-full">
+        <Map
+          ref={mapRef}
+          initialViewState={{
+            longitude: DENMARK_CENTER.longitude,
+            latitude: DENMARK_CENTER.latitude,
+            zoom: DENMARK_ZOOM,
+          }}
+          mapStyle={mapStyle}
+          onLoad={handleMapLoad}
+          onZoom={handleZoom}
+          attributionControl={false}
+          data-testid="explore-map"
+        >
+          <NavigationControl position="top-left" />
+        </Map>
+      </div>
       {hoverData && <FieldHoverTooltip {...hoverData} />}
     </>
   );

--- a/frontend/src/components/pesticidkort/FieldList.tsx
+++ b/frontend/src/components/pesticidkort/FieldList.tsx
@@ -8,6 +8,63 @@ import type { HistogramBin } from '@/components/pesticidkort/BurdenScale';
 import type { NearbyFieldSummary } from '@/components/pesticidkort/types';
 
 const INITIAL_VISIBLE = 5;
+const CARD_SCROLL_PADDING = 12;
+const EXPANSION_OBSERVER_WINDOW_MS = 400;
+
+function findScrollContainer(element: HTMLElement): HTMLElement | null {
+  let current = element.parentElement;
+
+  while (current) {
+    const style = window.getComputedStyle(current);
+    const overflowY = style.overflowY;
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      current.scrollHeight > current.clientHeight
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  return document.scrollingElement instanceof HTMLElement
+    ? document.scrollingElement
+    : null;
+}
+
+function ensureCardFullyVisible(
+  element: HTMLElement,
+  behavior: ScrollBehavior = 'smooth'
+) {
+  const container = findScrollContainer(element);
+
+  if (!container) {
+    element.scrollIntoView({ behavior, block: 'nearest' });
+    return;
+  }
+
+  const containerRect =
+    container === document.scrollingElement
+      ? { top: 0, bottom: window.innerHeight }
+      : container.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+  const visibleTop = containerRect.top + CARD_SCROLL_PADDING;
+  const visibleBottom = containerRect.bottom - CARD_SCROLL_PADDING;
+
+  if (elementRect.top < visibleTop) {
+    container.scrollBy({
+      top: elementRect.top - visibleTop,
+      behavior,
+    });
+    return;
+  }
+
+  if (elementRect.bottom > visibleBottom) {
+    container.scrollBy({
+      top: elementRect.bottom - visibleBottom,
+      behavior,
+    });
+  }
+}
 
 interface FieldListProps {
   fields: NearbyFieldSummary[];
@@ -45,25 +102,57 @@ export function FieldList({
 
   useEffect(() => {
     if (!selectedFieldUuid) return;
+
+    let animationFrame1 = 0;
+    let animationFrame2 = 0;
+    let resizeObserver: ResizeObserver | null = null;
+    let resizeObserverTimeout = 0;
+
+    const scrollSelectedCard = (behavior: ScrollBehavior = 'smooth') => {
+      const selectedCard = cardRefs.current.get(selectedFieldUuid);
+      if (!selectedCard) return;
+
+      ensureCardFullyVisible(selectedCard, behavior);
+
+      if (typeof ResizeObserver === 'undefined') return;
+
+      resizeObserver?.disconnect();
+      resizeObserver = new ResizeObserver(() => {
+        ensureCardFullyVisible(selectedCard, 'auto');
+      });
+      resizeObserver.observe(selectedCard);
+
+      window.clearTimeout(resizeObserverTimeout);
+      resizeObserverTimeout = window.setTimeout(() => {
+        resizeObserver?.disconnect();
+        resizeObserver = null;
+      }, EXPANSION_OBSERVER_WINDOW_MS);
+    };
+
+    const scheduleScroll = () => {
+      animationFrame1 = requestAnimationFrame(() => {
+        animationFrame2 = requestAnimationFrame(() => {
+          scrollSelectedCard();
+        });
+      });
+    };
+
     const idx = sortedFields.findIndex(
       (f) => f.field_uuid === selectedFieldUuid
     );
     if (idx >= INITIAL_VISIBLE && !showAll) {
       setShowAll(true);
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          cardRefs.current
-            .get(selectedFieldUuid)
-            ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        });
-      });
-      return;
+      scheduleScroll();
+    } else {
+      scheduleScroll();
     }
-    requestAnimationFrame(() => {
-      cardRefs.current
-        .get(selectedFieldUuid)
-        ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-    });
+
+    return () => {
+      cancelAnimationFrame(animationFrame1);
+      cancelAnimationFrame(animationFrame2);
+      resizeObserver?.disconnect();
+      window.clearTimeout(resizeObserverTimeout);
+    };
   }, [selectedFieldUuid, sortedFields, showAll]);
 
   return (

--- a/frontend/src/components/pesticidkort/MapLegend.tsx
+++ b/frontend/src/components/pesticidkort/MapLegend.tsx
@@ -7,11 +7,11 @@ import { ChevronDown } from 'lucide-react';
 import type { ChemicalFilter } from '@/components/pesticidkort/map-layers';
 
 const GRADE_ITEMS = [
-  { bg: 'bg-[#22c55e]', label: 'A \u2014 Under 0,5 B/ha' },
-  { bg: 'bg-[#84cc16]', label: 'B \u2014 0,5\u20132,0 B/ha' },
-  { bg: 'bg-[#eab308]', label: 'C \u2014 2,0\u20134,0 B/ha' },
-  { bg: 'bg-[#f97316]', label: 'D \u2014 4,0\u20138,0 B/ha' },
-  { bg: 'bg-[#dc2626]', label: 'E \u2014 Over 8,0 B/ha' },
+  { bg: 'bg-[#22c55e]', label: 'Under 0,5 B/ha' },
+  { bg: 'bg-[#84cc16]', label: '0,5\u20132,0 B/ha' },
+  { bg: 'bg-[#eab308]', label: '2,0\u20134,0 B/ha' },
+  { bg: 'bg-[#f97316]', label: '4,0\u20138,0 B/ha' },
+  { bg: 'bg-[#dc2626]', label: 'Over 8,0 B/ha' },
   { bg: 'bg-[#d1d5db]', label: 'Brak / ingen pesticider' },
 ] as const;
 
@@ -35,14 +35,14 @@ export function MapLegend({ activeFilter = 'none' }: MapLegendProps) {
   return (
     <div
       data-testid="map-legend"
-      className="bg-background/90 absolute bottom-4 left-4 z-20 rounded-lg px-3 py-2 shadow-md backdrop-blur-sm"
+      className="bg-background/90 absolute bottom-[calc(var(--pesticidkort-footer-height)+1rem)] left-4 z-20 max-w-[calc(100vw-2rem)] rounded-lg px-3 py-2 shadow-md backdrop-blur-sm"
     >
       <button
         onClick={() => setCollapsed(!collapsed)}
         data-testid="map-legend-toggle-button"
         className="flex min-h-[32px] w-full items-center justify-between gap-2 text-xs font-medium"
       >
-        <span className="text-foreground">
+        <span className="text-foreground min-w-0 text-left">
           {hasFilter ? CHEMICAL_META[activeFilter].label : 'Pesticidbelastning'}
         </span>
         <ChevronDown
@@ -80,7 +80,7 @@ function GradeLegendItems() {
       {GRADE_ITEMS.map((item) => (
         <div key={item.label} className="flex items-center gap-2">
           <div className={cn('h-3 w-3 shrink-0 rounded-sm', item.bg)} />
-          <span className="text-muted-foreground text-[11px]">
+          <span className="text-muted-foreground min-w-0 text-[11px] leading-tight">
             {item.label}
           </span>
         </div>
@@ -99,13 +99,15 @@ function ChemicalLegendItems({
     <>
       <div className="flex items-center gap-2">
         <div className={cn('h-3 w-3 shrink-0 rounded-sm', meta.bg)} />
-        <span className="text-muted-foreground text-[11px]">
+        <span className="text-muted-foreground min-w-0 text-[11px] leading-tight">
           Marker med {meta.label}
         </span>
       </div>
       <div className="flex items-center gap-2">
         <div className="h-3 w-3 shrink-0 rounded-sm bg-[#d1d5db] opacity-20" />
-        <span className="text-muted-foreground text-[11px]">Andre marker</span>
+        <span className="text-muted-foreground min-w-0 text-[11px] leading-tight">
+          Andre marker
+        </span>
       </div>
     </>
   );

--- a/frontend/src/components/pesticidkort/PesticidkortMap.tsx
+++ b/frontend/src/components/pesticidkort/PesticidkortMap.tsx
@@ -127,20 +127,22 @@ export function PesticidkortMap({
 
   return (
     <>
-      <Map
-        ref={mapRef}
-        initialViewState={{ longitude: lng, latitude: lat, zoom: 13.5 }}
-        mapStyle={mapStyle}
-        onLoad={handleMapLoad}
-        attributionControl={false}
-        data-testid="pesticidkort-map"
-      >
-        <NavigationControl position="top-left" />
-        {isReady && <ProximityRings lat={lat} lng={lng} radiusM={radiusM} />}
-        <Marker longitude={lng} latitude={lat} anchor="center">
-          <div className="bg-primary border-background h-4 w-4 rounded-full border-2 shadow-md" />
-        </Marker>
-      </Map>
+      <div className="pesticidkort-map-shell pesticidkort-map-shell--report h-full w-full">
+        <Map
+          ref={mapRef}
+          initialViewState={{ longitude: lng, latitude: lat, zoom: 13.5 }}
+          mapStyle={mapStyle}
+          onLoad={handleMapLoad}
+          attributionControl={false}
+          data-testid="pesticidkort-map"
+        >
+          <NavigationControl position="top-left" />
+          {isReady && <ProximityRings lat={lat} lng={lng} radiusM={radiusM} />}
+          <Marker longitude={lng} latitude={lat} anchor="center">
+            <div className="bg-primary border-background h-4 w-4 rounded-full border-2 shadow-md" />
+          </Marker>
+        </Map>
+      </div>
       {hoverData && <FieldHoverTooltip {...hoverData} />}
     </>
   );

--- a/frontend/src/components/pesticidkort/ReportMapView.tsx
+++ b/frontend/src/components/pesticidkort/ReportMapView.tsx
@@ -119,7 +119,7 @@ export function ReportMapView({
       <MapLegend activeFilter={chemFilter} />
 
       {/* Floating map controls: year + chemical pills */}
-      <div className="pointer-events-none absolute inset-x-0 bottom-[55%] z-40 flex flex-col items-center gap-2 px-4 md:right-[420px] md:bottom-6">
+      <div className="pointer-events-none absolute inset-x-0 bottom-[55%] z-40 flex flex-col items-center gap-2 px-4 md:right-[420px] md:bottom-[calc(var(--pesticidkort-footer-height)+1.5rem)]">
         <div className="bg-background/90 pointer-events-auto max-w-xs min-w-[200px] self-stretch rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-auto md:px-3">
           <YearTimeline year={year} onChange={onYearChange} />
         </div>

--- a/frontend/src/components/pesticidkort/map-chemical-filter.ts
+++ b/frontend/src/components/pesticidkort/map-chemical-filter.ts
@@ -14,7 +14,7 @@ const FILTER_PROPERTY: Record<Exclude<ChemicalFilter, 'none'>, string> = {
   diquat: 'diquat_applications',
 };
 
-/** A-E stepped gradient based on total_pesticide_belastning (B/ha). */
+/** Stepped burden gradient based on total_pesticide_belastning (B/ha). */
 export const GRADE_FILL_COLOR = [
   'case',
   ['==', ['coalesce', ['get', 'total_pesticide_belastning'], 0], 0],

--- a/frontend/tests/pesticidkort.spec.ts
+++ b/frontend/tests/pesticidkort.spec.ts
@@ -86,6 +86,116 @@ test.describe('Pesticidkort', () => {
     ).toBeVisible();
   });
 
+  test('should show burden ranges without A-E legend labels in explore mode', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    const exploreButton = page.locator('[data-testid="explore-map-button"]');
+    await exploreButton.click();
+
+    const legend = page.locator('[data-testid="map-legend"]');
+    await expect(legend).toBeVisible({ timeout: 10000 });
+    await expect(legend).toContainText('Under 0,5 B/ha');
+    await expect(legend).toContainText('0,5–2,0 B/ha');
+    await expect(legend).not.toContainText('A — Under 0,5 B/ha');
+    await expect(legend).not.toContainText('E — Over 8,0 B/ha');
+
+    const legendBox = await legend.boundingBox();
+    expect(legendBox).not.toBeNull();
+    expect(legendBox!.x + legendBox!.width).toBeLessThanOrEqual(375);
+
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(376);
+  });
+
+  test('should keep map zoom controls visible below the explore overlay on narrow mobile', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    const exploreButton = page.locator('[data-testid="explore-map-button"]');
+    await exploreButton.click();
+
+    const yearTimeline = page.locator('[data-testid="year-timeline"]');
+    const chemicalPills = page.locator('[data-testid="chemical-filter-pills"]');
+    const navControl = page.locator('.maplibregl-ctrl-top-left');
+
+    await expect(yearTimeline).toBeVisible({ timeout: 10000 });
+    await expect(chemicalPills).toBeVisible({ timeout: 10000 });
+    await expect(navControl).toBeVisible({ timeout: 10000 });
+
+    const yearBox = await yearTimeline.boundingBox();
+    const pillsBox = await chemicalPills.boundingBox();
+    const navBox = await navControl.boundingBox();
+
+    expect(yearBox).not.toBeNull();
+    expect(pillsBox).not.toBeNull();
+    expect(navBox).not.toBeNull();
+
+    expect(yearBox!.height).toBeLessThan(60);
+    expect(navBox!.y).toBeGreaterThan(pillsBox!.y + pillsBox!.height + 8);
+  });
+
+  test('should keep mobile footer expansion from covering the legend or report sheet', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    const footer = page.locator(
+      '[data-testid="pesticidkort-disclaimer-footer"]'
+    );
+    const footerToggle = page.locator(
+      '[data-testid="pesticidkort-disclaimer-toggle"]'
+    );
+
+    await page.locator('[data-testid="explore-map-button"]').click();
+    await expect(footerToggle).toBeVisible({ timeout: 10000 });
+    await footerToggle.click({ force: true });
+
+    const legend = page.locator('[data-testid="map-legend"]');
+    await expect(legend).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(100);
+
+    const footerTopInExplore = await footer.evaluate((el) =>
+      Math.round(el.getBoundingClientRect().top)
+    );
+    const legendBottom = await legend.evaluate((el) =>
+      Math.round(el.getBoundingClientRect().bottom)
+    );
+
+    expect(legendBottom).toBeLessThanOrEqual(footerTopInExplore - 4);
+
+    await page.goto(
+      '/pesticidkort?lat=55.6761&lng=12.5683&addr=K%C3%B8benhavn&y=2022'
+    );
+
+    await expect(
+      page.locator('[data-testid="share-report-button"]:visible').first()
+    ).toBeVisible({ timeout: 15000 });
+
+    const reportFooterToggle = page.locator(
+      '[data-testid="pesticidkort-disclaimer-toggle"]'
+    );
+    await expect(reportFooterToggle).toBeVisible({ timeout: 10000 });
+    await reportFooterToggle.click({ force: true });
+
+    const sheetHandle = page.locator('[data-testid="bottom-sheet-handle"]');
+    await expect(sheetHandle).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(100);
+
+    const footerTopInReport = await footer.evaluate((el) =>
+      Math.round(el.getBoundingClientRect().top)
+    );
+    const sheetBottom = await sheetHandle.evaluate((el) =>
+      Math.round(
+        (el.parentElement as HTMLElement).getBoundingClientRect().bottom
+      )
+    );
+
+    expect(sheetBottom).toBeLessThanOrEqual(footerTopInReport);
+  });
+
   test('should adapt landing page to mobile viewport', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-12T06:51:20.205647Z"
+exclude-newer = "2026-04-15T07:06:53.837838Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -69,7 +69,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.4"
+version = "3.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -80,38 +80,38 @@ dependencies = [
     { name = "propcache", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "yarl", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/4a/064321452809dae953c1ed6e017504e72551a26b6f5708a5a80e4bf556ff/aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38", size = 7859748, upload-time = "2026-03-28T17:19:40.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/7e/cb94129302d78c46662b47f9897d642fd0b33bdfef4b73b20c6ced35aa4c/aiohttp-3.13.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8ea0c64d1bcbf201b285c2246c51a0c035ba3bbd306640007bc5844a3b4658c1", size = 760027, upload-time = "2026-03-28T17:15:33.022Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/cd/2db3c9397c3bd24216b203dd739945b04f8b87bb036c640da7ddb63c75ef/aiohttp-3.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6f742e1fa45c0ed522b00ede565e18f97e4cf8d1883a712ac42d0339dfb0cce7", size = 508325, upload-time = "2026-03-28T17:15:34.714Z" },
-    { url = "https://files.pythonhosted.org/packages/36/a3/d28b2722ec13107f2e37a86b8a169897308bab6a3b9e071ecead9d67bd9b/aiohttp-3.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6dcfb50ee25b3b7a1222a9123be1f9f89e56e67636b561441f0b304e25aaef8f", size = 502402, upload-time = "2026-03-28T17:15:36.409Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/d6/acd47b5f17c4430e555590990a4746efbcb2079909bb865516892bf85f37/aiohttp-3.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3262386c4ff370849863ea93b9ea60fd59c6cf56bf8f93beac625cf4d677c04d", size = 1771224, upload-time = "2026-03-28T17:15:38.223Z" },
-    { url = "https://files.pythonhosted.org/packages/98/af/af6e20113ba6a48fd1cd9e5832c4851e7613ef50c7619acdaee6ec5f1aff/aiohttp-3.13.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:473bb5aa4218dd254e9ae4834f20e31f5a0083064ac0136a01a62ddbae2eaa42", size = 1731530, upload-time = "2026-03-28T17:15:39.988Z" },
-    { url = "https://files.pythonhosted.org/packages/81/16/78a2f5d9c124ad05d5ce59a9af94214b6466c3491a25fb70760e98e9f762/aiohttp-3.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e56423766399b4c77b965f6aaab6c9546617b8994a956821cc507d00b91d978c", size = 1827925, upload-time = "2026-03-28T17:15:41.944Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/1f/79acf0974ced805e0e70027389fccbb7d728e6f30fcac725fb1071e63075/aiohttp-3.13.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8af249343fafd5ad90366a16d230fc265cf1149f26075dc9fe93cfd7c7173942", size = 1923579, upload-time = "2026-03-28T17:15:44.071Z" },
-    { url = "https://files.pythonhosted.org/packages/af/53/29f9e2054ea6900413f3b4c3eb9d8331f60678ec855f13ba8714c47fd48d/aiohttp-3.13.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bc0a5cf4f10ef5a2c94fdde488734b582a3a7a000b131263e27c9295bd682d9", size = 1767655, upload-time = "2026-03-28T17:15:45.911Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/57/462fe1d3da08109ba4aa8590e7aed57c059af2a7e80ec21f4bac5cfe1094/aiohttp-3.13.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c7ff1028e3c9fc5123a865ce17df1cb6424d180c503b8517afbe89aa566e6be", size = 1630439, upload-time = "2026-03-28T17:15:48.11Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/4b/4813344aacdb8127263e3eec343d24e973421143826364fa9fc847f6283f/aiohttp-3.13.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ba5cf98b5dcb9bddd857da6713a503fa6d341043258ca823f0f5ab7ab4a94ee8", size = 1745557, upload-time = "2026-03-28T17:15:50.13Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/01/1ef1adae1454341ec50a789f03cfafe4c4ac9c003f6a64515ecd32fe4210/aiohttp-3.13.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:d85965d3ba21ee4999e83e992fecb86c4614d6920e40705501c0a1f80a583c12", size = 1741796, upload-time = "2026-03-28T17:15:52.351Z" },
-    { url = "https://files.pythonhosted.org/packages/22/04/8cdd99af988d2aa6922714d957d21383c559835cbd43fbf5a47ddf2e0f05/aiohttp-3.13.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:49f0b18a9b05d79f6f37ddd567695943fcefb834ef480f17a4211987302b2dc7", size = 1805312, upload-time = "2026-03-28T17:15:54.407Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/7f/b48d5577338d4b25bbdbae35c75dbfd0493cb8886dc586fbfb2e90862239/aiohttp-3.13.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7f78cb080c86fbf765920e5f1ef35af3f24ec4314d6675d0a21eaf41f6f2679c", size = 1621751, upload-time = "2026-03-28T17:15:56.564Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/89/4eecad8c1858e6d0893c05929e22343e0ebe3aec29a8a399c65c3cc38311/aiohttp-3.13.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:67a3ec705534a614b68bbf1c70efa777a21c3da3895d1c44510a41f5a7ae0453", size = 1826073, upload-time = "2026-03-28T17:15:58.489Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5c/9dc8293ed31b46c39c9c513ac7ca152b3c3d38e0ea111a530ad12001b827/aiohttp-3.13.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d6630ec917e85c5356b2295744c8a97d40f007f96a1c76bf1928dc2e27465393", size = 1760083, upload-time = "2026-03-28T17:16:00.677Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/bd/ede278648914cabbabfdf95e436679b5d4156e417896a9b9f4587169e376/aiohttp-3.13.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee62d4471ce86b108b19c3364db4b91180d13fe3510144872d6bad5401957360", size = 752158, upload-time = "2026-03-28T17:16:06.901Z" },
-    { url = "https://files.pythonhosted.org/packages/90/de/581c053253c07b480b03785196ca5335e3c606a37dc73e95f6527f1591fe/aiohttp-3.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c0fd8f41b54b58636402eb493afd512c23580456f022c1ba2db0f810c959ed0d", size = 501037, upload-time = "2026-03-28T17:16:08.82Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f9/a5ede193c08f13cc42c0a5b50d1e246ecee9115e4cf6e900d8dbd8fd6acb/aiohttp-3.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4baa48ce49efd82d6b1a0be12d6a36b35e5594d1dd42f8bfba96ea9f8678b88c", size = 501556, upload-time = "2026-03-28T17:16:10.63Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/10/88ff67cd48a6ec36335b63a640abe86135791544863e0cfe1f065d6cef7a/aiohttp-3.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d738ebab9f71ee652d9dbd0211057690022201b11197f9a7324fd4dba128aa97", size = 1757314, upload-time = "2026-03-28T17:16:12.498Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/15/fdb90a5cf5a1f52845c276e76298c75fbbcc0ac2b4a86551906d54529965/aiohttp-3.13.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0ce692c3468fa831af7dceed52edf51ac348cebfc8d3feb935927b63bd3e8576", size = 1731819, upload-time = "2026-03-28T17:16:14.558Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/df/28146785a007f7820416be05d4f28cc207493efd1e8c6c1068e9bdc29198/aiohttp-3.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e08abcfe752a454d2cb89ff0c08f2d1ecd057ae3e8cc6d84638de853530ebab", size = 1793279, upload-time = "2026-03-28T17:16:16.594Z" },
-    { url = "https://files.pythonhosted.org/packages/10/47/689c743abf62ea7a77774d5722f220e2c912a77d65d368b884d9779ef41b/aiohttp-3.13.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5977f701b3fff36367a11087f30ea73c212e686d41cd363c50c022d48b011d8d", size = 1891082, upload-time = "2026-03-28T17:16:18.71Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b6/f7f4f318c7e58c23b761c9b13b9a3c9b394e0f9d5d76fbc6622fa98509f6/aiohttp-3.13.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54203e10405c06f8b6020bd1e076ae0fe6c194adcee12a5a78af3ffa3c57025e", size = 1773938, upload-time = "2026-03-28T17:16:21.125Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/06/f207cb3121852c989586a6fc16ff854c4fcc8651b86c5d3bd1fc83057650/aiohttp-3.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:358a6af0145bc4dda037f13167bef3cce54b132087acc4c295c739d05d16b1c3", size = 1579548, upload-time = "2026-03-28T17:16:23.588Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/58/e1289661a32161e24c1fe479711d783067210d266842523752869cc1d9c2/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:898ea1850656d7d61832ef06aa9846ab3ddb1621b74f46de78fbc5e1a586ba83", size = 1714669, upload-time = "2026-03-28T17:16:25.713Z" },
-    { url = "https://files.pythonhosted.org/packages/96/0a/3e86d039438a74a86e6a948a9119b22540bae037d6ba317a042ae3c22711/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7bc30cceb710cf6a44e9617e43eebb6e3e43ad855a34da7b4b6a73537d8a6763", size = 1754175, upload-time = "2026-03-28T17:16:28.18Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/30/e717fc5df83133ba467a560b6d8ef20197037b4bb5d7075b90037de1018e/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4a31c0c587a8a038f19a4c7e60654a6c899c9de9174593a13e7cc6e15ff271f9", size = 1762049, upload-time = "2026-03-28T17:16:30.941Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/28/8f7a2d4492e336e40005151bdd94baf344880a4707573378579f833a64c1/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2062f675f3fe6e06d6113eb74a157fb9df58953ffed0cdb4182554b116545758", size = 1570861, upload-time = "2026-03-28T17:16:32.953Z" },
-    { url = "https://files.pythonhosted.org/packages/78/45/12e1a3d0645968b1c38de4b23fdf270b8637735ea057d4f84482ff918ad9/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d1ba8afb847ff80626d5e408c1fdc99f942acc877d0702fe137015903a220a9", size = 1790003, upload-time = "2026-03-28T17:16:35.468Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/0f/60374e18d590de16dcb39d6ff62f39c096c1b958e6f37727b5870026ea30/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b08149419994cdd4d5eecf7fd4bc5986b5a9380285bcd01ab4c0d6bfca47b79d", size = 1737289, upload-time = "2026-03-28T17:16:38.187Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/a20c4ac64aeaef1679e25c9983573618ff765d7aa829fa2b84ae7573169e/aiohttp-3.13.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ab7229b6f9b5c1ba4910d6c41a9eb11f543eadb3f384df1b4c293f4e73d44d6", size = 757513, upload-time = "2026-03-31T21:57:02.146Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/39fa6c6b179b53fcb3e4b3d2b6d6cad0180854eda17060c7218540102bef/aiohttp-3.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f14c50708bb156b3a3ca7230b3d820199d56a48e3af76fa21c2d6087190fe3d", size = 506748, upload-time = "2026-03-31T21:57:04.275Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/e38ce072e724fd7add6243613f8d1810da084f54175353d25ccf9f9c7e5a/aiohttp-3.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7d2f8616f0ff60bd332022279011776c3ac0faa0f1b463f7bb12326fbc97a1c", size = 501673, upload-time = "2026-03-31T21:57:06.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ba/3bc7525d7e2beaa11b309a70d48b0d3cfc3c2089ec6a7d0820d59c657053/aiohttp-3.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2567b72e1ffc3ab25510db43f355b29eeada56c0a622e58dcdb19530eb0a3cb", size = 1763757, upload-time = "2026-03-31T21:57:07.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ab/e87744cf18f1bd78263aba24924d4953b41086bd3a31d22452378e9028a0/aiohttp-3.13.5-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fb0540c854ac9c0c5ad495908fdfd3e332d553ec731698c0e29b1877ba0d2ec6", size = 1720152, upload-time = "2026-03-31T21:57:09.946Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f3/ed17a6f2d742af17b50bae2d152315ed1b164b07a5fd5cc1754d99e4dfa5/aiohttp-3.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9883051c6972f58bfc4ebb2116345ee2aa151178e99c3f2b2bbe2af712abd13", size = 1818010, upload-time = "2026-03-31T21:57:12.157Z" },
+    { url = "https://files.pythonhosted.org/packages/53/06/ecbc63dc937192e2a5cb46df4d3edb21deb8225535818802f210a6ea5816/aiohttp-3.13.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2294172ce08a82fb7c7273485895de1fa1186cc8294cfeb6aef4af42ad261174", size = 1907251, upload-time = "2026-03-31T21:57:14.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a5/0521aa32c1ddf3aa1e71dcc466be0b7db2771907a13f18cddaa45967d97b/aiohttp-3.13.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a807cabd5115fb55af198b98178997a5e0e57dead43eb74a93d9c07d6d4a7dc", size = 1759969, upload-time = "2026-03-31T21:57:16.146Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/78/a38f8c9105199dd3b9706745865a8a59d0041b6be0ca0cc4b2ccf1bab374/aiohttp-3.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6d0d932e0f39c02b80744273cd5c388a2d9bc07760a03164f229c8e02662f6", size = 1616871, upload-time = "2026-03-31T21:57:17.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/41/27392a61ead8ab38072105c71aa44ff891e71653fe53d576a7067da2b4e8/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60869c7ac4aaabe7110f26499f3e6e5696eae98144735b12a9c3d9eae2b51a49", size = 1739844, upload-time = "2026-03-31T21:57:19.679Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/55/5564e7ae26d94f3214250009a0b1c65a0c6af4bf88924ccb6fdab901de28/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:26d2f8546f1dfa75efa50c3488215a903c0168d253b75fba4210f57ab77a0fb8", size = 1731969, upload-time = "2026-03-31T21:57:22.006Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c5/705a3929149865fc941bcbdd1047b238e4a72bcb215a9b16b9d7a2e8d992/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1162a1492032c82f14271e831c8f4b49f2b6078f4f5fc74de2c912fa225d51d", size = 1795193, upload-time = "2026-03-31T21:57:24.256Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/edabed62f718d02cff7231ca0db4ef1c72504235bc467f7b67adb1679f48/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8b14eb3262fad0dc2f89c1a43b13727e709504972186ff6a99a3ecaa77102b6c", size = 1606477, upload-time = "2026-03-31T21:57:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/de/fc/76f80ef008675637d88d0b21584596dc27410a990b0918cb1e5776545b5b/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ca9ac61ac6db4eb6c2a0cd1d0f7e1357647b638ccc92f7e9d8d133e71ed3c6ac", size = 1813198, upload-time = "2026-03-31T21:57:28.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/67/5b3ac26b80adb20ea541c487f73730dc8fa107d632c998f25bbbab98fcda/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7996023b2ed59489ae4762256c8516df9820f751cf2c5da8ed2fb20ee50abab3", size = 1752321, upload-time = "2026-03-31T21:57:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload-time = "2026-03-31T21:57:36.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload-time = "2026-03-31T21:57:38.236Z" },
+    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload-time = "2026-03-31T21:57:39.923Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload-time = "2026-03-31T21:57:41.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload-time = "2026-03-31T21:57:43.904Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload-time = "2026-03-31T21:57:46.285Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload-time = "2026-03-31T21:57:48.734Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload-time = "2026-03-31T21:57:51.171Z" },
+    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload-time = "2026-03-31T21:57:53.326Z" },
+    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload-time = "2026-03-31T21:57:55.385Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload-time = "2026-03-31T21:57:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload-time = "2026-03-31T21:57:59.626Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload-time = "2026-03-31T21:58:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload-time = "2026-03-31T21:58:04.007Z" },
+    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload-time = "2026-03-31T21:58:06.337Z" },
 ]
 
 [[package]]
@@ -137,34 +137,12 @@ wheels = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "anyio"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -204,7 +182,6 @@ version = "0.1.0"
 source = { editable = "backend/pipelines/arbejdstilsynet_inspections" }
 dependencies = [
     { name = "duckdb", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "fastapi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "landbruget-common", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "loguru", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -214,7 +191,6 @@ dependencies = [
     { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "s3fs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "simple-singleton", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "uvicorn", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [package.dev-dependencies]
@@ -229,9 +205,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "duckdb" },
-    { name = "fastapi", specifier = ">=0.100.0" },
     { name = "landbruget-common", editable = "backend/common" },
-    { name = "loguru", specifier = ">=0.7.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "numpy", specifier = ">=2.4.4" },
     { name = "playwright", specifier = ">=1.40.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
@@ -239,7 +214,6 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "s3fs" },
     { name = "simple-singleton", specifier = ">=2.0.0" },
-    { name = "uvicorn", specifier = ">=0.20.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -300,18 +274,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "duckdb" },
     { name = "landbruget-common", editable = "backend/common" },
     { name = "lxml", specifier = ">=4.9.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pydantic" },
-    { name = "pyogrio", specifier = ">=0.7.0" },
+    { name = "pyogrio", specifier = ">=0.12.1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "requests", specifier = ">=2.31.0" },
+    { name = "requests", specifier = ">=2.33.1" },
     { name = "s3fs" },
     { name = "shapely", specifier = ">=2.0.0" },
-    { name = "tqdm", specifier = ">=4.67.1" },
+    { name = "tqdm", specifier = ">=4.67.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -320,8 +294,8 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "types-beautifulsoup4", specifier = ">=4.12.0" },
-    { name = "types-requests", specifier = ">=2.31.0" },
+    { name = "types-beautifulsoup4", specifier = ">=4.12.0.20250516" },
+    { name = "types-requests", specifier = ">=2.33.0.20260408" },
 ]
 
 [[package]]
@@ -362,7 +336,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "beautifulsoup4", specifier = ">=4.9.3" },
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "duckdb" },
     { name = "landbruget-common", editable = "backend/common" },
     { name = "pyarrow", specifier = ">=14.0.0" },
@@ -508,7 +482,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.13.0,<3.14" },
+    { name = "aiohttp", specifier = ">=3.13.5,<3.14" },
     { name = "certifi", specifier = "~=2026.2.25" },
     { name = "cryptography", specifier = ">=44.0.0" },
     { name = "duckdb" },
@@ -696,7 +670,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "beautifulsoup4", specifier = ">=4.9.3" },
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "duckdb" },
     { name = "ipywidgets", specifier = ">=8.0.0" },
     { name = "landbruget-common", editable = "backend/common" },
@@ -757,7 +731,7 @@ requires-dist = [
     { name = "duckdb" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },
     { name = "google-auth", specifier = ">=2.23.0" },
-    { name = "google-auth-httplib2", specifier = ">=0.1.1" },
+    { name = "google-auth-httplib2", specifier = ">=0.3.1" },
     { name = "google-auth-oauthlib", specifier = ">=1.1.0" },
     { name = "jpype1", specifier = ">=1.4.1" },
     { name = "landbruget-common", editable = "backend/common" },
@@ -820,22 +794,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
-]
-
-[[package]]
-name = "fastapi"
-version = "0.135.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/73/5903c4b13beae98618d64eb9870c3fac4f605523dd0312ca5c80dadbd5b9/fastapi-0.135.2.tar.gz", hash = "sha256:88a832095359755527b7f63bb4c6bc9edb8329a026189eed83d6c1afcf419d56", size = 395833, upload-time = "2026-03-23T14:12:41.697Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/ea/18f6d0457f9efb2fc6fa594857f92810cadb03024975726db6546b3d6fcf/fastapi-0.135.2-py3-none-any.whl", hash = "sha256:0af0447d541867e8db2a6a25c23a8c4bd80e2394ac5529bd87501bbb9e240ca5", size = 117407, upload-time = "2026-03-23T14:12:43.284Z" },
 ]
 
 [[package]]
@@ -944,15 +902,15 @@ wheels = [
 
 [[package]]
 name = "google-auth-httplib2"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "httplib2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/ad/c1f2b1175096a8d04cf202ad5ea6065f108d26be6fc7215876bde4a7981d/google_auth_httplib2-0.3.0.tar.gz", hash = "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b", size = 11134, upload-time = "2025-12-15T22:13:51.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/99/107612bef8d24b298bb5a7c8466f908ecda791d43f9466f5c3978f5b24c1/google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55", size = 11152, upload-time = "2026-03-30T22:50:26.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/d5/3c97526c8796d3caf5f4b3bed2b05e8a7102326f00a334e7a438237f3b22/google_auth_httplib2-0.3.0-py3-none-any.whl", hash = "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776", size = 9529, upload-time = "2025-12-15T22:13:51.048Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e9/93afb14d23a949acaa3f4e7cc51a0024671174e116e35f42850764b99634/google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c", size = 9534, upload-time = "2026-03-30T22:49:03.384Z" },
 ]
 
 [[package]]
@@ -1137,15 +1095,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/cd/89ce482a931b543b92cdd9b2888805518c4620e0094409acb8c81dd4610a/grpcio_status-1.78.0.tar.gz", hash = "sha256:a34cfd28101bfea84b5aa0f936b4b423019e9213882907166af6b3bddc59e189", size = 13808, upload-time = "2026-02-06T10:01:48.034Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/8a/1241ec22c41028bddd4a052ae9369267b4475265ad0ce7140974548dc3fa/grpcio_status-1.78.0-py3-none-any.whl", hash = "sha256:b492b693d4bf27b47a6c32590701724f1d3b9444b36491878fb71f6208857f34", size = 14523, upload-time = "2026-02-06T10:01:32.584Z" },
-]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -2391,7 +2340,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.0"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2399,9 +2348,9 @@ dependencies = [
     { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -2591,19 +2540,6 @@ wheels = [
 ]
 
 [[package]]
-name = "starlette"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
-]
-
-[[package]]
 name = "svineflytning-pipeline"
 version = "0.1.0"
 source = { editable = "backend/pipelines/svineflytning_pipeline" }
@@ -2783,14 +2719,14 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.33.0.20260327"
+version = "2.33.0.20260408"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/5f/2e3dbae6e21be6ae026563bad96cbf76602d73aa85ea09f13419ddbdabb4/types_requests-2.33.0.20260327.tar.gz", hash = "sha256:f4f74f0b44f059e3db420ff17bd1966e3587cdd34062fe38a23cda97868f8dd8", size = 23804, upload-time = "2026-03-27T04:23:38.737Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/55/951e733616c92cb96b57554746d2f65f4464d080cc2cc093605f897aba89/types_requests-2.33.0.20260327-py3-none-any.whl", hash = "sha256:fde0712be6d7c9a4d490042d6323115baf872d9a71a22900809d0432de15776e", size = 20737, upload-time = "2026-03-27T04:23:37.813Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]
@@ -2929,19 +2865,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "uvicorn"
-version = "0.42.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- [x] Fixed pesticidkort mobile/layout regressions by reserving footer space for map overlays, tightening legend labels, and repositioning map controls for explore/report modes.
- [x] Improved backend API export reliability by making JSON serialization Decimal-safe, running burden histogram export before long per-company generation, and batching per-company pesticide queries with regression tests.
- [x] Added defensive API fallbacks for burden histogram and drift-exposure endpoints, refreshed OG pesticide card grade metadata handling, and aligned workflow/docs/agent commands on `uv run --all-packages --group dev pytest`.

## ✅ How to Do Self-Test
- Run: `cd frontend && npm test && npm run lint`
- Run: `uv run --all-packages --group dev pytest`
- Targeted regression check used here: `uv run --all-packages --group dev pytest backend/pipelines/api_export/tests/test_pesticides.py -q`

## 📷 Screenshots (if applicable)
Not included

## 📝 Additional Notes
This PR includes all workspace changes on `mc/fix-pesticid-legend` (frontend pesticidkort UX fixes, backend exporter refactor/tests, and uv-based backend test command standardization).
