### PR TITLE
Fix pesticidkort mobile layout

### DIFF
--- a/frontend/src/components/pesticidkort/ChemicalFilterPills.tsx
+++ b/frontend/src/components/pesticidkort/ChemicalFilterPills.tsx
@@ -23,43 +23,47 @@ export function ChemicalFilterPills({
 }: ChemicalFilterPillsProps) {
   return (
     <div
-      className="bg-background/90 pointer-events-auto inline-flex gap-0.5 rounded-full p-0.5 shadow-sm backdrop-blur-sm"
+      className="flex w-full max-w-full justify-center overflow-x-auto px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       data-testid="chemical-filter-pills"
-      role="radiogroup"
-      aria-label="Filtrer kort-visning"
     >
-      {PILLS.map(({ id, label, dot }) => {
-        const isActive = active === id;
-        const needsZoom = id !== 'none' && id !== 'pfas' && zoomLevel < 12;
+      <div
+        className="bg-background/90 pointer-events-auto inline-flex min-w-max gap-0.5 rounded-full p-0.5 shadow-sm backdrop-blur-sm"
+        role="radiogroup"
+        aria-label="Filtrer kort-visning"
+      >
+        {PILLS.map(({ id, label, dot }) => {
+          const isActive = active === id;
+          const needsZoom = id !== 'none' && id !== 'pfas' && zoomLevel < 12;
 
-        return (
-          <button
-            key={id}
-            role="radio"
-            aria-checked={isActive}
-            disabled={needsZoom}
-            onClick={() => onChange(id)}
-            data-testid={`chemical-filter-${id}`}
-            title={needsZoom ? 'Zoom ind for at se' : undefined}
-            className={cn(
-              'flex items-center gap-1 rounded-full px-2.5 py-2 text-[11px] font-medium transition-colors',
-              isActive
-                ? 'bg-foreground text-background shadow-sm'
-                : 'hover:bg-muted text-muted-foreground',
-              needsZoom && 'pointer-events-none opacity-40'
-            )}
-          >
-            <span
+          return (
+            <button
+              key={id}
+              role="radio"
+              aria-checked={isActive}
+              disabled={needsZoom}
+              onClick={() => onChange(id)}
+              data-testid={`chemical-filter-${id}`}
+              title={needsZoom ? 'Zoom ind for at se' : undefined}
               className={cn(
-                'inline-block h-2 w-2 shrink-0 rounded-full',
-                isActive ? 'ring-background/50 ring-1' : '',
-                dot
+                'flex items-center gap-1 rounded-full px-2 py-1.5 text-[11px] font-medium whitespace-nowrap transition-colors sm:px-2.5 sm:py-2',
+                isActive
+                  ? 'bg-foreground text-background shadow-sm'
+                  : 'hover:bg-muted text-muted-foreground',
+                needsZoom && 'pointer-events-none opacity-40'
               )}
-            />
-            {label}
-          </button>
-        );
-      })}
+            >
+              <span
+                className={cn(
+                  'inline-block h-2 w-2 shrink-0 rounded-full',
+                  isActive ? 'ring-background/50 ring-1' : '',
+                  dot
+                )}
+              />
+              {label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/pesticidkort/DisclaimerFooter.tsx
+++ b/frontend/src/components/pesticidkort/DisclaimerFooter.tsx
@@ -75,11 +75,11 @@ export function DisclaimerFooter() {
           ))}
         </div>
 
-        <div className="flex items-center justify-between sm:hidden">
+        <div className="sm:hidden">
           <button
             type="button"
             onClick={() => setExpanded((v) => !v)}
-            className="text-muted-foreground flex items-center gap-1"
+            className="text-muted-foreground flex min-h-[40px] w-full items-center gap-1"
             data-testid="pesticidkort-disclaimer-toggle"
             aria-expanded={expanded}
             aria-label={expanded ? 'Skjul forbehold' : 'Vis forbehold og links'}
@@ -92,17 +92,23 @@ export function DisclaimerFooter() {
             {expanded ? 'Skjul' : 'Forbehold & vilkår'}
           </button>
           {expanded && (
-            <div className="flex flex-wrap justify-end gap-x-3 gap-y-1">
-              {LINKS.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
-                  data-testid={`pesticidkort-disclaimer-mlink-${link.id}`}
-                >
-                  {link.label}
-                </Link>
-              ))}
+            <div className="mt-2 space-y-3 pb-1">
+              <p className="text-muted-foreground leading-snug">
+                Beregnede data baseret på offentlige kilder. Værdier er
+                estimater og kan afvige fra faktisk sprøjtning.
+              </p>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                {LINKS.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+                    data-testid={`pesticidkort-disclaimer-mlink-${link.id}`}
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/components/pesticidkort/ExploreMapView.tsx
+++ b/frontend/src/components/pesticidkort/ExploreMapView.tsx
@@ -82,7 +82,7 @@ export function ExploreMapView({
       <MapLegend activeFilter={chemFilter} />
       <MapOnboardingHint />
 
-      <div className="absolute top-0 right-0 left-0 z-20 px-4 pt-3">
+      <div className="absolute top-0 right-0 left-0 z-20 px-3 pt-3 sm:px-4">
         <div className="mx-auto flex max-w-lg items-center gap-2">
           <button
             onClick={onBack}
@@ -108,8 +108,8 @@ export function ExploreMapView({
           )}
         </div>
 
-        <div className="mx-auto mt-2 flex max-w-lg flex-col items-center gap-2">
-          <div className="bg-background/90 w-full max-w-xs min-w-[200px] rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:px-3">
+        <div className="mx-auto mt-2 flex max-w-lg flex-col items-stretch gap-2">
+          <div className="bg-background/90 w-full max-w-full rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-center md:px-3">
             <YearTimeline year={year} onChange={onYearChange} />
           </div>
           <ChemicalFilterPills

--- a/frontend/src/components/pesticidkort/LandingHero.tsx
+++ b/frontend/src/components/pesticidkort/LandingHero.tsx
@@ -28,7 +28,7 @@ export function LandingHero({
       variants={staggerContainer(!!reducedMotion)}
       initial={reducedMotion ? false : 'hidden'}
       animate="visible"
-      className="relative flex min-h-screen flex-col overflow-hidden px-6 sm:px-8"
+      className="relative flex min-h-screen flex-col overflow-hidden px-6 pb-[var(--pesticidkort-footer-height)] sm:px-8"
     >
       {/* Map background */}
       <div className="absolute inset-0 -z-10" aria-hidden="true">
@@ -75,7 +75,7 @@ export function LandingHero({
 
         <motion.div
           variants={fadeSlideUp}
-          className="mt-6 flex items-center gap-3 text-sm"
+          className="mt-6 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm"
         >
           <button
             onClick={onExploreMap}
@@ -84,7 +84,7 @@ export function LandingHero({
           >
             Udforsk kortet
           </button>
-          <span className="text-border">·</span>
+          <span className="text-border hidden sm:block">·</span>
           <button
             onClick={() => router.push('/markanalyse')}
             data-testid="go-expert-button"
@@ -92,7 +92,7 @@ export function LandingHero({
           >
             Ekspertvisning
           </button>
-          <span className="text-border">·</span>
+          <span className="text-border hidden sm:block">·</span>
           <Link
             href="/pesticidanalyse/metode"
             data-testid="methodology-link"

--- a/frontend/src/components/pesticidkort/ReportMapView.tsx
+++ b/frontend/src/components/pesticidkort/ReportMapView.tsx
@@ -119,8 +119,8 @@ export function ReportMapView({
       <MapLegend activeFilter={chemFilter} />
 
       {/* Floating map controls: year + chemical pills */}
-      <div className="pointer-events-none absolute inset-x-0 bottom-[55%] z-40 flex flex-col items-center gap-2 px-4 md:right-[420px] md:bottom-[calc(var(--pesticidkort-footer-height)+1.5rem)]">
-        <div className="bg-background/90 pointer-events-auto max-w-xs min-w-[200px] self-stretch rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-auto md:px-3">
+      <div className="pointer-events-none absolute inset-x-0 bottom-[55%] z-40 flex flex-col items-stretch gap-2 px-3 sm:px-4 md:right-[420px] md:bottom-[calc(var(--pesticidkort-footer-height)+1.5rem)] md:items-center">
+        <div className="bg-background/90 pointer-events-auto w-full max-w-full self-stretch rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-auto md:px-3">
           <YearTimeline year={year} onChange={onYearChange} />
         </div>
         <ChemicalFilterPills

--- a/frontend/src/components/pesticidkort/YearTimeline.tsx
+++ b/frontend/src/components/pesticidkort/YearTimeline.tsx
@@ -53,7 +53,7 @@ export function YearTimeline({ year, onChange }: YearTimelineProps) {
 
   return (
     <div
-      className="flex items-center gap-0.5 select-none"
+      className="flex w-full items-center gap-0.5 select-none"
       data-testid="year-timeline"
       role="slider"
       aria-label="Vælg sprøjteår"
@@ -70,7 +70,7 @@ export function YearTimeline({ year, onChange }: YearTimelineProps) {
         disabled={activeIdx <= 0}
         aria-label="Forrige år"
         data-testid="year-prev-button"
-        className="text-muted-foreground hover:text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-30"
+        className="text-muted-foreground hover:text-foreground flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-30 sm:h-9 sm:w-9"
       >
         <ChevronLeft className="h-4 w-4" />
       </button>
@@ -90,7 +90,7 @@ export function YearTimeline({ year, onChange }: YearTimelineProps) {
               aria-current={isActive ? 'true' : undefined}
               onClick={() => onChange(y)}
               className={cn(
-                'shrink-0 snap-center rounded-full px-2.5 py-1.5 text-xs font-medium tabular-nums transition-colors',
+                'shrink-0 snap-center rounded-full px-2 py-1 text-[11px] font-medium tabular-nums transition-colors sm:px-2.5 sm:py-1.5 sm:text-xs',
                 isActive
                   ? 'bg-primary text-primary-foreground shadow-sm'
                   : 'text-muted-foreground hover:bg-muted hover:text-foreground'
@@ -110,7 +110,7 @@ export function YearTimeline({ year, onChange }: YearTimelineProps) {
         disabled={activeIdx >= YEARS.length - 1}
         aria-label="Næste år"
         data-testid="year-next-button"
-        className="text-muted-foreground hover:text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-30"
+        className="text-muted-foreground hover:text-foreground flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-30 sm:h-9 sm:w-9"
       >
         <ChevronRight className="h-4 w-4" />
       </button>


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- [x] Tightened the mobile year timeline and chemical filter pills so they fit narrow screens without awkward overflow.
- [x] Reworked the mobile disclaimer footer into a stacked layout and added footer-aware spacing on the landing view so content is no longer clipped behind the fixed footer.

## ✅ How to Do Self-Test
`cd frontend && npm run lint`
`cd frontend && npm test` *(blocked here by ENOSPC: no space left on device)*
`uv run --all-packages --group dev pytest` *(blocked here by ENOSPC: no space left on device)*

## 📷 Screenshots (if applicable)
UI change for mobile `pesticidkort`; screenshots were provided in the workspace thread.

## 📝 Additional Notes
`npm run lint` passed locally. Playwright and backend pytest could not complete in this workspace because the machine ran out of disk space while creating test artifacts / uv temp files.