### PR TITLE
feat(pipeline): add skovrejsning (afforestation areas) data source

### DIFF
--- a/.github/workflows/unified_pipeline.yml
+++ b/.github/workflows/unified_pipeline.yml
@@ -30,6 +30,7 @@ on:
           - cadastral
           - agricultural_fields
           - bnbo
+          - skovrejsning
           - dagi
           - jordbrugsanalyser
           - fvm_wfs
@@ -84,7 +85,7 @@ jobs:
                {"source":"fvm_wfs","layer_type":"organic_areas","year":2012},{"source":"fvm_wfs","layer_type":"organic_areas","year":2013},{"source":"fvm_wfs","layer_type":"organic_areas","year":2014},{"source":"fvm_wfs","layer_type":"organic_areas","year":2015},{"source":"fvm_wfs","layer_type":"organic_areas","year":2016},{"source":"fvm_wfs","layer_type":"organic_areas","year":2017},{"source":"fvm_wfs","layer_type":"organic_areas","year":2018},{"source":"fvm_wfs","layer_type":"organic_areas","year":2019},{"source":"fvm_wfs","layer_type":"organic_areas","year":2020},{"source":"fvm_wfs","layer_type":"organic_areas","year":2021},{"source":"fvm_wfs","layer_type":"organic_areas","year":2022},{"source":"fvm_wfs","layer_type":"organic_areas","year":2023},{"source":"fvm_wfs","layer_type":"organic_areas","year":2024}
              ]')) ||
             (github.event.inputs.source == 'all' &&
-             fromJson('[{"source":"soil_types"},{"source":"wetlands"},{"source":"water_typology"},{"source":"grukos"},{"source":"pesticide_disaggregation"},{"source":"pesticide_compliance"},{"source":"worker_safety"},{"source":"work_permits"},{"source":"dmi"},{"source":"cadastral"},{"source":"agricultural_fields"},{"source":"bnbo"},{"source":"dagi"},{"source":"jordbrugsanalyser"},{"source":"fvm_wfs"},{"source":"water_projects"},{"source":"property_cadastral_merge"},{"source":"field_production"},{"source":"field_area_analysis"},{"source":"arbejdstilsynet_inspections"},{"source":"dst"},{"source":"cvr_enrichment"},{"source":"nles5_nitrogen_estimation"},{"source":"geus_dataverse_pesticides"},{"source":"kemidata_surface_water_pesticides"}]')) ||
+             fromJson('[{"source":"soil_types"},{"source":"wetlands"},{"source":"water_typology"},{"source":"grukos"},{"source":"pesticide_disaggregation"},{"source":"pesticide_compliance"},{"source":"worker_safety"},{"source":"work_permits"},{"source":"dmi"},{"source":"cadastral"},{"source":"agricultural_fields"},{"source":"bnbo"},{"source":"skovrejsning"},{"source":"dagi"},{"source":"jordbrugsanalyser"},{"source":"fvm_wfs"},{"source":"water_projects"},{"source":"property_cadastral_merge"},{"source":"field_production"},{"source":"field_area_analysis"},{"source":"arbejdstilsynet_inspections"},{"source":"dst"},{"source":"cvr_enrichment"},{"source":"nles5_nitrogen_estimation"},{"source":"geus_dataverse_pesticides"},{"source":"kemidata_surface_water_pesticides"}]')) ||
             fromJson(format('[{{"source":"{0}"}}]', github.event.inputs.source))
           }}
       fail-fast: false

