### PR TITLE
fix(pesticidkort): show story map on mobile

### DIFF
--- a/frontend/src/components/pesticidkort/StoryChapter.tsx
+++ b/frontend/src/components/pesticidkort/StoryChapter.tsx
@@ -35,7 +35,7 @@ export function StoryChapter({
     <div
       ref={ref}
       data-testid={`story-chapter-${index}`}
-      className="flex min-h-screen items-center"
+      className="flex min-h-[70vh] items-center md:min-h-screen"
     >
       <motion.div
         initial={{ opacity: 0, y: 30 }}

--- a/frontend/src/components/pesticidkort/StoryMode.tsx
+++ b/frontend/src/components/pesticidkort/StoryMode.tsx
@@ -44,7 +44,7 @@ export function StoryMode({ report, onClose }: StoryModeProps) {
   return (
     <div
       data-testid="story-mode"
-      className="bg-background fixed inset-0 z-50 flex"
+      className="bg-background fixed inset-0 z-50 flex flex-col md:flex-row"
     >
       <button
         onClick={onClose}
@@ -54,7 +54,17 @@ export function StoryMode({ report, onClose }: StoryModeProps) {
         <X className="h-5 w-5" />
       </button>
 
-      <div className="w-full overflow-y-auto md:w-2/5">
+      <div className="h-[45vh] shrink-0 md:order-2 md:h-screen md:w-3/5">
+        <StoryMap
+          lat={report.lat}
+          lng={report.lng}
+          radiusM={report.radius_m}
+          year={report.year}
+          chapter={STORY_CHAPTERS[activeChapter]}
+        />
+      </div>
+
+      <div className="flex-1 overflow-y-auto md:order-1 md:h-screen md:w-2/5 md:flex-none">
         {STORY_CHAPTERS.map((ch, i) => (
           <StoryChapter
             key={ch.id}
@@ -66,16 +76,6 @@ export function StoryMode({ report, onClose }: StoryModeProps) {
             onEnterView={() => handleChapterEnter(i)}
           />
         ))}
-      </div>
-
-      <div className="sticky top-0 hidden h-screen md:block md:w-3/5">
-        <StoryMap
-          lat={report.lat}
-          lng={report.lng}
-          radiusM={report.radius_m}
-          year={report.year}
-          chapter={STORY_CHAPTERS[activeChapter]}
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 🛠️ Issue Fix

The "Forstå dine resultater" scrollytelling flow showed nothing but text on mobile — the map was hidden.

## 💡 Solution

- `StoryMode.tsx` was wrapping `<StoryMap>` in `hidden md:block`, so the map never mounted below `md`. Restructured the root into `flex flex-col md:flex-row` with `md:order-*` so mobile gets a map pinned at the top (45vh) and chapters scrolling below, while desktop keeps the side-by-side layout unchanged.
- `StoryChapter.tsx` `min-h-screen` → `min-h-[70vh] md:min-h-screen` so the `useInView({amount:0.5})` trigger still fires cleanly inside the smaller mobile scroll area.

## ✅ How to Do Self-Test

1. Open `/pesticidkort` on a mobile viewport (≤768px).
2. Search an address with fields nearby (e.g. "Rådhuspladsen 1, 8362 Hørning"), then tap "Forstå dine resultater".
3. Verify the map is pinned at the top and pans/zooms/repaints as you scroll through all 5 chapters.
4. Resize to desktop and confirm the original left-text / right-map layout still works.

## 📝 Additional Notes

Verified on Chrome 390×844 and 1440×900; `npm run lint` and `npm run test:smoke` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)