### PR TITLE
fix(svineflytning): handle None Response in silver transform

### DIFF
--- a/backend/pipelines/svineflytning_pipeline/silver/transform.py
+++ b/backend/pipelines/svineflytning_pipeline/silver/transform.py
@@ -176,8 +176,8 @@ class SvineflytningSilverProcessor:
         all_movements = []
 
         for chunk in raw_data:
-            response = chunk.get("response", {}).get("Response", {})
-            svineflytning_liste = response.get("SvineflytningListe", {})
+            response = ((chunk or {}).get("response") or {}).get("Response") or {}
+            svineflytning_liste = response.get("SvineflytningListe") or {}
 
             if isinstance(svineflytning_liste, dict) and "Svineflytning" in svineflytning_liste:
                 movements = svineflytning_liste["Svineflytning"]

--- a/backend/pipelines/svineflytning_pipeline/tests/test_silver_none_response.py
+++ b/backend/pipelines/svineflytning_pipeline/tests/test_silver_none_response.py
@@ -1,0 +1,29 @@
+"""Regression test: silver _transform_movements must tolerate None Response chunks.
+
+Triggered by GitHub Actions run 25418075728 where the SOAP service returned a
+chunk with `response["Response"] = None`, crashing the silver stage.
+"""
+
+from silver.transform import SvineflytningSilverProcessor
+
+
+def test_transform_movements_skips_chunks_with_none_response(sample_bronze_chunk):
+    none_response_chunk = {
+        "timestamp": "2026-03-01T00:00:00",
+        "start_date": "2026-03-01",
+        "end_date": "2026-03-03",
+        "response": {"GLRCHRWSInfoOutbound": {}, "Response": None},
+    }
+    raw_data = [none_response_chunk, sample_bronze_chunk]
+    expected = len(
+        sample_bronze_chunk["response"]["Response"]["SvineflytningListe"]["Svineflytning"]
+    )
+
+    processor = SvineflytningSilverProcessor(output_dir="/tmp/svineflytning_test")
+    try:
+        count = processor._transform_movements(raw_data, "20260301_000000")
+    finally:
+        if processor.conn is not None:
+            processor.conn.close()
+
+    assert count == expected


### PR DESCRIPTION
## 🛠️ Issue Fix
Fixes scheduled pipeline failure in [Actions run 25418075728](https://github.com/Klimabevaegelsen/landbruget.dk/actions/runs/25418075728).

## 💡 Solution
- Silver stage crashed with \`AttributeError: 'NoneType' object has no attribute 'get'\` when the SOAP service returned a chunk with \`response[\"Response\"] = None\`. \`dict.get(key, {})\` returns None (not the default) when the key is present with a None value, so the chained \`.get(\"SvineflytningListe\", {})\` blew up.
- Coerce None at each level via \`or {}\` in \`backend/pipelines/svineflytning_pipeline/silver/transform.py\`, keeping the existing isinstance/contains guard intact.
- Added a regression test (\`tests/test_silver_none_response.py\`) that mixes a None-Response chunk with a normal chunk and asserts the normal chunk's movements are still processed.

## ✅ How to Do Self-Test
\`\`\`bash
cd backend/pipelines/svineflytning_pipeline
uv run --isolated --no-sync pytest tests/ -v
\`\`\`
All 63 tests pass.

## 📝 Additional Notes
Re-trigger the workflow after merge to confirm the scheduled run succeeds.