--- a/backend/pipelines/unified_pipeline/src/tests/silver/test_skovrejsning_silver.py
+++ b/backend/pipelines/unified_pipeline/src/tests/silver/test_skovrejsning_silver.py
@@ -1,0 +1,173 @@
+import json
+
+import pytest
+
+from unified_pipeline.silver.skovrejsning import SkovrejsningSilver, SkovrejsningSilverConfig
+
+
+@pytest.fixture
+def silver_config() -> SkovrejsningSilverConfig:
+    return SkovrejsningSilverConfig()
+
+
+@pytest.fixture
+def skovrejsning_silver(silver_config: SkovrejsningSilverConfig) -> SkovrejsningSilver:
+    return SkovrejsningSilver(silver_config)
+
+
+@pytest.fixture
+def sample_geojson_payload() -> str:
+    def polygon(x: float, y: float) -> dict:
+        return {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [x, y],
+                    [x + 1000, y],
+                    [x + 1000, y + 1000],
+                    [x, y + 1000],
+                    [x, y],
+                ]
+            ],
+        }
+
+    return json.dumps(
+        {
+            "type": "FeatureCollection",
+            "numberMatched": 3,
+            "numberReturned": 3,
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "omraadenavn": "Uønsket",
+                        "komnavn": "Aarhus",
+                        "plangrund": "Vedtaget",
+                        "plannr": "1",
+                        "temanavn": "Skovrejsningsområde",
+                        "datovedt": "2024-01-01T00:00:00",
+                        "uuid": "undesired-uuid",
+                        "objekt_id": "1",
+                    },
+                    "geometry": polygon(560000, 6220000),
+                },
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "omraadenavn": "Ønsket",
+                        "komnavn": "Aarhus",
+                        "plangrund": "Vedtaget",
+                        "plannr": "2",
+                        "temanavn": "Skovrejsningsområde",
+                        "datovedt": "2024-01-02T00:00:00",
+                        "uuid": "desired-uuid",
+                        "objekt_id": "2",
+                    },
+                    "geometry": polygon(562000, 6220000),
+                },
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "omraadenavn": "Neutral",
+                        "komnavn": "Aarhus",
+                        "plangrund": "Vedtaget",
+                        "plannr": "3",
+                        "temanavn": "Skovrejsningsområde",
+                        "datovedt": "2024-01-03T00:00:00",
+                        "uuid": "neutral-uuid",
+                        "objekt_id": "3",
+                    },
+                    "geometry": polygon(564000, 6220000),
+                },
+            ],
+        }
+    )
+
+
+def test_skovrejsning_silver_config(silver_config: SkovrejsningSilverConfig) -> None:
+    assert silver_config.dataset == "skovrejsning"
+    assert silver_config.bucket == "landbruget-data"
+    assert silver_config.storage_batch_size == 5000
+    assert silver_config.category_mapping["Uønsket"] == "undesired"
+    assert silver_config.category_mapping["Ønsket"] == "desired"
+
+
+def test_read_bronze_data_with_in_memory_data(
+    skovrejsning_silver: SkovrejsningSilver,
+    silver_config: SkovrejsningSilverConfig,
+    sample_geojson_payload: str,
+) -> None:
+    result = skovrejsning_silver._read_bronze_data(
+        silver_config.dataset, silver_config.bucket, bronze_data=[sample_geojson_payload]
+    )
+
+    assert result is not None
+    assert isinstance(result, str)
+
+    row_count = skovrejsning_silver.conn.execute(f"SELECT COUNT(*) FROM {result}").fetchone()[0]
+    assert row_count == 1
+
+    payload = skovrejsning_silver.conn.execute(f"SELECT payload FROM {result}").fetchone()[0]
+    assert payload == sample_geojson_payload
+
+
+def test_process_geojson_data_maps_categories_and_geometry(
+    skovrejsning_silver: SkovrejsningSilver,
+    sample_geojson_payload: str,
+) -> None:
+    result = skovrejsning_silver._process_geojson_data({"payload": [sample_geojson_payload]})
+
+    assert result is not None
+    assert isinstance(result, str)
+
+    row_count = skovrejsning_silver.conn.execute(f"SELECT COUNT(*) FROM {result}").fetchone()[0]
+    assert row_count == 3
+
+    rows = skovrejsning_silver.conn.execute(f"""
+        SELECT omraadenavn, category, area_ha, ST_IsValid(geometry_spatial), geometry
+        FROM {result}
+        ORDER BY objekt_id
+    """).fetchall()
+
+    assert [(row[0], row[1]) for row in rows] == [
+        ("Uønsket", "undesired"),
+        ("Ønsket", "desired"),
+        ("Neutral", "neutral"),
+    ]
+    assert all(row[2] and row[2] > 0 for row in rows)
+    assert all(row[3] for row in rows)
+    assert all(row[4] for row in rows)
+
+
+def test_process_geojson_data_with_empty_payload(skovrejsning_silver: SkovrejsningSilver) -> None:
+    result = skovrejsning_silver._process_geojson_data(
+        {"payload": [json.dumps({"type": "FeatureCollection", "features": []})]}
+    )
+
+    assert result is None
+
+
+def test_create_dissolved_df_groups_by_category(
+    skovrejsning_silver: SkovrejsningSilver,
+    sample_geojson_payload: str,
+) -> None:
+    processed_table = skovrejsning_silver._process_geojson_data(
+        {"payload": [sample_geojson_payload]}
+    )
+    assert processed_table is not None
+
+    dissolved_table = skovrejsning_silver._create_dissolved_df(
+        processed_table, skovrejsning_silver.config.dataset
+    )
+
+    categories = skovrejsning_silver.conn.execute(f"""
+        SELECT category, ST_IsEmpty(geometry) as is_empty
+        FROM {dissolved_table}
+        ORDER BY category
+    """).fetchall()
+
+    assert categories == [
+        ("desired", False),
+        ("neutral", False),
+        ("undesired", False),
+    ]

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/app.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/app.py
@@ -37,6 +37,7 @@ from unified_pipeline.bronze.kemidata_surface_water import (
     KemidataSurfaceWaterBronze,
     KemidataSurfaceWaterBronzeConfig,
 )
