### PR TITLE
feat: drift exposure lookup and pesticidkort UI polish

### DIFF
--- a/frontend/src/app/api/drift-exposure/lookup/route.ts
+++ b/frontend/src/app/api/drift-exposure/lookup/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  DEFAULT_DRIFT_TILE_ZOOM,
+  haversineMeters,
+  lngLatToTile,
+  MATCH_TOLERANCE_M,
+  surroundingTiles,
+} from '@/lib/drift-exposure-tiles';
+import {
+  getCachedDriftExposureIndex,
+  getCachedDriftExposureTile,
+} from '@/lib/server-cache';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 604800;
+
+const CACHE_HEADERS = {
+  'Cache-Control': 'public, max-age=604800, stale-while-revalidate=604800',
+  'CDN-Cache-Control': 'public, max-age=604800',
+  'Vercel-CDN-Cache-Control': 'public, max-age=604800',
+};
+
+function parseCoordinate(value: string | null): number | null {
+  if (value === null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export async function GET(request: NextRequest) {
+  const params = new URL(request.url).searchParams;
+  const lat = parseCoordinate(params.get('lat'));
+  const lng = parseCoordinate(params.get('lng'));
+
+  if (lat === null || lng === null) {
+    return NextResponse.json(
+      { error: 'invalid coordinates' },
+      { status: 400, headers: CACHE_HEADERS }
+    );
+  }
+
+  let nationalAvgDriftDoseKg: number | null = null;
+  let tileZoom = DEFAULT_DRIFT_TILE_ZOOM;
+
+  try {
+    const index = await getCachedDriftExposureIndex();
+    nationalAvgDriftDoseKg = index.national_avg_drift_dose_kg;
+    tileZoom = index.tile_zoom ?? DEFAULT_DRIFT_TILE_ZOOM;
+  } catch {}
+
+  const centerTile = lngLatToTile(lat, lng, tileZoom);
+  const tileResponses = await Promise.all(
+    surroundingTiles(centerTile.x, centerTile.y, centerTile.z).map(
+      async (tile) => {
+        try {
+          return await getCachedDriftExposureTile(tile.z, tile.x, tile.y);
+        } catch {
+          return [];
+        }
+      }
+    )
+  );
+
+  const seen = new Set<string>();
+  const buildings: Awaited<ReturnType<typeof getCachedDriftExposureTile>> = [];
+  for (const tileBuildings of tileResponses) {
+    for (const building of tileBuildings) {
+      if (seen.has(building.uid)) continue;
+      seen.add(building.uid);
+      buildings.push(building);
+    }
+  }
+
+  let nearest: (typeof buildings)[number] | null = null;
+  let nearestDist = Infinity;
+
+  for (const building of buildings) {
+    const distance = haversineMeters(lat, lng, building.lat, building.lng);
+    if (distance < nearestDist) {
+      nearest = building;
+      nearestDist = distance;
+    }
+  }
+
+  if (!nearest || nearestDist > MATCH_TOLERANCE_M) {
+    return NextResponse.json(null, { headers: CACHE_HEADERS });
+  }
+
+  return NextResponse.json(
+    {
+      exposure_percentile: nearest.pct,
+      drift_dose_kg: nearest.dose,
+      national_avg_drift_dose_kg: nationalAvgDriftDoseKg,
+      building_distance_m: Math.round(nearestDist),
+    },
+    { headers: CACHE_HEADERS }
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3,6 +3,21 @@
 
 :root {
   --pesticidkort-footer-height: 0px;
+  --pesticidkort-color-burden-low: #22c55e;
+  --pesticidkort-color-burden-mid-low: #84cc16;
+  --pesticidkort-color-burden-mid: #eab308;
+  --pesticidkort-color-burden-mid-high: #f97316;
+  --pesticidkort-color-burden-high: #dc2626;
+  --pesticidkort-color-burden-none: #d1d5db;
+  --pesticidkort-color-pfas: #9333ea;
+  --pesticidkort-color-glyphosate: #0891b2;
+  --pesticidkort-color-diquat: #db2777;
+  --pesticidkort-color-ring: #3f6ab3;
+  --pesticidkort-color-highlight: #3a9d5d;
+  --pesticidkort-color-field-outline: #5f6b80;
+  --pesticidkort-color-school-fill: #ec4899;
+  --pesticidkort-color-school-outline: #be185d;
+  --pesticidkort-color-story-muted: #dfe6f2;
 }
 
 @keyframes typing {
@@ -288,6 +303,22 @@
   --color-sidebar-accent-foreground: oklch(85% 0.01 106);
   --color-sidebar-border: oklch(20% 0.01 106);
   --color-sidebar-ring: oklch(65% 0.12 142);
+
+  --pesticidkort-color-burden-low: #4ade80;
+  --pesticidkort-color-burden-mid-low: #a3e635;
+  --pesticidkort-color-burden-mid: #facc15;
+  --pesticidkort-color-burden-mid-high: #fb923c;
+  --pesticidkort-color-burden-high: #f87171;
+  --pesticidkort-color-burden-none: #64748b;
+  --pesticidkort-color-pfas: #c084fc;
+  --pesticidkort-color-glyphosate: #22d3ee;
+  --pesticidkort-color-diquat: #f472b6;
+  --pesticidkort-color-ring: #7dd3fc;
+  --pesticidkort-color-highlight: #86efac;
+  --pesticidkort-color-field-outline: #94a3b8;
+  --pesticidkort-color-school-fill: #f472b6;
+  --pesticidkort-color-school-outline: #f9a8d4;
+  --pesticidkort-color-story-muted: #334155;
 }
 
 @layer base {
@@ -585,6 +616,46 @@
 
   .pesticidkort-map-shell--report .maplibregl-ctrl-top-left {
     top: calc(env(safe-area-inset-top, 0px) + 4.5rem) !important;
+  }
+
+  .pesticidkort-map-shell .maplibregl-ctrl-group {
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--color-border) 85%, transparent);
+    background: color-mix(
+      in srgb,
+      var(--color-background) 88%,
+      transparent
+    ) !important;
+    box-shadow: 0 12px 30px
+      color-mix(in srgb, var(--color-foreground) 12%, transparent);
+    backdrop-filter: blur(14px);
+  }
+
+  .pesticidkort-map-shell .maplibregl-ctrl button {
+    background: transparent !important;
+    color: var(--color-foreground);
+  }
+
+  .pesticidkort-map-shell .maplibregl-ctrl button + button {
+    border-top: 1px solid
+      color-mix(in srgb, var(--color-border) 80%, transparent);
+  }
+
+  .pesticidkort-map-shell .maplibregl-ctrl button:hover {
+    background: color-mix(
+      in srgb,
+      var(--color-muted) 80%,
+      transparent
+    ) !important;
+  }
+
+  .pesticidkort-map-shell .maplibregl-ctrl button:focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: -2px;
+  }
+
+  .dark .pesticidkort-map-shell .maplibregl-ctrl-icon {
+    filter: invert(1) brightness(1.3);
   }
 
   @media (max-width: 768px) {

--- a/frontend/src/app/pesticidkort/layout.tsx
+++ b/frontend/src/app/pesticidkort/layout.tsx
@@ -1,3 +1,5 @@
+import 'maplibre-gl/dist/maplibre-gl.css';
+
 interface PesticidkortLayoutProps {
   children: React.ReactNode;
 }

--- a/frontend/src/components/pesticidkort/AddressMarker.tsx
+++ b/frontend/src/components/pesticidkort/AddressMarker.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { Marker } from '@vis.gl/react-maplibre';
+
+interface AddressMarkerProps {
+  lat: number;
+  lng: number;
+}
+
+export function AddressMarker({ lat, lng }: AddressMarkerProps) {
+  return (
+    <Marker longitude={lng} latitude={lat} anchor="center">
+      <div className="bg-primary border-background h-4 w-4 rounded-full border-2 shadow-md" />
+    </Marker>
+  );
+}

--- a/frontend/src/components/pesticidkort/BottomSheet.tsx
+++ b/frontend/src/components/pesticidkort/BottomSheet.tsx
@@ -80,7 +80,7 @@ export function BottomSheet({
       role="region"
       aria-label="Pesticidrapport"
       className={cn(
-        'bg-background fixed inset-x-0 bottom-[var(--pesticidkort-footer-height)] z-30 rounded-t-2xl shadow-2xl',
+        'bg-background border-border/70 fixed inset-x-0 bottom-[var(--pesticidkort-footer-height)] z-30 rounded-t-2xl border-t shadow-2xl',
         'h-[var(--sheet-height,140px)]',
         'transition-[height] duration-300 ease-[cubic-bezier(0.25,1,0.5,1)]',
         dragStartRef.current && 'transition-none'

--- a/frontend/src/components/pesticidkort/BurdenScale.tsx
+++ b/frontend/src/components/pesticidkort/BurdenScale.tsx
@@ -34,7 +34,7 @@ export function BurdenScale({ burden, histogram }: BurdenScaleProps) {
   }, [histogram]);
 
   return (
-    <div className="relative h-5 flex-1" data-testid="burden-scale">
+    <div className="relative h-6 flex-1" data-testid="burden-scale">
       {bars.map((bar, i) => {
         const barStyle = {
           left: `${bar.left}%`,
@@ -44,19 +44,19 @@ export function BurdenScale({ burden, histogram }: BurdenScaleProps) {
         return (
           <div
             key={i}
-            className="bg-muted-foreground/8 absolute bottom-0"
+            className="bg-foreground/18 dark:bg-foreground/24 absolute bottom-0 rounded-[1px]"
             style={barStyle}
           />
         );
       })}
-      <div className="bg-muted absolute bottom-[3px] h-[2px] w-full rounded-full" />
+      <div className="bg-foreground/20 dark:bg-foreground/30 absolute bottom-[3px] h-[2px] w-full rounded-full" />
       <div
-        className="bg-muted-foreground/25 absolute bottom-0 h-full w-px"
+        className="bg-primary/70 dark:bg-primary/80 absolute bottom-0 h-full w-px"
         style={avgStyle}
         title="Landsgennemsnit (2,15 B/ha)"
       />
       <div
-        className="bg-foreground absolute bottom-[1px] h-[6px] w-[6px] -translate-x-1/2 rounded-full"
+        className="bg-primary ring-background absolute bottom-0 h-[7px] w-[7px] -translate-x-1/2 rounded-full ring-1"
         style={dotStyle}
       />
     </div>

--- a/frontend/src/components/pesticidkort/ChemicalFilterPills.tsx
+++ b/frontend/src/components/pesticidkort/ChemicalFilterPills.tsx
@@ -3,11 +3,27 @@
 import { cn } from '@/lib/utils';
 import type { ChemicalFilter } from '@/components/pesticidkort/map-layers';
 
-const PILLS: { id: ChemicalFilter; label: string; dot: string }[] = [
-  { id: 'none', label: 'Belastning', dot: 'bg-[#22c55e]' },
-  { id: 'pfas', label: 'PFAS', dot: 'bg-[#9333ea]' },
-  { id: 'glyphosate', label: 'Glyphosat', dot: 'bg-[#0891b2]' },
-  { id: 'diquat', label: 'Diquat', dot: 'bg-[#db2777]' },
+const PILLS: { id: ChemicalFilter; label: string; dotClass: string }[] = [
+  {
+    id: 'none',
+    label: 'Belastning',
+    dotClass: 'bg-[var(--pesticidkort-color-burden-low)]',
+  },
+  {
+    id: 'pfas',
+    label: 'PFAS',
+    dotClass: 'bg-[var(--pesticidkort-color-pfas)]',
+  },
+  {
+    id: 'glyphosate',
+    label: 'Glyphosat',
+    dotClass: 'bg-[var(--pesticidkort-color-glyphosate)]',
+  },
+  {
+    id: 'diquat',
+    label: 'Diquat',
+    dotClass: 'bg-[var(--pesticidkort-color-diquat)]',
+  },
 ];
 
 interface ChemicalFilterPillsProps {
@@ -31,7 +47,7 @@ export function ChemicalFilterPills({
         role="radiogroup"
         aria-label="Filtrer kort-visning"
       >
-        {PILLS.map(({ id, label, dot }) => {
+        {PILLS.map(({ id, label, dotClass }) => {
           const isActive = active === id;
           const needsZoom = id !== 'none' && id !== 'pfas' && zoomLevel < 12;
 
@@ -56,7 +72,7 @@ export function ChemicalFilterPills({
                 className={cn(
                   'inline-block h-2 w-2 shrink-0 rounded-full',
                   isActive ? 'ring-background/50 ring-1' : '',
-                  dot
+                  dotClass
                 )}
               />
               {label}

--- a/frontend/src/components/pesticidkort/DesktopSidebar.tsx
+++ b/frontend/src/components/pesticidkort/DesktopSidebar.tsx
@@ -8,7 +8,7 @@ interface DesktopSidebarProps {
 export function DesktopSidebar({ children, controls }: DesktopSidebarProps) {
   return (
     <div className="pointer-events-none absolute top-0 right-0 bottom-[var(--pesticidkort-footer-height)] hidden w-[420px] md:block">
-      <div className="bg-background/95 pointer-events-auto flex h-full flex-col border-l pt-14 backdrop-blur-sm">
+      <div className="bg-background/95 border-border/70 pointer-events-auto flex h-full flex-col border-l pt-14 backdrop-blur-sm">
         <div
           className="flex-1 overflow-y-auto"
           role="region"

--- a/frontend/src/components/pesticidkort/EstimatedBadge.tsx
+++ b/frontend/src/components/pesticidkort/EstimatedBadge.tsx
@@ -41,11 +41,11 @@ export function EstimatedBadge({
           <Badge
             variant="outline"
             className={cn(
-              'gap-1 border-warning/40 bg-warning/10 text-warning-foreground',
+              'gap-1.5 border-warning/80 bg-warning text-warning-foreground rounded-full px-3 py-1 text-[11px] font-bold tracking-[0.08em] uppercase shadow-sm',
               className
             )}
           >
-            <InfoIcon className="size-3" />
+            <InfoIcon className="size-3.5 shrink-0" />
             {LABELS[variant]}
           </Badge>
         </button>

--- a/frontend/src/components/pesticidkort/ExploreFieldPanel.tsx
+++ b/frontend/src/components/pesticidkort/ExploreFieldPanel.tsx
@@ -23,7 +23,7 @@ export function ExploreFieldPanel({ field, onClose }: ExploreFieldPanelProps) {
   return (
     <div
       data-testid="explore-field-panel"
-      className="bg-background/95 absolute inset-x-0 bottom-[var(--pesticidkort-footer-height)] z-30 max-h-[60vh] overflow-y-auto rounded-t-2xl px-4 pt-4 pb-6 shadow-lg backdrop-blur-sm md:inset-x-auto md:top-48 md:right-4 md:bottom-auto md:max-h-[calc(100vh-13rem)] md:w-80 md:rounded-xl"
+      className="bg-background/95 border-border/70 absolute inset-x-0 bottom-[var(--pesticidkort-footer-height)] z-30 max-h-[60vh] overflow-y-auto rounded-t-2xl border-t px-4 pt-4 pb-6 shadow-lg backdrop-blur-sm md:inset-x-auto md:top-48 md:right-4 md:bottom-auto md:max-h-[calc(100vh-13rem)] md:w-80 md:rounded-xl md:border"
     >
       <div className="mb-3 flex items-start justify-between">
         <div>
@@ -47,12 +47,12 @@ export function ExploreFieldPanel({ field, onClose }: ExploreFieldPanelProps) {
 
       <div className="mb-3 flex flex-wrap items-center gap-2">
         {field.is_organic && (
-          <span className="bg-success/10 text-success rounded-full px-1.5 py-0.5 text-[10px] leading-none font-medium">
+          <span className="bg-success text-success-foreground rounded-full px-1.5 py-0.5 text-[10px] leading-none font-semibold shadow-sm">
             Økologisk
           </span>
         )}
         {hasPfas && (
-          <span className="bg-warning/10 text-warning rounded-full px-1.5 py-0.5 text-[10px] leading-none font-medium">
+          <span className="bg-warning text-warning-foreground rounded-full px-1.5 py-0.5 text-[10px] leading-none font-semibold shadow-sm">
             PFAS
           </span>
         )}

--- a/frontend/src/components/pesticidkort/ExploreMapInner.tsx
+++ b/frontend/src/components/pesticidkort/ExploreMapInner.tsx
@@ -2,13 +2,13 @@
 
 import { useRef, useEffect, useState, useCallback } from 'react';
 import Map, { NavigationControl, MapRef } from '@vis.gl/react-maplibre';
-import 'maplibre-gl/dist/maplibre-gl.css';
 import { useMapTheme } from '@/hooks/useMapTheme';
 import { pmtilesCacheService } from '@/lib/pmtiles-cache-service';
 import {
   addFieldLayers,
   addOverviewLayers,
   applyChemicalFilter,
+  syncFieldLayerTheme,
 } from '@/components/pesticidkort/map-layers';
 import type { ChemicalFilter } from '@/components/pesticidkort/map-layers';
 import { registerPmtilesProtocol } from '@/components/pesticidkort/pmtiles-protocol';
@@ -37,7 +37,7 @@ export function ExploreMapInner({
   onFieldClick,
   selectedFieldUuid,
 }: ExploreMapInnerProps) {
-  const { mapStyle } = useMapTheme();
+  const { mapStyle, mapStyleTheme } = useMapTheme();
   const mapRef = useRef<MapRef>(null);
   const [pmtilesUrl, setPmtilesUrl] = useState<string | null>(null);
   const [overviewUrl, setOverviewUrl] = useState<string | null>(null);
@@ -87,8 +87,9 @@ export function ExploreMapInner({
   useEffect(() => {
     if (!mapRef.current || !mapReady) return;
     const map = mapRef.current.getMap() as unknown as MapInstance;
+    syncFieldLayerTheme(map);
     applyChemicalFilter(map, activeFilter);
-  }, [activeFilter, mapReady]);
+  }, [activeFilter, mapReady, mapStyleTheme]);
 
   useEffect(() => {
     if (!mapReady) return;

--- a/frontend/src/components/pesticidkort/ExploreMapView.tsx
+++ b/frontend/src/components/pesticidkort/ExploreMapView.tsx
@@ -88,12 +88,12 @@ export function ExploreMapView({
             onClick={onBack}
             data-testid="explore-back-button"
             aria-label="Tilbage"
-            className="bg-background/90 text-muted-foreground flex h-12 w-12 shrink-0 items-center justify-center rounded-full backdrop-blur-sm"
+            className="bg-background/90 text-muted-foreground border-border/70 flex h-12 w-12 shrink-0 items-center justify-center rounded-full border backdrop-blur-sm"
           >
             &larr;
           </button>
           {searchOpen && (
-            <div className="bg-background/90 flex-1 rounded-full backdrop-blur-sm">
+            <div className="bg-background/90 border-border/70 flex-1 rounded-full border backdrop-blur-sm">
               <AddressAutocomplete onSelect={handleSelect} />
             </div>
           )}
@@ -101,7 +101,7 @@ export function ExploreMapView({
             <button
               onClick={() => setSearchOpen(true)}
               data-testid="explore-search-open-button"
-              className="bg-background/90 text-muted-foreground h-12 rounded-full px-5 text-sm backdrop-blur-sm"
+              className="bg-background/90 text-muted-foreground border-border/70 h-12 rounded-full border px-5 text-sm backdrop-blur-sm"
             >
               S&oslash;g adresse...
             </button>
@@ -109,7 +109,7 @@ export function ExploreMapView({
         </div>
 
         <div className="mx-auto mt-2 flex max-w-lg flex-col items-stretch gap-2">
-          <div className="bg-background/90 w-full max-w-full rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-center md:px-3">
+          <div className="bg-background/90 border-border/70 w-full max-w-full rounded-full border px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-center md:px-3">
             <YearTimeline year={year} onChange={onYearChange} />
           </div>
           <ChemicalFilterPills

--- a/frontend/src/components/pesticidkort/FieldCard.tsx
+++ b/frontend/src/components/pesticidkort/FieldCard.tsx
@@ -64,7 +64,7 @@ export const FieldCard = forwardRef<HTMLDivElement, FieldCardProps>(
               · {field.area_hectares.toFixed(1)} ha
             </span>
             {hasPfas && (
-              <span className="bg-warning/10 text-warning rounded-full px-1.5 py-0.5 text-[10px] leading-none font-medium">
+              <span className="bg-warning text-warning-foreground rounded-full px-1.5 py-0.5 text-[10px] leading-none font-semibold shadow-sm">
                 PFAS
               </span>
             )}

--- a/frontend/src/components/pesticidkort/MapLegend.tsx
+++ b/frontend/src/components/pesticidkort/MapLegend.tsx
@@ -7,21 +7,45 @@ import { ChevronDown } from 'lucide-react';
 import type { ChemicalFilter } from '@/components/pesticidkort/map-layers';
 
 const GRADE_ITEMS = [
-  { bg: 'bg-[#22c55e]', label: 'Under 0,5 B/ha' },
-  { bg: 'bg-[#84cc16]', label: '0,5\u20132,0 B/ha' },
-  { bg: 'bg-[#eab308]', label: '2,0\u20134,0 B/ha' },
-  { bg: 'bg-[#f97316]', label: '4,0\u20138,0 B/ha' },
-  { bg: 'bg-[#dc2626]', label: 'Over 8,0 B/ha' },
-  { bg: 'bg-[#d1d5db]', label: 'Brak / ingen pesticider' },
+  {
+    swatch: 'bg-[var(--pesticidkort-color-burden-low)]',
+    label: 'Under 0,5 B/ha',
+  },
+  {
+    swatch: 'bg-[var(--pesticidkort-color-burden-mid-low)]',
+    label: '0,5\u20132,0 B/ha',
+  },
+  {
+    swatch: 'bg-[var(--pesticidkort-color-burden-mid)]',
+    label: '2,0\u20134,0 B/ha',
+  },
+  {
+    swatch: 'bg-[var(--pesticidkort-color-burden-mid-high)]',
+    label: '4,0\u20138,0 B/ha',
+  },
+  {
+    swatch: 'bg-[var(--pesticidkort-color-burden-high)]',
+    label: 'Over 8,0 B/ha',
+  },
+  {
+    swatch: 'bg-[var(--pesticidkort-color-burden-none)]',
+    label: 'Brak / ingen pesticider',
+  },
 ] as const;
 
 const CHEMICAL_META: Record<
   Exclude<ChemicalFilter, 'none'>,
-  { label: string; bg: string }
+  { label: string; swatch: string }
 > = {
-  pfas: { label: 'PFAS-pesticider', bg: 'bg-[#9333ea]' },
-  glyphosate: { label: 'Glyphosat', bg: 'bg-[#0891b2]' },
-  diquat: { label: 'Diquat', bg: 'bg-[#db2777]' },
+  pfas: {
+    label: 'PFAS-pesticider',
+    swatch: 'bg-[var(--pesticidkort-color-pfas)]',
+  },
+  glyphosate: {
+    label: 'Glyphosat',
+    swatch: 'bg-[var(--pesticidkort-color-glyphosate)]',
+  },
+  diquat: { label: 'Diquat', swatch: 'bg-[var(--pesticidkort-color-diquat)]' },
 };
 
 interface MapLegendProps {
@@ -35,7 +59,7 @@ export function MapLegend({ activeFilter = 'none' }: MapLegendProps) {
   return (
     <div
       data-testid="map-legend"
-      className="bg-background/90 absolute bottom-[calc(var(--pesticidkort-footer-height)+1rem)] left-4 z-20 max-w-[calc(100vw-2rem)] rounded-lg px-3 py-2 shadow-md backdrop-blur-sm"
+      className="bg-background/90 border-border/70 absolute bottom-[calc(var(--pesticidkort-footer-height)+1rem)] left-4 z-20 max-w-[calc(100vw-2rem)] rounded-lg border px-3 py-2 shadow-md backdrop-blur-sm"
     >
       <button
         onClick={() => setCollapsed(!collapsed)}
@@ -79,7 +103,7 @@ function GradeLegendItems() {
     <>
       {GRADE_ITEMS.map((item) => (
         <div key={item.label} className="flex items-center gap-2">
-          <div className={cn('h-3 w-3 shrink-0 rounded-sm', item.bg)} />
+          <div className={cn('h-3 w-3 shrink-0 rounded-sm', item.swatch)} />
           <span className="text-muted-foreground min-w-0 text-[11px] leading-tight">
             {item.label}
           </span>
@@ -98,13 +122,13 @@ function ChemicalLegendItems({
   return (
     <>
       <div className="flex items-center gap-2">
-        <div className={cn('h-3 w-3 shrink-0 rounded-sm', meta.bg)} />
+        <div className={cn('h-3 w-3 shrink-0 rounded-sm', meta.swatch)} />
         <span className="text-muted-foreground min-w-0 text-[11px] leading-tight">
           Marker med {meta.label}
         </span>
       </div>
       <div className="flex items-center gap-2">
-        <div className="h-3 w-3 shrink-0 rounded-sm bg-[#d1d5db] opacity-20" />
+        <div className="h-3 w-3 shrink-0 rounded-sm bg-[var(--pesticidkort-color-burden-none)] opacity-45" />
         <span className="text-muted-foreground min-w-0 text-[11px] leading-tight">
           Andre marker
         </span>

--- a/frontend/src/components/pesticidkort/MapLoadingState.tsx
+++ b/frontend/src/components/pesticidkort/MapLoadingState.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+export function MapLoadingState() {
+  return (
+    <div className="bg-muted flex h-full items-center justify-center">
+      <p className="text-muted-foreground text-sm">Indlæser kort...</p>
+    </div>
+  );
+}

--- a/frontend/src/components/pesticidkort/MapOnboardingHint.tsx
+++ b/frontend/src/components/pesticidkort/MapOnboardingHint.tsx
@@ -24,7 +24,7 @@ export function MapOnboardingHint() {
   return (
     <div
       data-testid="map-onboarding-hint"
-      className="bg-background/95 absolute top-1/2 left-1/2 z-30 w-72 -translate-x-1/2 -translate-y-1/2 rounded-xl p-5 text-center shadow-xl backdrop-blur-sm"
+      className="bg-background/95 border-border/70 absolute top-1/2 left-1/2 z-30 w-72 -translate-x-1/2 -translate-y-1/2 rounded-xl border p-5 text-center shadow-xl backdrop-blur-sm"
     >
       <button
         onClick={dismiss}
@@ -38,15 +38,15 @@ export function MapOnboardingHint() {
       </p>
       <div className="mt-3 flex items-center justify-center gap-3">
         <div className="flex items-center gap-1.5">
-          <div className="h-3 w-3 rounded-sm bg-[#6abf69]" />
+          <div className="h-3 w-3 rounded-sm bg-[var(--pesticidkort-color-burden-low)]" />
           <span className="text-muted-foreground text-[11px]">Lavest</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <div className="h-3 w-3 rounded-sm bg-[#d4c54a]" />
+          <div className="h-3 w-3 rounded-sm bg-[var(--pesticidkort-color-burden-mid)]" />
           <span className="text-muted-foreground text-[11px]">Middel</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <div className="h-3 w-3 rounded-sm bg-[#c4512c]" />
+          <div className="h-3 w-3 rounded-sm bg-[var(--pesticidkort-color-burden-high)]" />
           <span className="text-muted-foreground text-[11px]">Højest</span>
         </div>
       </div>

--- a/frontend/src/components/pesticidkort/PersonalReport.tsx
+++ b/frontend/src/components/pesticidkort/PersonalReport.tsx
@@ -38,12 +38,29 @@ export function PersonalReport({
       className="animate-fade-slide-up space-y-6 px-5 py-4 motion-reduce:animate-none"
     >
       <div className="bg-card rounded-xl p-5">
-        {report.grade ? (
+        {report.grade_status === 'ready' && report.grade ? (
           <PesticideProximityScore
             grade={report.grade.grade}
             label={report.grade.label}
             description={report.grade.description}
           />
+        ) : report.grade_status === 'loading' ? (
+          <div
+            data-testid="pesticide-proximity-score-loading"
+            aria-live="polite"
+            className="pt-6 pb-8"
+          >
+            <p className="text-muted-foreground mb-2 text-xs font-semibold tracking-widest uppercase">
+              Pesticideksponering
+            </p>
+            <p className="font-display text-foreground text-3xl leading-tight font-semibold tracking-tight sm:text-4xl">
+              Beregner drift-eksponering...
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Vi matcher adressen med den nærmeste BBR-bygning for at vise din
+              endelige placering.
+            </p>
+          </div>
         ) : (
           <div
             data-testid="pesticide-proximity-score-empty"
@@ -91,13 +108,11 @@ export function PersonalReport({
         exposure100m={report.exposure_100m}
         exposure1000m={report.exposure_1000m}
       />
-
       <SummaryStats
         fieldsCount={report.fields_count}
         avgBurden={report.avg_burden}
         nearestFieldM={report.nearest_field_m}
       />
-
       <FieldList
         fields={report.fields}
         histogram={histogram}
@@ -105,7 +120,6 @@ export function PersonalReport({
         clickedField={clickedField}
         onFieldSelect={onFieldSelect}
       />
-
       {report.has_bnbo_overlap && (
         <div className="space-y-3">
           <AlertCallout
@@ -118,7 +132,6 @@ export function PersonalReport({
           />
         </div>
       )}
-
       <footer className="text-muted-foreground pt-4 pb-4">
         <p className="text-xs leading-relaxed">
           Data fra Miljøstyrelsen, Landbrugsstyrelsen, Geodatastyrelsen og 18+

--- a/frontend/src/components/pesticidkort/PesticidkortMap.tsx
+++ b/frontend/src/components/pesticidkort/PesticidkortMap.tsx
@@ -1,20 +1,24 @@
 'use client';
 
 import { useRef, useEffect, useState, useCallback } from 'react';
-import Map, { NavigationControl, Marker, MapRef } from '@vis.gl/react-maplibre';
-import 'maplibre-gl/dist/maplibre-gl.css';
+import Map, { NavigationControl, MapRef } from '@vis.gl/react-maplibre';
 import { useMapTheme } from '@/hooks/useMapTheme';
+import { AddressMarker } from '@/components/pesticidkort/AddressMarker';
 import { ProximityRings } from '@/components/pesticidkort/ProximityRings';
 import {
   addFieldLayers,
   addOverviewLayers,
   applyChemicalFilter,
+  syncFieldLayerTheme,
 } from '@/components/pesticidkort/map-layers';
 import type { ChemicalFilter } from '@/components/pesticidkort/map-layers';
-import { addBuildingLayers } from '@/components/pesticidkort/map-layers-buildings';
 import {
-  highlightField,
+  addBuildingLayers,
+  syncBuildingLayerTheme,
+} from '@/components/pesticidkort/map-layers-buildings';
+import {
   flyToField,
+  highlightField,
 } from '@/components/pesticidkort/map-highlight';
 import { registerPmtilesProtocol } from '@/components/pesticidkort/pmtiles-protocol';
 import { usePesticidkortData } from '@/components/pesticidkort/usePesticidkortData';
@@ -23,6 +27,7 @@ import {
   updateSourceUrl,
 } from '@/components/pesticidkort/map-events';
 import { FieldHoverTooltip } from '@/components/pesticidkort/FieldHoverTooltip';
+import { MapLoadingState } from '@/components/pesticidkort/MapLoadingState';
 import { useFieldHover } from '@/components/pesticidkort/useFieldHover';
 import type { NearbyFieldSummary } from '@/components/pesticidkort/types';
 import type { MapInstance } from '@/components/field-analysis/map-constants';
@@ -48,7 +53,7 @@ export function PesticidkortMap({
   onFieldClick,
   activeFilter = 'none',
 }: PesticidkortMapProps) {
-  const { mapStyle } = useMapTheme();
+  const { mapStyle, mapStyleTheme } = useMapTheme();
   const mapRef = useRef<MapRef>(null);
   const [isReady, setIsReady] = useState(false);
   const { hoverData, attachHover } = useFieldHover();
@@ -115,15 +120,12 @@ export function PesticidkortMap({
   useEffect(() => {
     if (!isReady || !mapRef.current) return;
     const map = mapRef.current.getMap() as unknown as MapInstance;
+    syncFieldLayerTheme(map);
+    syncBuildingLayerTheme(map);
     applyChemicalFilter(map, activeFilter);
-  }, [activeFilter, isReady]);
+  }, [activeFilter, isReady, mapStyleTheme]);
 
-  if (!pmtilesUrl)
-    return (
-      <div className="bg-muted flex h-full items-center justify-center">
-        <p className="text-muted-foreground text-sm">Indlæser kort...</p>
-      </div>
-    );
+  if (!pmtilesUrl) return <MapLoadingState />;
 
   return (
     <>
@@ -138,9 +140,7 @@ export function PesticidkortMap({
         >
           <NavigationControl position="top-left" />
           {isReady && <ProximityRings lat={lat} lng={lng} radiusM={radiusM} />}
-          <Marker longitude={lng} latitude={lat} anchor="center">
-            <div className="bg-primary border-background h-4 w-4 rounded-full border-2 shadow-md" />
-          </Marker>
+          <AddressMarker lat={lat} lng={lng} />
         </Map>
       </div>
       {hoverData && <FieldHoverTooltip {...hoverData} />}

--- a/frontend/src/components/pesticidkort/ProximityRings.tsx
+++ b/frontend/src/components/pesticidkort/ProximityRings.tsx
@@ -1,5 +1,6 @@
 import { Source, Layer } from '@vis.gl/react-maplibre';
 import { useMemo, useEffect, useState } from 'react';
+import { resolvePesticidkortColor } from '@/components/pesticidkort/color-theme';
 
 interface ProximityRingsProps {
   lat: number;
@@ -30,6 +31,7 @@ function createCircleGeoJSON(
 
 export function ProximityRings({ lat, lng, radiusM }: ProximityRingsProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const ringColor = resolvePesticidkortColor('ring');
   const geojson = useMemo(
     () => ({
       type: 'FeatureCollection' as const,
@@ -53,7 +55,7 @@ export function ProximityRings({ lat, lng, radiusM }: ProximityRingsProps) {
         id="proximity-rings-fill"
         type="fill"
         paint={{
-          'fill-color': '#3f6ab3',
+          'fill-color': ringColor,
           'fill-opacity': isVisible ? 0.04 : 0,
           'fill-opacity-transition': { duration: 650, delay: 50 },
         }}
@@ -62,7 +64,7 @@ export function ProximityRings({ lat, lng, radiusM }: ProximityRingsProps) {
         id="proximity-rings-line"
         type="line"
         paint={{
-          'line-color': '#3f6ab3',
+          'line-color': ringColor,
           'line-width': 1.5,
           'line-dasharray': [4, 3],
           'line-opacity': isVisible ? 0.5 : 0,

--- a/frontend/src/components/pesticidkort/ReportHeader.tsx
+++ b/frontend/src/components/pesticidkort/ReportHeader.tsx
@@ -7,7 +7,7 @@ interface ReportHeaderProps {
 
 export function ReportHeader({ address, onBack }: ReportHeaderProps) {
   return (
-    <header className="bg-background/90 absolute top-0 right-0 left-0 z-20 flex items-center gap-3 border-b px-4 py-2.5 backdrop-blur-sm md:right-[420px]">
+    <header className="bg-background/90 border-border/70 absolute top-0 right-0 left-0 z-20 flex items-center gap-3 border-b px-4 py-2.5 backdrop-blur-sm md:right-[420px]">
       <button
         onClick={onBack}
         data-testid="back-to-search-button"

--- a/frontend/src/components/pesticidkort/ReportMapView.tsx
+++ b/frontend/src/components/pesticidkort/ReportMapView.tsx
@@ -120,7 +120,7 @@ export function ReportMapView({
 
       {/* Floating map controls: year + chemical pills */}
       <div className="pointer-events-none absolute inset-x-0 bottom-[55%] z-40 flex flex-col items-stretch gap-2 px-3 sm:px-4 md:right-[420px] md:bottom-[calc(var(--pesticidkort-footer-height)+1.5rem)] md:items-center">
-        <div className="bg-background/90 pointer-events-auto w-full max-w-full self-stretch rounded-full px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-auto md:px-3">
+        <div className="bg-background/90 border-border/70 pointer-events-auto w-full max-w-full self-stretch rounded-full border px-2 py-1 backdrop-blur-sm md:max-w-md md:min-w-[480px] md:self-auto md:px-3">
           <YearTimeline year={year} onChange={onYearChange} />
         </div>
         <ChemicalFilterPills

--- a/frontend/src/components/pesticidkort/StoryMapInner.tsx
+++ b/frontend/src/components/pesticidkort/StoryMapInner.tsx
@@ -2,15 +2,16 @@
 
 import { useRef, useEffect, useState, useCallback } from 'react';
 import Map, { Marker, MapRef } from '@vis.gl/react-maplibre';
-import 'maplibre-gl/dist/maplibre-gl.css';
 import { useMapTheme } from '@/hooks/useMapTheme';
 import { pmtilesCacheService } from '@/lib/pmtiles-cache-service';
 import {
   addFieldLayers,
   addOverviewLayers,
+  syncFieldLayerTheme,
 } from '@/components/pesticidkort/map-layers';
 import { registerPmtilesProtocol } from '@/components/pesticidkort/pmtiles-protocol';
 import { ProximityRings } from '@/components/pesticidkort/ProximityRings';
+import { resolvePesticidkortColor } from '@/components/pesticidkort/color-theme';
 import type { StoryChapter } from '@/components/pesticidkort/story-chapters';
 import type { MapInstance } from '@/components/field-analysis/map-constants';
 
@@ -29,7 +30,7 @@ export function StoryMapInner({
   year,
   chapter,
 }: StoryMapInnerProps) {
-  const { mapStyle } = useMapTheme();
+  const { mapStyle, mapStyleTheme } = useMapTheme();
   const mapRef = useRef<MapRef>(null);
   const [pmtilesUrl, setPmtilesUrl] = useState<string | null>(null);
   const [overviewUrl, setOverviewUrl] = useState<string | null>(null);
@@ -57,9 +58,10 @@ export function StoryMapInner({
   useEffect(() => {
     if (!mapRef.current || !ready) return;
     const map = mapRef.current.getMap();
+    syncFieldLayerTheme(map as unknown as MapInstance);
     map.flyTo({ center: [lng, lat], zoom: chapter.mapZoom, duration: 1200 });
     applyPaintMode(map, chapter.paintMode);
-  }, [chapter, lat, lng, ready]);
+  }, [chapter, lat, lng, mapStyleTheme, ready]);
 
   const showRings = chapter.showLayers.includes('proximity-rings');
   if (!pmtilesUrl) return null;
@@ -99,8 +101,8 @@ function applyPaintMode(
     color = [
       'case',
       ['>', ['coalesce', ['get', 'pfas_applications'], 0], 0],
-      '#d06a3a',
-      '#dfe6f2',
+      resolvePesticidkortColor('pfas'),
+      resolvePesticidkortColor('storyMuted'),
     ];
     opacity = 0.8;
   } else if (mode === 'burden') {
@@ -109,17 +111,17 @@ function applyPaintMode(
       ['linear'],
       ['coalesce', ['get', 'total_pesticide_belastning'], 0],
       0,
-      '#6abf69',
+      resolvePesticidkortColor('burdenLow'),
       2,
-      '#d4c54a',
+      resolvePesticidkortColor('burdenMid'),
       5,
-      '#d89135',
+      resolvePesticidkortColor('burdenMidHigh'),
       10,
-      '#c4512c',
+      resolvePesticidkortColor('burdenHigh'),
     ];
     opacity = 0.7;
   } else {
-    color = '#3a9d5d';
+    color = resolvePesticidkortColor('highlight');
     opacity = 0.5;
   }
   for (const id of layers) {

--- a/frontend/src/components/pesticidkort/SummaryStats.tsx
+++ b/frontend/src/components/pesticidkort/SummaryStats.tsx
@@ -67,9 +67,9 @@ export function SummaryStats({
             className={cn(
               'mt-0.5 text-xs',
               avgBurden >= 8
-                ? 'text-destructive/80 font-medium'
+                ? 'text-destructive font-semibold'
                 : avgBurden >= 4
-                  ? 'text-warning/80 font-medium'
+                  ? 'text-warning font-semibold'
                   : 'text-muted-foreground'
             )}
           >

--- a/frontend/src/components/pesticidkort/YearTimeline.tsx
+++ b/frontend/src/components/pesticidkort/YearTimeline.tsx
@@ -18,6 +18,8 @@ interface YearTimelineProps {
 export function YearTimeline({ year, onChange }: YearTimelineProps) {
   const stripRef = useRef<HTMLDivElement>(null);
   const activeIdx = YEARS.indexOf(year as (typeof YEARS)[number]);
+  const hasPrevYear = activeIdx > 0;
+  const hasNextYear = activeIdx >= 0 && activeIdx < YEARS.length - 1;
 
   useEffect(() => {
     const strip = stripRef.current;
@@ -64,20 +66,25 @@ export function YearTimeline({ year, onChange }: YearTimelineProps) {
       tabIndex={0}
       onKeyDown={handleKeyDown}
     >
-      <button
-        type="button"
-        onClick={() => activeIdx > 0 && onChange(YEARS[activeIdx - 1])}
-        disabled={activeIdx <= 0}
-        aria-label="Forrige år"
-        data-testid="year-prev-button"
-        className="text-muted-foreground hover:text-foreground flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-30 sm:h-9 sm:w-9"
-      >
-        <ChevronLeft className="h-4 w-4" />
-      </button>
+      {hasPrevYear && (
+        <button
+          type="button"
+          onClick={() => onChange(YEARS[activeIdx - 1])}
+          aria-label="Forrige år"
+          data-testid="year-prev-button"
+          className="text-muted-foreground hover:text-foreground flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors sm:h-9 sm:w-9"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+      )}
 
       <div
         ref={stripRef}
-        className="flex min-w-0 flex-1 snap-x snap-mandatory gap-0.5 overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className={cn(
+          'flex min-w-0 flex-1 snap-x snap-mandatory gap-0.5 overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+          hasPrevYear ? '' : 'pl-1',
+          hasNextYear ? '' : 'pr-1'
+        )}
       >
         {YEARS.map((y) => {
           const isActive = y === year;
@@ -102,18 +109,17 @@ export function YearTimeline({ year, onChange }: YearTimelineProps) {
         })}
       </div>
 
-      <button
-        type="button"
-        onClick={() =>
-          activeIdx < YEARS.length - 1 && onChange(YEARS[activeIdx + 1])
-        }
-        disabled={activeIdx >= YEARS.length - 1}
-        aria-label="Næste år"
-        data-testid="year-next-button"
-        className="text-muted-foreground hover:text-foreground flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-30 sm:h-9 sm:w-9"
-      >
-        <ChevronRight className="h-4 w-4" />
-      </button>
+      {hasNextYear && (
+        <button
+          type="button"
+          onClick={() => onChange(YEARS[activeIdx + 1])}
+          aria-label="Næste år"
+          data-testid="year-next-button"
+          className="text-muted-foreground hover:text-foreground flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors sm:h-9 sm:w-9"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/pesticidkort/color-theme.ts
+++ b/frontend/src/components/pesticidkort/color-theme.ts
@@ -1,0 +1,55 @@
+'use client';
+
+const COLOR_VARS = {
+  burdenLow: '--pesticidkort-color-burden-low',
+  burdenMidLow: '--pesticidkort-color-burden-mid-low',
+  burdenMid: '--pesticidkort-color-burden-mid',
+  burdenMidHigh: '--pesticidkort-color-burden-mid-high',
+  burdenHigh: '--pesticidkort-color-burden-high',
+  burdenNone: '--pesticidkort-color-burden-none',
+  pfas: '--pesticidkort-color-pfas',
+  glyphosate: '--pesticidkort-color-glyphosate',
+  diquat: '--pesticidkort-color-diquat',
+  ring: '--pesticidkort-color-ring',
+  highlight: '--pesticidkort-color-highlight',
+  fieldOutline: '--pesticidkort-color-field-outline',
+  schoolFill: '--pesticidkort-color-school-fill',
+  schoolOutline: '--pesticidkort-color-school-outline',
+  storyMuted: '--pesticidkort-color-story-muted',
+} as const;
+
+const FALLBACKS = {
+  burdenLow: '#22c55e',
+  burdenMidLow: '#84cc16',
+  burdenMid: '#eab308',
+  burdenMidHigh: '#f97316',
+  burdenHigh: '#dc2626',
+  burdenNone: '#d1d5db',
+  pfas: '#9333ea',
+  glyphosate: '#0891b2',
+  diquat: '#db2777',
+  ring: '#3f6ab3',
+  highlight: '#3a9d5d',
+  fieldOutline: '#5f6b80',
+  schoolFill: '#ec4899',
+  schoolOutline: '#be185d',
+  storyMuted: '#dfe6f2',
+} as const;
+
+export type PesticidkortColorKey = keyof typeof COLOR_VARS;
+
+export function pesticidkortCssColor(key: PesticidkortColorKey): string {
+  return `var(${COLOR_VARS[key]})`;
+}
+
+export function resolvePesticidkortColor(key: PesticidkortColorKey): string {
+  if (typeof document === 'undefined') {
+    return FALLBACKS[key];
+  }
+
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(COLOR_VARS[key])
+    .trim();
+
+  return value || FALLBACKS[key];
+}

--- a/frontend/src/components/pesticidkort/map-chemical-filter.ts
+++ b/frontend/src/components/pesticidkort/map-chemical-filter.ts
@@ -1,4 +1,5 @@
 import type { MapInstance } from '@/components/field-analysis/map-constants';
+import { resolvePesticidkortColor } from '@/components/pesticidkort/color-theme';
 
 export type ChemicalFilter = 'none' | 'pfas' | 'glyphosate' | 'diquat';
 
@@ -14,52 +15,67 @@ const FILTER_PROPERTY: Record<Exclude<ChemicalFilter, 'none'>, string> = {
   diquat: 'diquat_applications',
 };
 
-/** Stepped burden gradient based on total_pesticide_belastning (B/ha). */
-export const GRADE_FILL_COLOR = [
-  'case',
-  ['==', ['coalesce', ['get', 'total_pesticide_belastning'], 0], 0],
-  '#d1d5db',
-  [
-    'step',
-    ['get', 'total_pesticide_belastning'],
-    '#22c55e',
-    0.5,
-    '#84cc16',
-    2.0,
-    '#eab308',
-    4.0,
-    '#f97316',
-    8.0,
-    '#dc2626',
-  ],
-];
+function getChemicalColors() {
+  return {
+    pfas: resolvePesticidkortColor('pfas'),
+    glyphosate: resolvePesticidkortColor('glyphosate'),
+    diquat: resolvePesticidkortColor('diquat'),
+  } as const;
+}
 
-export const GRADE_FILL_OPACITY = [
-  'case',
-  ['==', ['coalesce', ['get', 'total_pesticide_belastning'], 0], 0],
-  0.35,
-  0.7,
-];
+/** Stepped burden gradient based on total_pesticide_belastning (B/ha). */
+export function getGradeFillColor() {
+  return [
+    'case',
+    ['==', ['coalesce', ['get', 'total_pesticide_belastning'], 0], 0],
+    resolvePesticidkortColor('burdenNone'),
+    [
+      'step',
+      ['get', 'total_pesticide_belastning'],
+      resolvePesticidkortColor('burdenLow'),
+      0.5,
+      resolvePesticidkortColor('burdenMidLow'),
+      2.0,
+      resolvePesticidkortColor('burdenMid'),
+      4.0,
+      resolvePesticidkortColor('burdenMidHigh'),
+      8.0,
+      resolvePesticidkortColor('burdenHigh'),
+    ],
+  ];
+}
+
+export function getGradeFillOpacity() {
+  return [
+    'case',
+    ['==', ['coalesce', ['get', 'total_pesticide_belastning'], 0], 0],
+    0.42,
+    0.72,
+  ];
+}
 
 /** Apply or clear a chemical filter on both detail and overview fill layers. */
 export function applyChemicalFilter(map: MapInstance, filter: ChemicalFilter) {
+  const gradeFillColor = getGradeFillColor();
+  const gradeFillOpacity = getGradeFillOpacity();
+
   if (filter === 'none') {
-    setLayerPaint(map, 'fields-fill', GRADE_FILL_COLOR, GRADE_FILL_OPACITY);
+    setLayerPaint(map, 'fields-fill', gradeFillColor, gradeFillOpacity);
     setLayerPaint(
       map,
       'fields-overview-fill',
-      GRADE_FILL_COLOR,
-      GRADE_FILL_OPACITY
+      gradeFillColor,
+      gradeFillOpacity
     );
     return;
   }
 
   const prop = FILTER_PROPERTY[filter];
-  const color = CHEMICAL_COLORS[filter];
+  const color = getChemicalColors()[filter];
   const hasChemical = ['>', ['coalesce', ['get', prop], 0], 0];
 
-  const filteredColor = ['case', hasChemical, color, GRADE_FILL_COLOR];
-  const filteredOpacity = ['case', hasChemical, 0.75, 0.08];
+  const filteredColor = ['case', hasChemical, color, gradeFillColor];
+  const filteredOpacity = ['case', hasChemical, 0.78, 0.12];
 
   // Detail layers have all properties — apply any filter
   setLayerPaint(map, 'fields-fill', filteredColor, filteredOpacity);
@@ -69,9 +85,9 @@ export function applyChemicalFilter(map: MapInstance, filter: ChemicalFilter) {
     setLayerPaint(map, 'fields-overview-fill', filteredColor, filteredOpacity);
   } else {
     // Can't filter glyphosate/diquat on overview — dim everything slightly
-    setLayerPaint(map, 'fields-overview-fill', GRADE_FILL_COLOR, [
+    setLayerPaint(map, 'fields-overview-fill', gradeFillColor, [
       'literal',
-      0.08,
+      0.12,
     ]);
   }
 }

--- a/frontend/src/components/pesticidkort/map-highlight.ts
+++ b/frontend/src/components/pesticidkort/map-highlight.ts
@@ -1,4 +1,5 @@
 import type { MapRef } from '@vis.gl/react-maplibre';
+import { resolvePesticidkortColor } from '@/components/pesticidkort/color-theme';
 
 const HIGHLIGHT_LAYER = 'fields-highlight';
 const HIGHLIGHT_SOURCE = 'fields';
@@ -22,12 +23,18 @@ export function highlightField(
       'source-layer': SOURCE_LAYER,
       type: 'line',
       paint: {
-        'line-color': '#3a9d5d',
+        'line-color': resolvePesticidkortColor('highlight'),
         'line-width': 3,
         'line-opacity': 1,
       },
       filter: ['==', 'field_uuid', ''],
     });
+  } else {
+    map.setPaintProperty(
+      HIGHLIGHT_LAYER,
+      'line-color',
+      resolvePesticidkortColor('highlight')
+    );
   }
 
   map.setFilter(

--- a/frontend/src/components/pesticidkort/map-layers-buildings.ts
+++ b/frontend/src/components/pesticidkort/map-layers-buildings.ts
@@ -1,4 +1,23 @@
 import type { MapInstance } from '@/components/field-analysis/map-constants';
+import { resolvePesticidkortColor } from '@/components/pesticidkort/color-theme';
+
+export function syncBuildingLayerTheme(map: MapInstance) {
+  if (map.getLayer('buildings-edu-fill')) {
+    map.setPaintProperty(
+      'buildings-edu-fill',
+      'fill-color',
+      resolvePesticidkortColor('schoolFill')
+    );
+  }
+
+  if (map.getLayer('buildings-edu-outline')) {
+    map.setPaintProperty(
+      'buildings-edu-outline',
+      'line-color',
+      resolvePesticidkortColor('schoolOutline')
+    );
+  }
+}
 
 /** School and institution building outlines for the pesticidkort map. */
 export function addBuildingLayers(map: MapInstance, pmtilesUrl: string) {
@@ -17,7 +36,7 @@ export function addBuildingLayers(map: MapInstance, pmtilesUrl: string) {
       type: 'fill',
       filter: ['==', ['get', 'building_usage_category'], 'publicServices'],
       paint: {
-        'fill-color': '#EC4899',
+        'fill-color': resolvePesticidkortColor('schoolFill'),
         'fill-opacity': 0.45,
       },
     });
@@ -29,10 +48,12 @@ export function addBuildingLayers(map: MapInstance, pmtilesUrl: string) {
       type: 'line',
       filter: ['==', ['get', 'building_usage_category'], 'publicServices'],
       paint: {
-        'line-color': '#BE185D',
+        'line-color': resolvePesticidkortColor('schoolOutline'),
         'line-width': 1.5,
         'line-opacity': 0.8,
       },
     });
   }
+
+  syncBuildingLayerTheme(map);
 }

--- a/frontend/src/components/pesticidkort/map-layers.ts
+++ b/frontend/src/components/pesticidkort/map-layers.ts
@@ -1,14 +1,32 @@
 import type { MapInstance } from '@/components/field-analysis/map-constants';
 import {
-  GRADE_FILL_COLOR,
-  GRADE_FILL_OPACITY,
+  getGradeFillColor,
+  getGradeFillOpacity,
 } from '@/components/pesticidkort/map-chemical-filter';
+import { resolvePesticidkortColor } from '@/components/pesticidkort/color-theme';
 
 export type { ChemicalFilter } from '@/components/pesticidkort/map-chemical-filter';
 export {
   CHEMICAL_COLORS,
   applyChemicalFilter,
 } from '@/components/pesticidkort/map-chemical-filter';
+
+export function syncFieldLayerTheme(map: MapInstance) {
+  const fillColor = getGradeFillColor();
+  const fillOpacity = getGradeFillOpacity();
+  const outlineColor = resolvePesticidkortColor('fieldOutline');
+
+  for (const layerId of ['fields-fill', 'fields-overview-fill']) {
+    if (!map.getLayer(layerId)) continue;
+    map.setPaintProperty(layerId, 'fill-color', fillColor);
+    map.setPaintProperty(layerId, 'fill-opacity', fillOpacity);
+  }
+
+  for (const layerId of ['fields-outline', 'fields-overview-outline']) {
+    if (!map.getLayer(layerId)) continue;
+    map.setPaintProperty(layerId, 'line-color', outlineColor);
+  }
+}
 
 /** Detail layers — full property data, used for queries at high zoom. */
 export function addFieldLayers(map: MapInstance, pmtilesUrl: string) {
@@ -27,8 +45,8 @@ export function addFieldLayers(map: MapInstance, pmtilesUrl: string) {
       type: 'fill',
       minzoom: 12,
       paint: {
-        'fill-color': GRADE_FILL_COLOR as unknown as string,
-        'fill-opacity': GRADE_FILL_OPACITY as unknown as number,
+        'fill-color': getGradeFillColor() as unknown as string,
+        'fill-opacity': getGradeFillOpacity() as unknown as number,
       },
     });
     map.addLayer({
@@ -38,12 +56,14 @@ export function addFieldLayers(map: MapInstance, pmtilesUrl: string) {
       type: 'line',
       minzoom: 12,
       paint: {
-        'line-color': '#5f6b80',
+        'line-color': resolvePesticidkortColor('fieldOutline'),
         'line-width': 0.5,
         'line-opacity': 0.4,
       },
     });
   }
+
+  syncFieldLayerTheme(map);
 }
 
 /** Overview layers — 3 properties only, all features at every zoom. */
@@ -63,8 +83,8 @@ export function addOverviewLayers(map: MapInstance, overviewUrl: string) {
       type: 'fill',
       maxzoom: 12,
       paint: {
-        'fill-color': GRADE_FILL_COLOR as unknown as string,
-        'fill-opacity': GRADE_FILL_OPACITY as unknown as number,
+        'fill-color': getGradeFillColor() as unknown as string,
+        'fill-opacity': getGradeFillOpacity() as unknown as number,
       },
     });
     map.addLayer({
@@ -74,10 +94,12 @@ export function addOverviewLayers(map: MapInstance, overviewUrl: string) {
       type: 'line',
       maxzoom: 12,
       paint: {
-        'line-color': '#5f6b80',
+        'line-color': resolvePesticidkortColor('fieldOutline'),
         'line-width': 0.5,
         'line-opacity': 0.3,
       },
     });
   }
+
+  syncFieldLayerTheme(map);
 }

--- a/frontend/src/components/pesticidkort/types.ts
+++ b/frontend/src/components/pesticidkort/types.ts
@@ -12,6 +12,8 @@ export interface GradeInfo {
   description: string;
 }
 
+export type PesticideGradeStatus = 'loading' | 'ready' | 'no_data';
+
 export interface NearbyFieldSummary {
   field_uuid: string;
   crop_name: string;
@@ -51,6 +53,7 @@ export interface PesticideReport {
   radius_m: number;
   year: number;
   grade: GradeInfo | null;
+  grade_status: PesticideGradeStatus;
   score: number;
   fields_count: number;
   pfas_fields_count: number;

--- a/frontend/src/components/pesticidkort/useDriftExposure.ts
+++ b/frontend/src/components/pesticidkort/useDriftExposure.ts
@@ -1,13 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import {
-  DEFAULT_DRIFT_TILE_ZOOM,
-  haversineMeters,
-  lngLatToTile,
-  MATCH_TOLERANCE_M,
-  surroundingTiles,
-} from '@/lib/drift-exposure-tiles';
 
 export interface DriftExposureMatch {
   exposure_percentile: number;
@@ -16,25 +9,9 @@ export interface DriftExposureMatch {
   building_distance_m: number;
 }
 
-interface DriftExposureIndexResponse {
-  pesticide_year: number | null;
-  national_avg_drift_dose_kg: number | null;
-  tile_zoom: number;
-}
-
-interface DriftExposureBuildingResponse {
-  uid: string;
-  lat: number;
-  lng: number;
-  pct: number;
-  dose: number;
-}
-
 /**
- * Look up drift-exposure percentile for a coordinate by loading the address's
- * slippy-map tile plus adjacent tiles, then finding the nearest BBR building.
- * Returns null when no nearby building shard exists or no building is within
- * {@link MATCH_TOLERANCE_M}.
+ * Look up the final drift-exposure match for a coordinate via a single server
+ * endpoint that resolves nearby tiles and nearest-building matching.
  */
 export function useDriftExposure(
   lat: number | undefined,
@@ -59,60 +36,29 @@ export function useDriftExposure(
     setMatch(null);
 
     (async () => {
-      const indexRes = await fetch('/api/drift-exposure');
+      const params = new URLSearchParams({
+        lat: lat.toString(),
+        lng: lng.toString(),
+      });
+      const response = await fetch(`/api/drift-exposure/lookup?${params}`);
       if (cancelled) return;
-      const index = indexRes.ok
-        ? ((await indexRes.json()) as DriftExposureIndexResponse)
-        : null;
-      if (cancelled) return;
-      const tileZoom = index?.tile_zoom ?? DEFAULT_DRIFT_TILE_ZOOM;
-      const centerTile = lngLatToTile(lat, lng, tileZoom);
-      const tileResponses = await Promise.all(
-        surroundingTiles(centerTile.x, centerTile.y, centerTile.z).map(
-          async (tile) => {
-            const response = await fetch(
-              `/api/drift-exposure?z=${tile.z}&x=${tile.x}&y=${tile.y}`
-            );
-            if (!response.ok) return [];
-            return (await response.json()) as DriftExposureBuildingResponse[];
-          }
-        )
-      );
-      if (cancelled) return;
-      const seen = new Set<string>();
-      const buildings: DriftExposureBuildingResponse[] = [];
-      for (const tileBuildings of tileResponses) {
-        for (const building of tileBuildings) {
-          if (seen.has(building.uid)) continue;
-          seen.add(building.uid);
-          buildings.push(building);
-        }
+      if (!response.ok) {
+        setStatus('no_match');
+        return;
       }
-
-      let nearest: DriftExposureBuildingResponse | null = null;
-      let nearestDist = Infinity;
-      for (const b of buildings) {
-        const d = haversineMeters(lat, lng, b.lat, b.lng);
-        if (d < nearestDist) {
-          nearest = b;
-          nearestDist = d;
-        }
-      }
-
-      if (!nearest || nearestDist > MATCH_TOLERANCE_M) {
+      const driftMatch = (await response.json()) as DriftExposureMatch | null;
+      if (cancelled) return;
+      if (!driftMatch) {
         setStatus('no_match');
         return;
       }
 
-      setMatch({
-        exposure_percentile: nearest.pct,
-        drift_dose_kg: nearest.dose,
-        national_avg_drift_dose_kg: index?.national_avg_drift_dose_kg ?? null,
-        building_distance_m: Math.round(nearestDist),
-      });
+      setMatch(driftMatch);
       setStatus('ready');
     })().catch(() => {
-      if (!cancelled) setStatus('no_match');
+      if (!cancelled) {
+        setStatus('no_match');
+      }
     });
 
     return () => {

--- a/frontend/src/components/pesticidkort/useReportBuilder.ts
+++ b/frontend/src/components/pesticidkort/useReportBuilder.ts
@@ -8,6 +8,7 @@ import type {
   NearbyFieldSummary,
   ExposureSummary,
   GradeInfo,
+  PesticideGradeStatus,
 } from '@/components/pesticidkort/types';
 import type { DriftExposureMatch } from '@/components/pesticidkort/useDriftExposure';
 
@@ -49,72 +50,75 @@ export function useReportBuilder({
   driftExposure,
   driftStatus,
 }: UseReportBuilderOptions) {
+  const [fields, setFields] = useState<NearbyFieldSummary[] | null>(null);
   const [report, setReport] = useState<PesticideReport | null>(null);
 
-  const handleFieldsLoaded = useCallback(
-    (fields: NearbyFieldSummary[]) => {
-      const { score, grade: fallbackGrade } = computePesticideScore(
-        fields,
-        radiusM
-      );
-      // When drift-exposure has no BBR match AND we found no nearby sprayed
-      // fields, we genuinely have no signal — don't default to UNDER_AVG (the
-      // burden fallback returns that for fields.length === 0 and that misled
-      // users into thinking every address was below average).
-      const hasNoData = driftStatus === 'no_match' && fields.length === 0;
-      const grade: GradeInfo | null = hasNoData
-        ? null
-        : driftExposure
-          ? driftPercentileToGrade(
-              driftExposure.exposure_percentile,
-              driftExposure.drift_dose_kg,
-              driftExposure.national_avg_drift_dose_kg
-            )
-          : fallbackGrade;
-      let pfasCount = 0;
-      let totalBurden = 0;
-      let hasBnbo = false;
-      for (const f of fields) {
-        if (f.pfas_applications > 0) pfasCount++;
-        totalBurden += f.total_pesticide_belastning;
-        if (f.bnbo_area_hectares && f.bnbo_area_hectares > 0) hasBnbo = true;
-      }
-      setReport({
-        address,
-        lat,
-        lng,
-        radius_m: radiusM,
-        year,
-        grade,
-        score,
-        fields_count: fields.length,
-        pfas_fields_count: pfasCount,
-        avg_burden:
-          fields.length > 0
-            ? Math.round((totalBurden / fields.length) * 100) / 100
-            : 0,
-        nearest_field_m: fields[0]?.distance_m ?? 0,
-        fields,
-        has_bnbo_overlap: hasBnbo,
-        has_violations: false,
-        exposure_100m: computeExposure(fields, 100),
-        exposure_1000m: computeExposure(fields, radiusM),
-      });
-    },
-    [address, lat, lng, radiusM, year, driftExposure, driftStatus]
-  );
+  const handleFieldsLoaded = useCallback((fields: NearbyFieldSummary[]) => {
+    setFields(fields);
+  }, []);
 
-  // If drift exposure lands after fields, upgrade the grade in place.
   useEffect(() => {
-    if (!report || !driftExposure) return;
-    const driftGrade = driftPercentileToGrade(
-      driftExposure.exposure_percentile,
-      driftExposure.drift_dose_kg,
-      driftExposure.national_avg_drift_dose_kg
+    if (!fields) {
+      setReport(null);
+      return;
+    }
+
+    const { score, grade: fallbackGrade } = computePesticideScore(
+      fields,
+      radiusM
     );
-    if (report.grade && driftGrade.grade === report.grade.grade) return;
-    setReport({ ...report, grade: driftGrade });
-  }, [driftExposure, report]);
+
+    let grade: GradeInfo | null = null;
+    let gradeStatus: PesticideGradeStatus = 'loading';
+
+    if (driftExposure) {
+      grade = driftPercentileToGrade(
+        driftExposure.exposure_percentile,
+        driftExposure.drift_dose_kg,
+        driftExposure.national_avg_drift_dose_kg
+      );
+      gradeStatus = 'ready';
+    } else if (driftStatus === 'no_match') {
+      if (fields.length === 0) {
+        gradeStatus = 'no_data';
+      } else {
+        grade = fallbackGrade;
+        gradeStatus = 'ready';
+      }
+    }
+
+    let pfasCount = 0;
+    let totalBurden = 0;
+    let hasBnbo = false;
+    for (const f of fields) {
+      if (f.pfas_applications > 0) pfasCount++;
+      totalBurden += f.total_pesticide_belastning;
+      if (f.bnbo_area_hectares && f.bnbo_area_hectares > 0) hasBnbo = true;
+    }
+
+    setReport({
+      address,
+      lat,
+      lng,
+      radius_m: radiusM,
+      year,
+      grade,
+      grade_status: gradeStatus,
+      score,
+      fields_count: fields.length,
+      pfas_fields_count: pfasCount,
+      avg_burden:
+        fields.length > 0
+          ? Math.round((totalBurden / fields.length) * 100) / 100
+          : 0,
+      nearest_field_m: fields[0]?.distance_m ?? 0,
+      fields,
+      has_bnbo_overlap: hasBnbo,
+      has_violations: false,
+      exposure_100m: computeExposure(fields, 100),
+      exposure_1000m: computeExposure(fields, radiusM),
+    });
+  }, [address, driftExposure, driftStatus, fields, lat, lng, radiusM, year]);
 
   return { report, handleFieldsLoaded };
 }

--- a/frontend/tests/pesticidkort.spec.ts
+++ b/frontend/tests/pesticidkort.spec.ts
@@ -137,6 +137,67 @@ test.describe('Pesticidkort', () => {
     expect(navBox!.y).toBeGreaterThan(pillsBox!.y + pillsBox!.height + 8);
   });
 
+  test('should render pesticidkort overlays with dark-safe contrast in dark mode', async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      window.localStorage.setItem('landbruget-theme', 'dark');
+    });
+
+    await page.reload();
+    await page.locator('[data-testid="explore-map-button"]').click();
+
+    await expect(page.locator('[data-testid="map-legend"]')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.locator('.maplibregl-ctrl-group').first()).toBeVisible();
+    await expect(
+      page.locator('[data-testid="chemical-filter-pfas"]')
+    ).toBeVisible();
+
+    const styles = await page.evaluate(() => {
+      const readLuma = (value: string) => {
+        const matches = value.match(/\d+(\.\d+)?/g);
+        if (!matches || matches.length < 3) return null;
+        const [r, g, b] = matches.slice(0, 3).map(Number);
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+      };
+
+      const legend = document.querySelector(
+        '[data-testid="map-legend"]'
+      ) as HTMLElement | null;
+      const ctrl = document.querySelector(
+        '.maplibregl-ctrl-group'
+      ) as HTMLElement | null;
+      const pillDot = document.querySelector(
+        '[data-testid="chemical-filter-pfas"] span'
+      ) as HTMLElement | null;
+
+      if (!legend || !ctrl || !pillDot) {
+        return null;
+      }
+
+      const legendStyle = getComputedStyle(legend);
+      const ctrlStyle = getComputedStyle(ctrl);
+      const pillDotStyle = getComputedStyle(pillDot);
+
+      return {
+        rootDark: document.documentElement.classList.contains('dark'),
+        legendLuma: readLuma(legendStyle.backgroundColor),
+        ctrlLuma: readLuma(ctrlStyle.backgroundColor),
+        pillDotBg: pillDotStyle.backgroundColor,
+      };
+    });
+
+    expect(styles).not.toBeNull();
+    expect(styles!.rootDark).toBe(true);
+    expect(styles!.legendLuma).not.toBeNull();
+    expect(styles!.ctrlLuma).not.toBeNull();
+    expect(styles!.pillDotBg).not.toBe('rgba(0, 0, 0, 0)');
+    expect(styles!.legendLuma!).toBeLessThan(80);
+    expect(styles!.ctrlLuma!).toBeLessThan(80);
+  });
+
   test('should keep mobile footer expansion from covering the legend or report sheet', async ({
     page,
   }) => {

--- a/frontend/tests/routes/drift-exposure-lookup.route.test.ts
+++ b/frontend/tests/routes/drift-exposure-lookup.route.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from '@/app/api/drift-exposure/lookup/route';
+import {
+  getCachedDriftExposureIndex,
+  getCachedDriftExposureTile,
+} from '@/lib/server-cache';
+
+import { createRouteRequest } from './helpers/request';
+
+vi.mock('@/lib/server-cache', () => ({
+  getCachedDriftExposureIndex: vi.fn(),
+  getCachedDriftExposureTile: vi.fn(),
+}));
+
+const getCachedDriftExposureIndexMock = vi.mocked(getCachedDriftExposureIndex);
+const getCachedDriftExposureTileMock = vi.mocked(getCachedDriftExposureTile);
+
+describe('GET /api/drift-exposure/lookup', () => {
+  beforeEach(() => {
+    getCachedDriftExposureIndexMock.mockReset();
+    getCachedDriftExposureTileMock.mockReset();
+  });
+
+  it('returns the nearest drift-exposure match for a coordinate', async () => {
+    getCachedDriftExposureIndexMock.mockResolvedValue({
+      pesticide_year: 2024,
+      national_avg_drift_dose_kg: 1.23,
+      building_count: 2,
+      tile_zoom: 12,
+      tile_count: 1,
+    });
+    getCachedDriftExposureTileMock.mockResolvedValueOnce([
+      { uid: 'near', lat: 55.6761, lng: 12.5683, pct: 95, dose: 2.4 },
+      { uid: 'far', lat: 55.68, lng: 12.58, pct: 50, dose: 0.8 },
+    ]);
+    getCachedDriftExposureTileMock.mockResolvedValue([]);
+
+    const response = await GET(
+      createRouteRequest(
+        'https://landbruget.dk/api/drift-exposure/lookup?lat=55.6761&lng=12.5683'
+      )
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      exposure_percentile: 95,
+      drift_dose_kg: 2.4,
+      national_avg_drift_dose_kg: 1.23,
+      building_distance_m: 0,
+    });
+  });
+
+  it('returns null when no building is within match tolerance', async () => {
+    getCachedDriftExposureIndexMock.mockResolvedValue({
+      pesticide_year: 2024,
+      national_avg_drift_dose_kg: 1.23,
+      building_count: 1,
+      tile_zoom: 12,
+      tile_count: 1,
+    });
+    getCachedDriftExposureTileMock.mockResolvedValue([
+      { uid: 'far', lat: 55.68, lng: 12.58, pct: 50, dose: 0.8 },
+    ]);
+
+    const response = await GET(
+      createRouteRequest(
+        'https://landbruget.dk/api/drift-exposure/lookup?lat=55.6761&lng=12.5683'
+      )
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toBeNull();
+  });
+
+  it('rejects invalid coordinates', async () => {
+    const response = await GET(
+      createRouteRequest(
+        'https://landbruget.dk/api/drift-exposure/lookup?lat=north&lng=12.5683'
+      )
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid coordinates',
+    });
+  });
+});


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked

## 💡 Solution
- Added `/api/drift-exposure/lookup` and refactored `useDriftExposure` to use one server lookup flow with nearest-building matching and cache headers.
- Updated report assembly to handle `grade_status` (`loading`/`ready`/`no_data`) and show clearer loading/no-data score states.
- Polished pesticidkort map UI and theming across controls, legend/pills, overlays, plus theme-synced map layer colors and conditional year navigation arrows to avoid clipped active years.
- Added shared map helpers/components (`color-theme`, `MapLoadingState`, `AddressMarker`) and expanded coverage with route tests and dark-mode overlay contrast E2E assertions.

## ✅ How to Do Self-Test
- `cd frontend && npm run test:routes -- tests/routes/drift-exposure-lookup.route.test.ts`
- Run `cd frontend && npm test && npm run lint` for full frontend verification.

## 📷 Screenshots (if applicable)
- UI was updated for map overlays/controls and year timeline edge behavior; capture fresh screenshots from `/pesticidkort` in light and dark mode.

## 📝 Additional Notes
- Pre-commit hooks passed during commit, including `Playwright Smoke Test (Fast)`.