+from unified_pipeline.bronze.skovrejsning import SkovrejsningBronze, SkovrejsningBronzeConfig
 from unified_pipeline.bronze.soil_types import SoilTypesBronze, SoilTypesBronzeConfig
 from unified_pipeline.bronze.water_projects import WaterProjectsBronze, WaterProjectsBronzeConfig
 from unified_pipeline.bronze.water_typology import WaterTypologyBronze, WaterTypologyBronzeConfig
@@ -150,6 +151,7 @@ from unified_pipeline.silver.kemidata_surface_water import (
     KemidataSurfaceWaterSilver,
     KemidataSurfaceWaterSilverConfig,
 )
+from unified_pipeline.silver.skovrejsning import SkovrejsningSilver, SkovrejsningSilverConfig
 from unified_pipeline.silver.soil_types import SoilTypesSilver, SoilTypesSilverConfig
 from unified_pipeline.silver.water_projects import WaterProjectsSilver, WaterProjectsSilverConfig
 from unified_pipeline.silver.water_typology import WaterTypologySilver, WaterTypologySilverConfig
@@ -429,6 +431,14 @@ def execute(cli_config: cli_models.CliConfig) -> int:
             cli_models.Stage.all: [
                 (BNBOStatusBronze, BNBOStatusBronzeConfig),
                 (BNBOStatusSilver, BNBOStatusSilverConfig),
+            ],
+        },
+        cli_models.Source.skovrejsning: {
+            cli_models.Stage.bronze: [(SkovrejsningBronze, SkovrejsningBronzeConfig)],
+            cli_models.Stage.silver: [(SkovrejsningSilver, SkovrejsningSilverConfig)],
+            cli_models.Stage.all: [
+                (SkovrejsningBronze, SkovrejsningBronzeConfig),
+                (SkovrejsningSilver, SkovrejsningSilverConfig),
             ],
         },
         cli_models.Source.agricultural_fields: {

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/skovrejsning.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/skovrejsning.py
@@ -1,0 +1,201 @@
+"""Bronze layer data ingestion for Danish afforestation areas."""
+
+import asyncio
+import ssl
+from asyncio import Semaphore
+from typing import ClassVar
+
+import aiohttp
+from pydantic import ConfigDict
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from unified_pipeline.common.base import BaseJobConfig, BaseSource, BronzeJobInterface
+from unified_pipeline.util.timing import AsyncTimer
+
+
+class SkovrejsningBronzeConfig(BaseJobConfig):
+    """Configuration for Danish afforestation areas from Plandata WFS."""
+
+    name: str = "Danish Afforestation Areas"
+    dataset: str = "skovrejsning"
+    type: str = "wfs"
+    description: str = "Municipal afforestation area classifications"
+    url: str = "https://geoserver.plandata.dk/geoserver/wfs"
+    frequency: str = "weekly"
+    bucket: str = "landbruget-data"
+
+    batch_size: int = 100
+    max_concurrent: int = 3
+    request_timeout: int = 300
+    storage_batch_size: int = 5000
+    request_timeout_config: aiohttp.ClientTimeout = aiohttp.ClientTimeout(
+        total=request_timeout, connect=60, sock_read=300
+    )
+    headers: ClassVar[dict[str, str]] = {"User-Agent": "Mozilla/5.0 QGIS/33603/macOS 15.1"}
+    request_semaphore: Semaphore = Semaphore(max_concurrent)
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+
+class SkovrejsningBronze(BaseSource[SkovrejsningBronzeConfig], BronzeJobInterface):
+    """Bronze layer processor for Danish afforestation areas."""
+
+    def __init__(self, config: SkovrejsningBronzeConfig):
+        """Initialize the skovrejsning bronze processor."""
+        super().__init__(config)
+
+    def _get_params(self, start_index: int = 0) -> dict[str, str]:
+        """Get WFS request parameters for GeoJSON pagination."""
+        return {
+            "service": "WFS",
+            "version": "2.0.0",
+            "request": "GetFeature",
+            "typeNames": "pdk:theme_pdk_skovrejsningsomraade_vedtaget",
+            "outputFormat": "application/json",
+            "srsName": "urn:ogc:def:crs:EPSG::25832",
+            "startIndex": str(start_index),
+            "count": str(self.config.batch_size),
+        }
+
+    @retry(
+        retry=retry_if_exception_type(Exception),
+        wait=wait_exponential(multiplier=1, min=4, max=10),
+        stop=stop_after_attempt(5),
+    )
+    async def _fetch_chunck(self, session: aiohttp.ClientSession, start_index: int) -> dict:
+        """Fetch a GeoJSON chunk from the WFS service."""
+        async with (
+            self.config.request_semaphore,
+            AsyncTimer(
+                f"Fetching chunk from {start_index} to {start_index + self.config.batch_size}"
+            ),
+        ):
+            self.log.debug(
+                f"Trying to fetch data from {start_index} to {start_index + self.config.batch_size}"
+            )
+            params = self._get_params(start_index)
+            try:
+                async with session.get(self.config.url, params=params) as response:
+                    if response.status != 200:
+                        err_msg = f"Failed to fetch data. Status: {response.status}"
+                        self.log.error(err_msg)
+                        raise Exception(err_msg)
+
+                    text = await response.text()
+                    try:
+                        parsed = await response.json(content_type=None)
+                        return {
+                            "text": text,
+                            "start_index": start_index,
+                            "total_features": int(parsed.get("numberMatched", 0) or 0),
+                            "returned_features": int(parsed.get("numberReturned", 0) or 0),
+                        }
+                    except Exception as e:
+                        err_msg = f"Failed to parse GeoJSON response: {e}"
+                        self.log.error(err_msg)
+                        raise Exception(err_msg) from e
+            except Exception as e:
+                err_msg = f"Error fetching data: {e}"
+                self.log.error(err_msg)
+                raise Exception(err_msg) from e
+
+    async def _fetch_raw_data(self) -> list[str] | None:
+        """Fetch all available skovrejsning GeoJSON chunks from the WFS service."""
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+
+        connector = aiohttp.TCPConnector(ssl=ssl_context)
+        raw_features = []
+        async with (
+            aiohttp.ClientSession(headers=self.config.headers, connector=connector) as session,
+            AsyncTimer("Fetching raw data from WFS service for Skovrejsning"),
+        ):
+            try:
+                raw_data = await self._fetch_chunck(session, 0)
+                total_features = raw_data["total_features"]
+                returned_features = raw_data["returned_features"]
+                raw_features.append(raw_data["text"])
+                fetched_features_count = returned_features
+                self.log.info(f"Fetched {fetched_features_count} out of {total_features}")
+
+                tasks = [
+                    self._fetch_chunck(session, start_index)
+                    for start_index in range(
+                        returned_features, total_features, self.config.batch_size
+                    )
+                ]
+
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+
+                for result in results:
+                    if isinstance(result, Exception):
+                        self.log.error(f"Error occurred while fetching chunk: {result}")
+                        raise result
+
+                    if isinstance(result, dict):
+                        raw_features.append(result["text"])
+                        fetched_features_count += result["returned_features"]
+                        self.log.debug(
+                            f"Processed chunk with {result['returned_features']} features"
+                        )
+                    else:
+                        self.log.error(f"Unexpected result type: {type(result)}")
+
+                self.log.info(
+                    f"Fetched all {fetched_features_count} out of {total_features} features"
+                )
+                return raw_features
+            except Exception as e:
+                self.log.error(f"Error occured while fetching chunk: {e}")
+                raise e
+
+    def create_dataframe(self, raw_data: list[str]):
+        """Create a DuckDB table with raw GeoJSON payloads and metadata."""
+        current_timestamp = self.conn.execute("SELECT current_timestamp").fetchone()[0]
+
+        self.conn.execute("CREATE OR REPLACE TABLE temp_skovrejsning_data (payload VARCHAR)")
+
+        for data_str in raw_data:
+            self.conn.execute("INSERT INTO temp_skovrejsning_data VALUES (?)", [data_str])
+
+        self.conn.execute(
+            """
+            CREATE OR REPLACE TABLE final_dataframe AS
+            SELECT
+                payload,
+                ? as source,
+                ? as created_at,
+                ? as updated_at
+            FROM temp_skovrejsning_data
+        """,
+            [self.config.name, current_timestamp, current_timestamp],
+        )
+
+        self.conn.execute("DROP TABLE temp_skovrejsning_data")
+
+        return "final_dataframe"
+
+    async def run(self) -> list[str] | None:
+        """Run the complete skovrejsning bronze layer job."""
+        async with AsyncTimer("Running Skovrejsning bronze job for"):
+            self.log.info("Running Skovrejsning bronze job")
+            raw_data = await self._fetch_raw_data()
+            if not raw_data:
+                self.log.error("No raw data fetched")
+                return None
+            self.log.info("Fetched raw data successfully")
+
+            table_name = self.create_dataframe(raw_data)
+
+            self._save_data(
+                data=table_name,
+                dataset=self.config.dataset,
+                bucket=self.config.bucket,
+                stage="bronze",
+                conn=self.conn,
+            )
+            self.log.info("Saved raw data successfully")
+            self.log.info("Skovrejsning bronze job completed successfully")
+
+            return raw_data

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/config.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/config.py
@@ -104,6 +104,9 @@ class PMTilesGeneratorConfig(BaseJobConfig):
     bnbo_status_path: str = Field(
         default="silver/bnbo_status_dissolved/", description="BNBO status dissolved path"
     )
+    skovrejsning_path: str = Field(
+        default="silver/skovrejsning_dissolved/", description="Skovrejsning dissolved path"
+    )
     wetlands_path: str = Field(
         default="silver/wetlands_dissolved/", description="Wetlands dissolved path"
     )

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/data_loader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/data_loader.py
@@ -1195,6 +1195,11 @@ class PMTilesDataLoader:
         if water_projects_table:
             layers["water_projects"] = water_projects_table
 
+        # Load skovrejsning
+        skovrejsning_table = await self._load_skovrejsning()
+        if skovrejsning_table:
+            layers["skovrejsning"] = skovrejsning_table
+
         # Load BBR buildings
         buildings_table = await self._load_bbr_buildings()
         if buildings_table:
@@ -1313,6 +1318,45 @@ class PMTilesDataLoader:
                     )
                 else:
                     logger.error(f"Error loading BNBO status data: {e}")
+
+        return None
+
+    async def _load_skovrejsning(self) -> str | None:
+        """Load skovrejsning dissolved data."""
+        base_path = f"r2://{self.config.storage_bucket}/{self.config.skovrejsning_path}"
+        storage_paths = await self._find_timestamped_paths_ranked(base_path)
+        if not storage_paths:
+            logger.warning(f"Skovrejsning data not found in: {base_path}")
+            return None
+
+        table_name = "skovrejsning_dissolved"
+
+        for i, storage_path in enumerate(storage_paths):
+            try:
+                logger.info(f"Loading skovrejsning data from {storage_path}")
+                query = f"""
+                CREATE OR REPLACE TABLE {table_name} AS
+                SELECT *
+                FROM read_parquet('{storage_path}*.parquet')
+                """
+                await asyncio.to_thread(self.conn.execute, query)
+
+                count_result = await asyncio.to_thread(
+                    self.conn.execute, f"SELECT COUNT(*) FROM {table_name}"
+                )
+                count = count_result.fetchone()[0]
+
+                logger.info(f"Loaded {count:,} skovrejsning records")
+                return table_name
+
+            except Exception as e:
+                if i < len(storage_paths) - 1:
+                    logger.warning(
+                        f"Failed to load skovrejsning from {storage_path}, "
+                        f"trying older timestamp: {e}"
+                    )
+                else:
+                    logger.error(f"Error loading skovrejsning data: {e}")
 
         return None
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/environmental_generator.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/environmental_generator.py
@@ -69,6 +69,12 @@ class EnvironmentalLayersPMTilesGenerator:
                 environmental_layers["water_projects"]
             )
 
+        # Generate skovrejsning PMTiles
+        if "skovrejsning" in environmental_layers:
+            results["skovrejsning"] = await self._generate_skovrejsning_pmtiles(
+                environmental_layers["skovrejsning"]
+            )
+
         # Log summary
         successful = sum(1 for path in results.values() if path is not None)
         logger.info(f"Generated {successful}/{len(results)} environmental layer PMTiles")
@@ -180,6 +186,95 @@ class EnvironmentalLayersPMTilesGenerator:
 
         except Exception as e:
             logger.error(f"Error exporting BNBO GeoJSON: {e}")
+            return False
+
+    async def _generate_skovrejsning_pmtiles(self, table_name: str) -> str | None:
+        """Generate skovrejsning PMTiles."""
+        logger.info("Generating skovrejsning PMTiles")
+
+        with FileManager(self.config.temp_dir) as file_manager:
+            try:
+                geojson_path = file_manager.create_temp_file(
+                    suffix=".geojson", prefix="skovrejsning_"
+                )
+
+                success = await self._export_skovrejsning_geojson(table_name, geojson_path)
+                if not success:
+                    logger.error("Failed to export skovrejsning GeoJSON")
+                    return None
+
+                pmtiles_path = file_manager.create_temp_file(
+                    suffix=".pmtiles", prefix="skovrejsning_"
+                )
+
+                success = await self.tippecanoe.generate_pmtiles(
+                    geojson_path=geojson_path,
+                    output_path=pmtiles_path,
+                    layer_name="skovrejsning",
+                    max_zoom=12,
+                    min_zoom=0,
+                    buffer=32,
+                    simplification=5,
+                    additional_args=["--drop-densest-as-needed"],
+                )
+
+                if not success:
+                    logger.error("Failed to generate skovrejsning PMTiles")
+                    return None
+
+                final_path = os.path.join(
+                    os.path.dirname(self.config.temp_dir), "skovrejsning.pmtiles"
+                )
+
+                import shutil
+
+                shutil.copy2(pmtiles_path, final_path)
+
+                if os.path.exists(final_path):
+                    size_mb = os.path.getsize(final_path) / (1024 * 1024)
+                    logger.info(f"Generated skovrejsning PMTiles: {size_mb:.1f} MB")
+
+                return final_path
+
+            except Exception as e:
+                logger.error(f"Error generating skovrejsning PMTiles: {e}")
+                return None
+
+    async def _export_skovrejsning_geojson(self, table_name: str, output_path: str) -> bool:
+        """Export skovrejsning dissolved data as GeoJSON."""
+        try:
+            geom_expr = (
+                "ST_AsGeoJSON(ST_Transform(geometry, 'EPSG:25832', 'EPSG:4326', always_xy := true))"
+                if USE_UTM_PROCESSING
+                else "ST_AsGeoJSON(ST_FlipCoordinates(geometry))"
+            )
+            query = f"""
+            SELECT
+                category,
+                CASE category
+                    WHEN 'undesired' THEN '#dc2626'
+                    WHEN 'desired' THEN '#16a34a'
+                    ELSE '#9ca3af'
+                END AS color,
+                CASE category
+                    WHEN 'undesired' THEN 'Skovrejsning uønsket'
+                    WHEN 'desired' THEN 'Skovrejsning ønsket'
+                    ELSE 'Neutralområde'
+                END AS category_danish,
+                {geom_expr} AS geometry
+            FROM {table_name}
+            WHERE geometry IS NOT NULL
+            """
+
+            return await GeoJSONWriter.write_geojson_from_query(
+                self.conn,
+                query,
+                output_path,
+                ["category", "color", "category_danish"],
+            )
+
+        except Exception as e:
+            logger.error(f"Error exporting skovrejsning GeoJSON: {e}")
             return False
 
     async def _generate_wetlands_pmtiles(self, table_name: str) -> str | None:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/model/cli.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/model/cli.py
@@ -33,6 +33,7 @@ class Source(Enum):
 
     Attributes:
         bnbo: BNBO (Boringsnære beskyttelsesområder) data source
+        skovrejsning: Danish afforestation areas data source
         agricultural_fields: Danish Agricultural Fields from ArcGIS API
         cadastral: Danish Cadastral Properties from WFS
         soil_types: Danish Soil Types from Environmental Portal WFS
@@ -59,6 +60,7 @@ class Source(Enum):
     """
 
     bnbo = "bnbo"
+    skovrejsning = "skovrejsning"
     agricultural_fields = "agricultural_fields"
     cadastral = "cadastral"
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/skovrejsning.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/skovrejsning.py
@@ -1,0 +1,227 @@
+"""Silver layer processing for Danish afforestation areas."""
+
+import json
+from typing import Any, ClassVar
+
+from common.geometry_validator import validate_and_normalize_to_utm
+
+from unified_pipeline.common.base import BaseJobConfig, BaseSource, SilverJobInterface
+from unified_pipeline.util.timing import AsyncTimer, timed
+
+USE_UTM_PROCESSING = True
+
+
+class SkovrejsningSilverConfig(BaseJobConfig):
+    """Configuration for skovrejsning silver processing."""
+
+    dataset: str = "skovrejsning"
+    bucket: str = "landbruget-data"
+    storage_batch_size: int = 5000
+    category_mapping: ClassVar[dict[str, str]] = {"Uønsket": "undesired", "Ønsket": "desired"}
+
+
+class SkovrejsningSilver(BaseSource[SkovrejsningSilverConfig], SilverJobInterface):
+    """Silver layer processor for Danish afforestation areas."""
+
+    def __init__(self, config: SkovrejsningSilverConfig):
+        """Initialize the skovrejsning silver processor."""
+        super().__init__(config)
+        self.log.info("SkovrejsningSilver: Using unified cloud storage access and DuckDB")
+
+    def _normalize_property(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        value_str = str(value).strip()
+        return value_str if value_str else None
+
+    def _read_payload_rows(self, raw_data) -> list[tuple[Any, ...]] | None:
+        if raw_data is None:
+            self.log.warning("No raw data to process")
+            return None
+
+        if isinstance(raw_data, str):
+            row_count = self.conn.execute(f"SELECT COUNT(*) FROM {raw_data}").fetchone()[0]
+            if row_count == 0:
+                self.log.warning("No raw data to process")
+                return None
+            rows = self.conn.execute(f"SELECT payload FROM {raw_data}").fetchall()
+        elif isinstance(raw_data, dict) and "payload" in raw_data:
+            rows = [(payload,) for payload in raw_data["payload"]]
+        else:
+            self.log.warning(f"Unexpected raw_data type: {type(raw_data)}")
+            return None
+
+        if not rows:
+            self.log.warning("No raw data to process")
+            return None
+        return rows
+
+    @timed(name="Processing bronze GeoJSON data")  # type: ignore
+    def _process_geojson_data(self, raw_data) -> str | None:
+        """Process bronze GeoJSON payloads into a DuckDB spatial feature table."""
+        raw_rows = self._read_payload_rows(raw_data)
+        if raw_rows is None:
+            return None
+
+        features = []
+        for index, row_tuple in enumerate(raw_rows):
+            try:
+                payload = row_tuple[0]
+                collection = json.loads(payload)
+                for feature in collection.get("features", []):
+                    geometry = feature.get("geometry")
+                    if not geometry:
+                        continue
+
+                    properties = feature.get("properties") or {}
+                    omraadenavn = self._normalize_property(properties.get("omraadenavn"))
+                    features.append(
+                        {
+                            "geometry_geojson": json.dumps(geometry),
+                            "omraadenavn": omraadenavn,
+                            "komnavn": self._normalize_property(properties.get("komnavn")),
+                            "plangrund": self._normalize_property(properties.get("plangrund")),
+                            "plannr": self._normalize_property(properties.get("plannr")),
+                            "temanavn": self._normalize_property(properties.get("temanavn")),
+                            "datovedt": self._normalize_property(properties.get("datovedt")),
+                            "uuid": self._normalize_property(properties.get("uuid")),
+                            "objekt_id": self._normalize_property(properties.get("objekt_id")),
+                            "category": self.config.category_mapping.get(
+                                omraadenavn or "", "neutral"
+                            ),
+                        }
+                    )
+            except Exception as e:
+                self.log.error(f"Error processing row {index}: {e!s}", exc_info=True)
+                raise e
+
+        self.log.info(f"Parsed {len(features):,} features from GeoJSON data")
+
+        if not features:
+            self.log.warning("No features extracted from GeoJSON data")
+            return None
+
+        staging_table = "skovrejsning_features_raw"
+        table_name = "skovrejsning_processed_features"
+        columns = list(features[0].keys())
+
+        self.conn.execute(f"""
+            CREATE OR REPLACE TABLE {staging_table} (
+                {", ".join([f"{col} VARCHAR" for col in columns])}
+            )
+        """)
+
+        placeholders = ", ".join(["?" for _ in columns])
+        for feature in features:
+            values = [feature.get(col) for col in columns]
+            self.conn.execute(
+                f"""
+                INSERT INTO {staging_table} ({", ".join(columns)})
+                VALUES ({placeholders})
+            """,
+                values,
+            )
+
+        self.conn.execute(f"""
+            CREATE OR REPLACE TABLE {table_name} AS
+            SELECT
+                omraadenavn,
+                komnavn,
+                plangrund,
+                plannr,
+                temanavn,
+                TRY_CAST(datovedt AS TIMESTAMP) as datovedt,
+                uuid,
+                objekt_id,
+                category,
+                ST_GeomFromGeoJSON(geometry_geojson) as geometry_spatial,
+                CAST(NULL AS VARCHAR) as geometry,
+                CAST(NULL AS DOUBLE) as area_ha
+            FROM {staging_table}
+            WHERE geometry_geojson IS NOT NULL
+        """)
+
+        if USE_UTM_PROCESSING:
+            validate_and_normalize_to_utm(
+                self.conn, table_name, self.config.dataset, geometry_column="geometry_spatial"
+            )
+
+        self.conn.execute(f"""
+            UPDATE {table_name} SET
+                geometry = ST_AsText(geometry_spatial),
+                area_ha = ST_Area(geometry_spatial) / 10000
+            WHERE geometry_spatial IS NOT NULL
+        """)
+
+        feature_count = self.conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]
+        self.log.info(f"Created DuckDB table '{table_name}' with {feature_count:,} features")
+
+        self.conn.execute(f"DROP TABLE IF EXISTS {staging_table}")
+
+        return table_name
+
+    @timed(name="Creating dissolved table using DuckDB-spatial")  # type: ignore
+    def _create_dissolved_df(self, input_table_name: str, dataset: str) -> str:
+        """Create dissolved geometries grouped by skovrejsning category."""
+        dissolved_table_name = "skovrejsning_dissolved_features"
+
+        self.log.info(f"Creating dissolved geometries for {dataset} by category")
+
+        self.conn.execute(f"""
+            CREATE OR REPLACE TABLE {dissolved_table_name} AS
+            SELECT
+                category,
+                ST_Union_Agg(geometry_spatial) as geometry,
+                current_timestamp as dissolved_at
+            FROM {input_table_name}
+            WHERE geometry_spatial IS NOT NULL
+                AND ST_IsValid(geometry_spatial)
+            GROUP BY category
+        """)
+
+        total_count = self.conn.execute(f"SELECT COUNT(*) FROM {dissolved_table_name}").fetchone()[
+            0
+        ]
+
+        if total_count == 0:
+            self.log.warning("No valid geometries to dissolve")
+            self.conn.execute(f"""
+                CREATE OR REPLACE TABLE {dissolved_table_name} AS
+                SELECT
+                    CAST(NULL AS VARCHAR) as category,
+                    CAST(NULL AS GEOMETRY) as geometry,
+                    CAST(NULL AS TIMESTAMP) as dissolved_at
+                WHERE FALSE
+            """)
+
+        return dissolved_table_name
+
+    async def run(self, bronze_data=None) -> str | None:
+        """Run the complete skovrejsning silver layer job."""
+        async with AsyncTimer("Running Skovrejsning silver job"):
+            self.log.info("Running Skovrejsning silver job")
+
+            raw_data = self._read_bronze_data(
+                self.config.dataset, self.config.bucket, bronze_data=bronze_data
+            )
+            if raw_data is None:
+                self.log.error("No bronze data found")
+                return None
+
+            table_name = self._process_geojson_data(raw_data)
+            if table_name is None:
+                self.log.error("No processed data created")
+                return None
+
+            dissolved_table_name = self._create_dissolved_df(table_name, self.config.dataset)
+
+            self.save_data_direct(table_name, self.config.dataset, self.config.bucket, "silver")
+            self.save_data_direct(
+                dissolved_table_name,
+                f"{self.config.dataset}_dissolved",
+                self.config.bucket,
+                "silver",
+            )
+
+            self.log.info("Skovrejsning silver job completed successfully")
+            return table_name

--- a/pipeline_dependencies.yml
+++ b/pipeline_dependencies.yml
@@ -25,6 +25,7 @@ pipelines:
       - silver/agricultural_fields
       - silver/fvm_marker_{year}
       - silver/bnbo_status_dissolved
+      - silver/skovrejsning_dissolved
       - silver/wetlands_dissolved
       - silver/water_projects_dissolved
       - silver/soil_types
@@ -271,7 +272,7 @@ pipelines:
     workflow: generate-pmtiles.yml
     description: "Map tiles from all gold layers for visualization"
     upstream:
-      - unified_pipeline # silver/fvm_marker, bnbo, wetlands, water_projects
+      - unified_pipeline # silver/fvm_marker, bnbo, wetlands, water_projects, skovrejsning
       - field_area_analysis # gold/field_environmental_analysis_fields
       - field_production # gold/field_production
       - pesticide_proximity # gold/pesticide_proximity


### PR DESCRIPTION
## What & why

Implements #469 — adds Denmark's **skovrejsningsområder** (afforestation areas) to the data platform. Each area is classified as **Ønsket** (afforestation wanted), **Uønsket** (not allowed), or neutral. The [TV2 story](https://nyheder.tv2.dk/business/2025-08-24-danmark-skal-have-masser-af-skov-men-i-store-dele-af-landet-er-traeerne-uoenskede) in the issue is about the *Uønsket* areas where trees are unwanted.

**Scope: backend data pipeline only.** It ingests the dataset, dissolves it by category, generates PMTiles, and uploads to R2 so the data is on the CDN. The frontend map layer is a deliberate follow-up.

## Data source

- Service: `https://geoserver.plandata.dk/geoserver/wfs` (Plandataregistret)
- Typename: `pdk:theme_pdk_skovrejsningsomraade_vedtaget`
- Category field: `omraadenavn` → `Uønsket`→`undesired`, `Ønsket`→`desired`, else `neutral`
- Requested in EPSG:25832 (project UTM processing rule)

## Approach

This mirrors the existing **BNBO** environmental layer end-to-end:

- **bronze** (`bronze/skovrejsning.py`): paginated GeoJSON fetch
- **silver** (`silver/skovrejsning.py`): DuckDB `ST_GeomFromGeoJSON` parse, category normalization, UTM validation/normalization, dissolve-by-category → `silver/skovrejsning` + `silver/skovrejsning_dissolved`
- **gold/pmtiles**: `data_loader` + `environmental_generator` produce `pmtiles/skovrejsning.pmtiles`, uploaded to R2 by the existing uploader. Styling metadata emphasizes **Uønsket** (red `#dc2626`).
- registration in the CLI `Source` enum + `app.py` pipeline_map
- weekly source matrix in `unified_pipeline.yml`; `silver/skovrejsning_dissolved` added to the dependency graph

## Testing

- New silver unit tests (`test_skovrejsning_silver.py`): category mapping, GeoJSON→geometry parsing, dissolve-by-category — **5 passed**.
- `ruff check` + `ruff format --check` clean.
- CLI exposes `skovrejsning` as a source choice.

> Note: a full live end-to-end run against the WFS (bronze→silver→R2) was not executed here as it needs R2 credentials; the source is wired identically to BNBO and unit-tested. Recommend a manual `python -m unified_pipeline all --source skovrejsning` smoke run before relying on the CDN output.

## Follow-up (out of scope)

Frontend map layer (LayerControlPanel toggle, `map-layers-skovrejsning.ts`, legend) consuming `pmtiles/skovrejsning.pmtiles`.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)