### PR TITLE
Rebrand: Klimabevægelsen → Bureau 10 i om os, brugsvilkår og privatlivspolitik

### DIFF
--- a/frontend/src/app/(main)/brugsvilkaar/page.tsx
+++ b/frontend/src/app/(main)/brugsvilkaar/page.tsx
@@ -8,7 +8,7 @@ import html from 'remark-html';
 export const metadata: Metadata = {
   title: 'Brugsvilkår - Landbruget.dk',
   description:
-    'Læs vores brugsvilkår for Landbruget.dk - et almennyttigt, open-source og non-profit initiativ drevet af Klimabevægelsen.',
+    'Læs vores brugsvilkår for Landbruget.dk - et almennyttigt, open-source og non-profit initiativ drevet af Bureau 10.',
 };
 
 async function getTermsContent() {

--- a/frontend/src/app/(main)/om-os/page.tsx
+++ b/frontend/src/app/(main)/om-os/page.tsx
@@ -4,7 +4,7 @@ import { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Om os - Landbruget.dk',
   description:
-    'Lær mere om Landbruget.dk - et almennyttigt, open-source og non-profit initiativ drevet af Klimabevægelsen.',
+    'Lær mere om Landbruget.dk – et almennyttigt, open-source og non-profit initiativ drevet af den almennyttige forening Bureau 10.',
 };
 
 export default function AboutPage() {
@@ -28,9 +28,9 @@ export default function AboutPage() {
                 >
                   open-source
                 </a>{' '}
-                og non-profit initiativ drevet af Klimabevægelsen. Vores mission
-                er at indsamle og formidle offentligt tilgængelige data om den
-                danske landbrugssektor.
+                og non-profit initiativ drevet af den publicistiske forening
+                Bureau 10. Vores formål er at indsamle og formidle offentligt
+                tilgængelige data om den danske landbrugssektor.
               </p>
             </header>
 
@@ -42,93 +42,56 @@ export default function AboutPage() {
                 Hvorfor gør vi det?
               </h2>
               <p className="text-muted-foreground text-lg leading-relaxed">
-                Landbruget spiller en afgørende rolle i Danmark – for vores
-                økonomi, vores landskab, vores miljø, vores sundhed og vores
-                klima. Beslutninger truffet i og omkring sektoren har
-                vidtrækkende konsekvenser. Vi mener, at en åben og informeret
-                offentlig debat er essentiel for at sikre en bæredygtig
-                udvikling. Desværre er mange relevante data i dag spredt, svært
-                tilgængelige eller gemt i formater, der gør dem vanskelige at
-                anvende for den almindelige borger, journalist, forsker eller
-                endda landmanden selv.
+                Landbruget spiller en stor rolle i Danmark – for økonomien,
+                landskabet, miljøet, sundheden og klimaet. Beslutninger i og
+                omkring sektoren har vidtrækkende konsekvenser, og en åben og
+                informeret offentlig debat forudsætter adgang til fakta. I dag
+                er mange relevante data spredt, svært tilgængelige eller gemt i
+                formater, der gør dem vanskelige at anvende for den almindelige
+                borger, journalist, forsker eller landmanden selv.
               </p>
             </section>
 
             {/* Section 2 */}
             <section className="space-y-8">
               <h2 className="text-primary border-primary/20 mt-16 border-b pb-4 text-3xl leading-tight font-bold">
-                Vores mål er at:
+                Vores formål er at:
               </h2>
 
               <div className="space-y-8">
                 <div className="space-y-4">
                   <h3 className="text-primary-darker text-2xl leading-tight font-bold">
-                    Fremme offentlig oplysning og inspirere
+                    Fremme offentlig oplysning
                   </h3>
                   <p className="text-muted-foreground text-lg leading-relaxed">
                     Vi vil gøre det lettere for alle at forstå
                     landbrugssektorens komplekse sammenhænge og dens påvirkning
-                    på samfundet, herunder miljø, sundhed og klima. Samtidig
-                    ønsker vi at synliggøre de landmænd og virksomheder, der går
-                    forrest med bæredygtige løsninger og viser vejen mod en
-                    grønnere praksis.
+                    på samfundet, herunder miljø, sundhed og klima.
                   </p>
                 </div>
 
                 <div className="space-y-4">
                   <h3 className="text-primary-darker text-2xl leading-tight font-bold">
-                    Understøtte en informeret og konstruktiv demokratisk debat
+                    Understøtte en informeret offentlig debat
                   </h3>
                   <p className="text-muted-foreground text-lg leading-relaxed">
-                    Ved at gøre data tilgængelige og brugervenlige ønsker vi at
-                    styrke grundlaget for en dialog om landbrugets fremtid og
-                    den nødvendige grønne omstilling, båret af både udfordringer
-                    og succesfulde eksempler.
+                    Ved at gøre data tilgængelige og brugervenlige vil vi styrke
+                    grundlaget for en faktabaseret debat om landbrugets forhold
+                    og fremtid.
                   </p>
                 </div>
 
                 <div className="space-y-4">
                   <h3 className="text-primary-darker text-2xl leading-tight font-bold">
-                    Styrke transparens, ansvarlighed og læring af historien
-                  </h3>
-                  <div className="space-y-4">
-                    <p className="text-muted-foreground text-lg leading-relaxed">
-                      Vi tror på, at åbenhed om data – herunder
-                      produktionsforhold, miljøpåvirkning, økonomiske
-                      støtteordninger og ledelsesforhold – er afgørende for at
-                      drive positive forandringer. For at forstå nutiden og
-                      forme fremtiden er det vigtigt at lære af fortiden. Derfor
-                      inkluderer vi også oplysninger om tidligere ledelses- og
-                      ejerforhold.
-                    </p>
-                    <p className="text-muted-foreground text-lg leading-relaxed">
-                      Det handler ikke kun om at placere ansvar for beslutninger
-                      med langsigtede negative konsekvenser, som f.eks.
-                      pesticidanvendelse der påvirker grundvandet. Lige så
-                      vigtigt er det at kunne identificere og fremhæve de
-                      positive, langsigtede initiativer, f.eks. de landmænd der
-                      tidligt plantede træer, investerede i naturpleje eller
-                      omlagde til driftsformer, der først årtier senere viser
-                      deres fulde positive værdi for miljø og biodiversitet.
-                      Denne historiske indsigt er afgørende for både at
-                      anerkende fremsynede handlinger og for at sikre en
-                      retfærdig forståelse af, hvordan vi er nået til, hvor vi
-                      er i dag.
-                    </p>
-                  </div>
-                </div>
-
-                <div className="space-y-4">
-                  <h3 className="text-primary-darker text-2xl leading-tight font-bold">
-                    Understøtte den grønne omstilling
+                    Styrke transparens og læring af historien
                   </h3>
                   <p className="text-muted-foreground text-lg leading-relaxed">
-                    Særligt i lyset af Den Grønne Trepartsaftale er der et stort
-                    behov for et solidt datagrundlag. Landbruget.dk skal levere
-                    data, der kan hjælpe med at monitorere og evaluere
-                    implementeringen af aftalens mål, fremhæve fremskridt og
-                    accelerere transformationen mod en mere bæredygtig
-                    arealanvendelse og fødevareproduktion.
+                    Vi mener, at åbenhed om data – herunder produktionsforhold,
+                    miljøpåvirkning, økonomiske støtteordninger og ledelses- og
+                    ejerforhold – er et gode i sig selv. For at forstå nutiden
+                    er det relevant også at kunne se tidligere ledelses- og
+                    ejerforhold; derfor inkluderer vi også historiske
+                    oplysninger. Formålet er at oplyse, ikke at placere skyld.
                   </p>
                 </div>
               </div>
@@ -157,69 +120,47 @@ export default function AboutPage() {
                 </p>
 
                 <p className="text-muted-foreground text-lg leading-relaxed">
-                  Vi bestræber os på, med bedste intention og efter bedste evne,
-                  at formidle data neutralt og basere vores arbejde på den
-                  bedste tilgængelige videnskab. De data, vi indsamler, er
-                  primært dem, der i forvejen er offentligt tilgængelige via
-                  officielle kilder. Hvor vi har mulighed for det, stiller vi
-                  disse data frit til rådighed under en Creative Commons licens.
-                  For data, hvor dette ikke er tilfældet, bibeholder de den
-                  ophavsret og de vilkår, som de oprindeligt er offentliggjort
-                  under, af de offentlige myndigheder.
+                  Vi bestræber os på, efter bedste evne, at formidle data
+                  neutralt og basere arbejdet på den bedste tilgængelige viden.
+                  De data, vi indsamler, er primært dem, der i forvejen er
+                  offentligt tilgængelige via officielle kilder. Hvor vi kan,
+                  stiller vi data frit til rådighed under en Creative
+                  Commons-licens. For data, hvor dette ikke er tilfældet,
+                  bevares den ophavsret og de vilkår, som de oprindeligt er
+                  offentliggjort under.
                 </p>
 
                 <p className="text-muted-foreground text-lg leading-relaxed">
-                  Selvom vi lægger stor vægt på datakvalitet og nøjagtighed, og
-                  løbende arbejder på at forbedre disse, er det vigtigt at
-                  understrege, at platformen og de data, den indeholder, stilles
-                  til rådighed{' '}
+                  Selvom vi lægger stor vægt på datakvalitet og nøjagtighed,
+                  stilles platformen og dens data til rådighed{' '}
                   <strong className="text-foreground font-bold">
                     &apos;som de er og forefindes&apos;
                   </strong>
-                  . Vi kan derfor ikke give garantier for, at alle informationer
-                  til enhver tid er fuldstændigt udtømmende, fejlfrie eller
-                  opdaterede, især i et felt der konstant udvikler sig.
+                  . Vi kan derfor ikke garantere, at alle informationer til
+                  enhver tid er udtømmende, fejlfrie eller opdaterede.
                 </p>
 
                 <p className="text-muted-foreground text-lg leading-relaxed">
-                  For at sikre platformens integritet, stabilitet og kvalitet,
-                  vil alle forslag til ændringer i koden blive gennemgået og
-                  verificeret af projektets kernebidragydere fra
-                  Klimabevægelsen, før de eventuelt integreres i den offentlige
-                  version. Landbrugssektoren og dens samfundsmæssige
-                  påvirkninger er dog et komplekst felt, hvor viden og
-                  forståelse konstant udvikler sig. Derfor anerkender vi, at vi
-                  alle bliver klogere over tid.
+                  For at sikre platformens integritet og kvalitet bliver alle
+                  forslag til ændringer i koden gennemgået og verificeret af
+                  projektets kernebidragydere i Bureau 10, før de eventuelt
+                  integreres i den offentlige version.
                 </p>
 
                 <p className="text-muted-foreground text-lg leading-relaxed">
-                  Da vi er en almennyttig forening drevet af ønsket om at
-                  bidrage positivt til samfundet og uden kommerciel interesse i
-                  dette projekt, opfordrer vi aktivt til samarbejde og modtager
-                  med stor taknemmelighed bidrag, der kan styrke platformen og
-                  dens formål. Dette kan være forslag til nye relevante
-                  datakilder, forbedrede metoder, eller anden viden. Det gælder
-                  også, hvis du mener at have fundet fejl, unøjagtigheder eller
-                  har forslag til forbedringer af eksisterende indhold.
-                </p>
-
-                <p className="text-muted-foreground text-lg leading-relaxed">
-                  Sådanne henvendelser betragter vi som værdifuld hjælp i vores
-                  bestræbelser på løbende at forbedre platformens kvalitet og
-                  nøjagtighed, hvilket understøtter idéen om kollektiv
-                  forbedring gennem åbenhed. Alle bidrag og henvendelser vil
-                  blive taget seriøst i betragtning og vurderet af
-                  projektteamet, ligesom vi gør med forslag til kodeændringer.
-                  På grund af projektets natur og ressourcer kan vi dog ikke
-                  garantere, at alle indsendte forslag eller fejlrettelser kan
-                  implementeres, eller hvornår det i givet fald vil ske, men vi
-                  værdsætter al den feedback, vi modtager.
+                  Som en almennyttig forening uden kommerciel interesse i
+                  projektet opfordrer vi til samarbejde og modtager gerne
+                  bidrag, der kan styrke platformen – fx forslag til nye
+                  datakilder, forbedrede metoder eller anden viden, herunder
+                  hvis du mener at have fundet fejl eller unøjagtigheder. Vi
+                  vurderer alle henvendelser seriøst, men kan på grund af
+                  projektets ressourcer ikke garantere, at alle forslag kan
+                  implementeres.
                 </p>
 
                 <p className="text-muted-foreground text-lg leading-relaxed">
                   Vi håber, at Landbruget.dk kan blive et værdifuldt redskab for
-                  alle med interesse i dansk landbrug og dets rolle i en
-                  bæredygtig fremtid.
+                  alle med interesse i dansk landbrug og dets rolle i samfundet.
                 </p>
               </div>
             </section>
@@ -231,8 +172,8 @@ export default function AboutPage() {
               </h2>
               <div className="space-y-4">
                 <p className="text-muted-foreground text-lg leading-relaxed">
-                  Har du spørgsmål, forslag til forbedringer, eller har du
-                  fundet fejl i vores data? Vi hører gerne fra dig!
+                  Har du spørgsmål, forslag eller har du fundet fejl i vores
+                  data? Vi hører gerne fra dig!
                 </p>
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
                   <a

--- a/frontend/src/content/about.md
+++ b/frontend/src/content/about.md
@@ -1,45 +1,37 @@
 # Om os
 
-Velkommen til Landbruget.dk. Vi er et almennyttigt, [open-source](https://github.com/klimabevaegelsen/landbruget.dk/) og non-profit initiativ drevet af Klimabevægelsen. Vores mission er at indsamle og formidle offentligt tilgængelige data om den danske landbrugssektor.
+Velkommen til Landbruget.dk. Vi er et almennyttigt, [open-source](https://github.com/klimabevaegelsen/landbruget.dk/) og non-profit initiativ drevet af den publicistiske forening Bureau 10. Vores formål er at indsamle og formidle offentligt tilgængelige data om den danske landbrugssektor.
 
 ---
 
 ## Hvorfor gør vi det?
 
-Landbruget spiller en afgørende rolle i Danmark – for vores økonomi, vores landskab, vores miljø, vores sundhed og vores klima. Beslutninger truffet i og omkring sektoren har vidtrækkende konsekvenser. Vi mener, at en åben og informeret offentlig debat er essentiel for at sikre en bæredygtig udvikling. Desværre er mange relevante data i dag spredt, svært tilgængelige eller gemt i formater, der gør dem vanskelige at anvende for den almindelige borger, journalist, forsker eller endda landmanden selv.
+Landbruget spiller en stor rolle i Danmark – for økonomien, landskabet, miljøet, sundheden og klimaet. Beslutninger i og omkring sektoren har vidtrækkende konsekvenser, og en åben og informeret offentlig debat forudsætter adgang til fakta. I dag er mange relevante data spredt, svært tilgængelige eller gemt i formater, der gør dem vanskelige at anvende for den almindelige borger, journalist, forsker eller landmanden selv.
 
-## Vores mål er at:
+## Vores formål er at:
 
-### Fremme offentlig oplysning og inspirere
+### Fremme offentlig oplysning
 
-Vi vil gøre det lettere for alle at forstå landbrugssektorens komplekse sammenhænge og dens påvirkning på samfundet, herunder miljø, sundhed og klima. Samtidig ønsker vi at synliggøre de landmænd og virksomheder, der går forrest med bæredygtige løsninger og viser vejen mod en grønnere praksis.
+Vi vil gøre det lettere for alle at forstå landbrugssektorens komplekse sammenhænge og dens påvirkning på samfundet, herunder miljø, sundhed og klima.
 
-### Understøtte en informeret og konstruktiv demokratisk debat
+### Understøtte en informeret offentlig debat
 
-Ved at gøre data tilgængelige og brugervenlige ønsker vi at styrke grundlaget for en dialog om landbrugets fremtid og den nødvendige grønne omstilling, båret af både udfordringer og succesfulde eksempler.
+Ved at gøre data tilgængelige og brugervenlige vil vi styrke grundlaget for en faktabaseret debat om landbrugets forhold og fremtid.
 
-### Styrke transparens, ansvarlighed og læring af historien
+### Styrke transparens og læring af historien
 
-Vi tror på, at åbenhed om data – herunder produktionsforhold, miljøpåvirkning, økonomiske støtteordninger og ledelsesforhold – er afgørende for at drive positive forandringer. For at forstå nutiden og forme fremtiden er det vigtigt at lære af fortiden. Derfor inkluderer vi også oplysninger om tidligere ledelses- og ejerforhold.
-
-Det handler ikke kun om at placere ansvar for beslutninger med langsigtede negative konsekvenser, som f.eks. pesticidanvendelse der påvirker grundvandet. Lige så vigtigt er det at kunne identificere og fremhæve de positive, langsigtede initiativer, f.eks. de landmænd der tidligt plantede træer, investerede i naturpleje eller omlagde til driftsformer, der først årtier senere viser deres fulde positive værdi for miljø og biodiversitet. Denne historiske indsigt er afgørende for både at anerkende fremsynede handlinger og for at sikre en retfærdig forståelse af, hvordan vi er nået til, hvor vi er i dag.
-
-### Understøtte den grønne omstilling
-
-Særligt i lyset af Den Grønne Trepartsaftale er der et stort behov for et solidt datagrundlag. Landbruget.dk skal levere data, der kan hjælpe med at monitorere og evaluere implementeringen af aftalens mål, fremhæve fremskridt og accelerere transformationen mod en mere bæredygtig arealanvendelse og fødevareproduktion.
+Vi mener, at åbenhed om data – herunder produktionsforhold, miljøpåvirkning, økonomiske støtteordninger og ledelses- og ejerforhold – er et gode i sig selv. For at forstå nutiden er det relevant også at kunne se tidligere ledelses- og ejerforhold; derfor inkluderer vi også historiske oplysninger. Formålet er at oplyse, ikke at placere skyld.
 
 ## Hvordan arbejder vi?
 
 Landbruget.dk er baseret på [open-source](https://github.com/klimabevaegelsen/landbruget.dk/) principper. Det betyder, at vores metoder og software er åbne for alle at inspicere, foreslå ændringer til og videreudvikle på.
 
-Vi bestræber os på, med bedste intention og efter bedste evne, at formidle data neutralt og basere vores arbejde på den bedste tilgængelige videnskab. De data, vi indsamler, er primært dem, der i forvejen er offentligt tilgængelige via officielle kilder. Hvor vi har mulighed for det, stiller vi disse data frit til rådighed under en Creative Commons licens. For data, hvor dette ikke er tilfældet, bibeholder de den ophavsret og de vilkår, som de oprindeligt er offentliggjort under, af de offentlige myndigheder.
+Vi bestræber os på, efter bedste evne, at formidle data neutralt og basere arbejdet på den bedste tilgængelige viden. De data, vi indsamler, er primært dem, der i forvejen er offentligt tilgængelige via officielle kilder. Hvor vi kan, stiller vi data frit til rådighed under en Creative Commons-licens. For data, hvor dette ikke er tilfældet, bevares den ophavsret og de vilkår, som de oprindeligt er offentliggjort under.
 
-Selvom vi lægger stor vægt på datakvalitet og nøjagtighed, og løbende arbejder på at forbedre disse, er det vigtigt at understrege, at platformen og de data, den indeholder, stilles til rådighed 'som de er og forefindes'. Vi kan derfor ikke give garantier for, at alle informationer til enhver tid er fuldstændigt udtømmende, fejlfrie eller opdaterede, især i et felt der konstant udvikler sig.
+Selvom vi lægger stor vægt på datakvalitet og nøjagtighed, stilles platformen og dens data til rådighed 'som de er og forefindes'. Vi kan derfor ikke garantere, at alle informationer til enhver tid er udtømmende, fejlfrie eller opdaterede.
 
-For at sikre platformens integritet, stabilitet og kvalitet, vil alle forslag til ændringer i koden blive gennemgået og verificeret af projektets kernebidragydere fra Klimabevægelsen, før de eventuelt integreres i den offentlige version. Landbrugssektoren og dens samfundsmæssige påvirkninger er dog et komplekst felt, hvor viden og forståelse konstant udvikler sig. Derfor anerkender vi, at vi alle bliver klogere over tid.
+For at sikre platformens integritet og kvalitet bliver alle forslag til ændringer i koden gennemgået og verificeret af projektets kernebidragydere i Bureau 10, før de eventuelt integreres i den offentlige version.
 
-Da vi er en almennyttig forening drevet af ønsket om at bidrage positivt til samfundet og uden kommerciel interesse i dette projekt, opfordrer vi aktivt til samarbejde og modtager med stor taknemmelighed bidrag, der kan styrke platformen og dens formål. Dette kan være forslag til nye relevante datakilder, forbedrede metoder, eller anden viden. Det gælder også, hvis du mener at have fundet fejl, unøjagtigheder eller har forslag til forbedringer af eksisterende indhold.
+Som en almennyttig forening uden kommerciel interesse i projektet opfordrer vi til samarbejde og modtager gerne bidrag, der kan styrke platformen – fx forslag til nye datakilder, forbedrede metoder eller anden viden, herunder hvis du mener at have fundet fejl eller unøjagtigheder. Vi vurderer alle henvendelser seriøst, men kan på grund af projektets ressourcer ikke garantere, at alle forslag kan implementeres.
 
-Sådanne henvendelser betragter vi som værdifuld hjælp i vores bestræbelser på løbende at forbedre platformens kvalitet og nøjagtighed, hvilket understøtter idéen om kollektiv forbedring gennem åbenhed. Alle bidrag og henvendelser vil blive taget seriøst i betragtning og vurderet af projektteamet, ligesom vi gør med forslag til kodeændringer. På grund af projektets natur og ressourcer kan vi dog ikke garantere, at alle indsendte forslag eller fejlrettelser kan implementeres, eller hvornår det i givet fald vil ske, men vi værdsætter al den feedback, vi modtager.
-
-Vi håber, at Landbruget.dk kan blive et værdifuldt redskab for alle med interesse i dansk landbrug og dets rolle i en bæredygtig fremtid.
+Vi håber, at Landbruget.dk kan blive et værdifuldt redskab for alle med interesse i dansk landbrug og dets rolle i samfundet.

--- a/frontend/src/content/privacy-policy.md
+++ b/frontend/src/content/privacy-policy.md
@@ -4,20 +4,19 @@ _Sidst opdateret: 19. april 2026_
 
 ---
 
-Denne privatlivspolitik forklarer, hvordan Landbruget.dk og underplatformen pesticidkortet.dk (begge drevet af Klimabevægelsen, en almennyttig forening) indsamler og behandler personoplysninger.
+Denne privatlivspolitik forklarer, hvordan Landbruget.dk og underplatformen pesticidkortet.dk (begge drevet af Bureau 10, en almennyttig forening) indsamler og behandler personoplysninger.
 
 ## 1. Dataansvarlig
 
 Den dataansvarlige for behandlingen af personoplysninger på Landbruget.dk og pesticidkortet.dk er:
 
-**Klimabevægelsen i Danmark**  
-Bragesgade 8 B, 2200 København N  
-CVR-nr.: 34364672  
-Email: kontakt@klimabev.dk
+**Bureau 10**  
+Nørre Søgade 37D, 1370 København K  
+Email: hej@bureau10.dk
 
 ## 2. Formål med og retsgrundlag for behandling af personoplysninger
 
-Landbruget.dk behandler personoplysninger med det overordnede almennyttige formål at fremme offentlig oplysning, transparens og en informeret demokratisk debat om den danske landbrugssektors miljø-, sundheds- og klimapåvirkning, samt at understøtte sektorens grønne omstilling. Projektet er non-profit og drives af en anerkendt NGO med fokus på klima og miljø.
+Landbruget.dk behandler personoplysninger med det overordnede almennyttige formål at fremme offentlig oplysning, transparens og en informeret offentlig debat om den danske landbrugssektor. Projektet er non-profit og drives af den almennyttige forening Bureau 10.
 
 ### Specifikt behandler vi oplysninger om:
 
@@ -60,7 +59,7 @@ Oplysningerne hentes udelukkende fra det adgangsniveau i Ejerfortegnelsen (typis
 
 Vi behandler som udgangspunkt ikke følsomme personoplysninger (som defineret i GDPR artikel 9). Skulle sådanne oplysninger undtagelsesvist og utilsigtet blive en del af de offentlige datasæt vi indsamler, vil de ikke blive aktivt brugt eller fremhævet, medmindre de på en åbenlys måde er gjort offentliggjort af den registrerede selv i en kontekst, der er direkte relevant for Landbruget.dk's almennyttige formål, og behandlingen er lovlig.
 
-For at opnå formålet med Landbruget.dk kan visse data på platformen være beregnede eller estimerede. Dette sker på baggrund af offentligt tilgængelige data og den bedste tilgængelige viden og anerkendte metoder. Når data er beregnet eller estimeret, vil dette blive tydeligt angivet sammen med information om den anvendte metode. Der må forventes en vis usikkerhed og potentielle afvigelser i forhold til de faktiske forhold for sådanne data. Vi opfordrer brugere, der mener at have mere præcise oplysninger eller forslag til forbedring af vores metoder, til at kontakte os via kontakt@klimabev.dk.
+For at opnå formålet med Landbruget.dk kan visse data på platformen være beregnede eller estimerede. Dette sker på baggrund af offentligt tilgængelige data og den bedste tilgængelige viden og anerkendte metoder. Når data er beregnet eller estimeret, vil dette blive tydeligt angivet sammen med information om den anvendte metode. Der må forventes en vis usikkerhed og potentielle afvigelser i forhold til de faktiske forhold for sådanne data. Vi opfordrer brugere, der mener at have mere præcise oplysninger eller forslag til forbedring af vores metoder, til at kontakte os via hej@bureau10.dk.
 
 ## 4. Kilder
 
@@ -114,7 +113,7 @@ Du har ret til at gøre indsigelse mod vores ellers lovlige behandling af dine p
 
 Denne rettighed gælder typisk ikke for behandling baseret på legitim interesse, men hvis relevant, har du ret til at modtage dine personoplysninger i et struktureret, almindeligt anvendt og maskinlæsbart format.
 
-Du kan læse mere om dine rettigheder i Datatilsynets vejledning om de registreredes rettigheder, som du finder på www.datatilsynet.dk. Hvis du ønsker at gøre brug af dine rettigheder, bedes du kontakte os på kontakt@klimabev.dk. Vi kan bede om yderligere information for at bekræfte din identitet.
+Du kan læse mere om dine rettigheder i Datatilsynets vejledning om de registreredes rettigheder, som du finder på www.datatilsynet.dk. Hvis du ønsker at gøre brug af dine rettigheder, bedes du kontakte os på hej@bureau10.dk. Vi kan bede om yderligere information for at bekræfte din identitet.
 
 ## 8. Datasikkerhed
 
@@ -128,7 +127,7 @@ Du har ret til at indgive en klage til Datatilsynet, hvis du er utilfreds med de
 
 Landbruget.dk indsamler, systematiserer og formidler offentligt tilgængelige data, herunder personoplysninger som beskrevet i denne privatlivspolitik. Vi tilstræber høj datakvalitet og en korrekt gengivelse af oplysninger fra vores kilder. Dine rettigheder i forhold til dine personoplysninger, herunder retten til berigtigelse, er også beskrevet i denne privatlivspolitik.
 
-Det er dog vigtigt at understrege, at al information og alle data på Landbruget.dk og pesticidkortet.dk leveres "som de er og forefindes". Klimabevægelsen kan ikke garantere for dataenes fuldstændighed, konstante ajourføring eller absolutte nøjagtighed, da disse ofte stammer fra eksterne, offentlige registre, hvis indhold vi ikke kontrollerer. Anvendelse af information fra platformen, herunder de personoplysninger der formidles, sker på brugerens eget ansvar.
+Det er dog vigtigt at understrege, at al information og alle data på Landbruget.dk og pesticidkortet.dk leveres "som de er og forefindes". Bureau 10 kan ikke garantere for dataenes fuldstændighed, konstante ajourføring eller absolutte nøjagtighed, da disse ofte stammer fra eksterne, offentlige registre, hvis indhold vi ikke kontrollerer. Anvendelse af information fra platformen, herunder de personoplysninger der formidles, sker på brugerens eget ansvar.
 
 På pesticidkortet.dk er mange af de viste tal desuden **modellerede estimater** (bl.a. fordeling af pesticidforbrug fra virksomhed til mark samt drift- og nærhedsberegninger). Faktisk sprøjtning på en konkret mark kan afvige fra det viste. Se den udførlige beskrivelse i Brugsvilkårenes afsnit 4 ("Særligt om pesticidkortet.dk") og afsnit 6 (Ansvarsfraskrivelse).
 

--- a/frontend/src/content/terms-of-use.md
+++ b/frontend/src/content/terms-of-use.md
@@ -6,13 +6,13 @@ _Sidst opdateret: 19. april 2026_
 
 ## 1. Indledning
 
-Velkommen til Landbruget.dk ("Platformen"). "Platformen" omfatter både landbruget.dk og underplatformen pesticidkortet.dk. Begge drives af Klimabevægelsen i Danmark ("os", "vi", "vores"), en almennyttig forening. Disse brugsvilkår ("Vilkårene") regulerer din ("Brugeren", "du", "din") adgang til og brug af Platformen, herunder alt indhold, data, software og funktionalitet, der stilles til rådighed.
+Velkommen til Landbruget.dk ("Platformen"). "Platformen" omfatter både landbruget.dk og underplatformen pesticidkortet.dk. Begge drives af Bureau 10 ("os", "vi", "vores"), en almennyttig forening. Disse brugsvilkår ("Vilkårene") regulerer din ("Brugeren", "du", "din") adgang til og brug af Platformen, herunder alt indhold, data, software og funktionalitet, der stilles til rådighed.
 
 Ved at tilgå eller bruge Platformen accepterer du at være bundet af disse Vilkår samt vores Privatlivspolitik, som er tilgængelig på Platformen og udgør en integreret del af disse Vilkår. Hvis du ikke accepterer disse Vilkår, bedes du undlade at bruge Platformen.
 
 ## 2. Platformens Formål og Beskrivelse af Tjenesten
 
-Landbruget.dk er et almennyttigt, [open-source](https://github.com/klimabevaegelsen/landbruget.dk/) og non-profit initiativ. Vores mission er at indsamle, systematisere og formidle offentligt tilgængelige data om den danske landbrugssektor. Formålet er at fremme offentlig oplysning, transparens og en informeret demokratisk debat om den danske landbrugssektors miljø-, sundheds- og klimapåvirkning, samt at understøtte sektorens grønne omstilling. Platformen sigter mod at gøre komplekse data tilgængelige og brugbare for borgere, journalister, forskere, landmænd og embedsmænd.
+Landbruget.dk er et almennyttigt, [open-source](https://github.com/klimabevaegelsen/landbruget.dk/) og non-profit initiativ. Vores mission er at indsamle, systematisere og formidle offentligt tilgængelige data om den danske landbrugssektor. Formålet er at fremme offentlig oplysning, transparens og en informeret offentlig debat om den danske landbrugssektor og dens forhold ved at gøre offentligt tilgængelige data samlet, søgbart og anvendeligt for borgere, journalister, forskere, landmænd og embedsmænd.
 
 Pesticidkortet.dk er en del af Platformen og har særligt fokus på at visualisere, hvilke pesticider der er rapporteret brugt på danske landbrugsmarker, samt at estimere eksponering nær konkrete adresser. Værdierne på pesticidkortet.dk er modellerede og bygger på offentlige data kombineret med anerkendte beregningsmetoder — se afsnit 4 for detaljer om datakvalitet og forbehold.
 
@@ -36,7 +36,7 @@ Det er strengt forbudt at bruge Platformen eller dens data til følgende formål
 
 - **Uhensigtsmæssig automatiseret dataindsamling**: Intensiv eller uansvarlig automatiseret dataindsamling (herunder scraping, crawling) der uforholdsmæssigt belaster Platformens servere, forringer Platformens ydeevne for andre brugere, eller har til formål at omgå disse Vilkår. Landbruget.dk drives i vid udstrækning af frivillige og med begrænsede økonomiske midler, og vores infrastruktur er dimensioneret til almindelig brugeradgang. Misbrug gennem aggressiv automatiseret dataindsamling kan true Platformens stabilitet og tilgængelighed for alle og vil medføre øjeblikkelig blokering af adgang
 
-- Kommerciel udnyttelse af Platformens data eller funktionalitet uden udtrykkelig skriftlig tilladelse fra Klimabevægelsen, medmindre andet følger af den specifikke licens, data stilles til rådighed under
+- Kommerciel udnyttelse af Platformens data eller funktionalitet uden udtrykkelig skriftlig tilladelse fra Bureau 10, medmindre andet følger af den specifikke licens, data stilles til rådighed under
 
 - At forsøge at opnå uautoriseret adgang til Platformens systemer eller netværk
 
@@ -48,7 +48,7 @@ Det er strengt forbudt at bruge Platformen eller dens data til følgende formål
 
 ### Særlige Dataudtræk til Almennyttige Formål
 
-Landbruget.dk ønsker at understøtte journalistik, forskning og andre almennyttige projekter, der er i tråd med Platformens overordnede formål. Hvis du har behov for et specifikt, større dataudtræk, som ikke hensigtsmæssigt kan opnås via almindelig brug af Platformen, og som tjener et klart almennyttigt formål, opfordrer vi dig til at rette henvendelse til os på kontakt@klimabev.dk. Beskriv venligst dit projekt og dine databehov. Vi vil da vurdere, om og hvordan vi inden for rammerne af vores tilgængelige ressourcer kan imødekomme din anmodning. Vi kan ikke garantere, at alle anmodninger kan efterkommes, men vi bestræber os på at være så hjælpsomme som muligt.
+Landbruget.dk ønsker at understøtte journalistik, forskning og andre almennyttige projekter, der er i tråd med Platformens overordnede formål. Hvis du har behov for et specifikt, større dataudtræk, som ikke hensigtsmæssigt kan opnås via almindelig brug af Platformen, og som tjener et klart almennyttigt formål, opfordrer vi dig til at rette henvendelse til os på hej@bureau10.dk. Beskriv venligst dit projekt og dine databehov. Vi vil da vurdere, om og hvordan vi inden for rammerne af vores tilgængelige ressourcer kan imødekomme din anmodning. Vi kan ikke garantere, at alle anmodninger kan efterkommes, men vi bestræber os på at være så hjælpsomme som muligt.
 
 ## 4. Data og Informationskvalitet
 
@@ -83,12 +83,12 @@ Alle viste tal på pesticidkortet.dk skal læses som et **modelleret estimat**, 
 
 ### Platformens Indhold og Software
 
-Platformen Landbruget.dk er udviklet på [open-source](https://github.com/klimabevaegelsen/landbruget.dk/) principper. Den specifikke software kan være underlagt en open-source licens (f.eks. MIT, GPL), som vil være angivet i Platformens dokumentation eller kildekode-repository (f.eks. på GitHub). Al anden originalt indhold skabt af Klimabevægelsen for Platformen (tekster, design, logoer) tilhører Klimabevægelsen eller er licenseret hertil, medmindre andet er angivet.
+Platformen Landbruget.dk er udviklet på [open-source](https://github.com/klimabevaegelsen/landbruget.dk/) principper. Den specifikke software kan være underlagt en open-source licens (f.eks. MIT, GPL), som vil være angivet i Platformens dokumentation eller kildekode-repository (f.eks. på GitHub). Al anden originalt indhold skabt af Bureau 10 for Platformen (tekster, design, logoer) tilhører Bureau 10 eller er licenseret hertil, medmindre andet er angivet.
 
 ### Data
 
 - De rådata, der hentes fra offentlige registre, bevarer den ophavsret eller de brugsvilkår, som den oprindelige offentlige kilde har fastsat.
-- Den måde, hvorpå Landbruget.dk systematiserer, kombinerer og præsenterer data, samt eventuelle afledte datasæt skabt af Landbruget.dk, stilles som udgangspunkt til rådighed under en Creative Commons Attribution 4.0 International (CC BY 4.0) licens, medmindre andet udtrykkeligt er angivet for specifikke datasæt. Dette betyder, at du frit kan dele og bearbejde disse materialer, forudsat at du krediterer Landbruget.dk/Klimabevægelsen korrekt, angiver et link til licensen, og indikerer om der er foretaget ændringer.
+- Den måde, hvorpå Landbruget.dk systematiserer, kombinerer og præsenterer data, samt eventuelle afledte datasæt skabt af Landbruget.dk, stilles som udgangspunkt til rådighed under en Creative Commons Attribution 4.0 International (CC BY 4.0) licens, medmindre andet udtrykkeligt er angivet for specifikke datasæt. Dette betyder, at du frit kan dele og bearbejde disse materialer, forudsat at du krediterer Landbruget.dk/Bureau 10 korrekt, angiver et link til licensen, og indikerer om der er foretaget ændringer.
 
 ## 6. Ansvarsfraskrivelse
 
@@ -96,7 +96,7 @@ Oplysningerne på Landbruget.dk ("Platformen") stilles til rådighed i offentlig
 
 Al information og alle data på Platformen leveres dog "som de er og forefindes" ("as is and as available") og uden nogen udtrykkelig eller underforstået garanti for deres fuldstændighed, nøjagtighed, pålidelighed eller egnethed til et specifikt formål. Fejl eller udeladelser kan forekomme, dels fordi data stammer fra eksterne kilder, som vi ikke har fuld kontrol over, dels på grund af den komplekse natur af dataindsamling, -behandling og -estimering.
 
-Brugen af Platformen sker på Brugerens eget ansvar. Klimabevægelsen kan ikke holdes ansvarlig for nogen form for direkte eller indirekte tab, skade eller ulempe, herunder men ikke begrænset til tab af data, driftstab, tabt fortjeneste eller lignende, der måtte opstå som følge af:
+Brugen af Platformen sker på Brugerens eget ansvar. Bureau 10 kan ikke holdes ansvarlig for nogen form for direkte eller indirekte tab, skade eller ulempe, herunder men ikke begrænset til tab af data, driftstab, tabt fortjeneste eller lignende, der måtte opstå som følge af:
 
 a. Din adgang til, brug af eller tillid til information fundet på Platformen.
 
@@ -108,7 +108,7 @@ d. Andre brugeres eller tredjeparters fortolkning, anvendelse, videreformidling 
 
 Du accepterer ved anvendelsen af Platformen, at brugen af Platformens information sker på dit eget ansvar. Vi opfordrer til kildekritik og til, at data fra Platformen, hvor det er relevant, sammenholdes med andre kilder. Enhver bruger er selv ansvarlig for at overholde gældende lovgivning og respektere andres rettigheder i forbindelse med sin brug og eventuelle videreformidling af information fra Platformen.
 
-Denne ansvarsfraskrivelse påvirker ikke Klimabevægelsens ansvar i henhold til ufravigelig dansk lovgivning.
+Denne ansvarsfraskrivelse påvirker ikke Bureau 10's ansvar i henhold til ufravigelig dansk lovgivning.
 
 ## 7. Links til Tredjepartssider
 
@@ -116,11 +116,11 @@ Platformen kan indeholde links til hjemmesider, der drives af tredjeparter. Diss
 
 ## 8. Ændringer til Brugsvilkår
 
-Klimabevægelsen forbeholder sig retten til at ændre disse Vilkår til enhver tid. Eventuelle ændringer træder i kraft umiddelbart efter offentliggørelse på Platformen. Den dato, hvor Vilkårene sidst blev opdateret, vil fremgå øverst. Din fortsatte brug af Platformen efter sådanne ændringer udgør din accept af de nye Vilkår. Vi opfordrer dig til jævnligt at gennemgå disse Vilkår.
+Bureau 10 forbeholder sig retten til at ændre disse Vilkår til enhver tid. Eventuelle ændringer træder i kraft umiddelbart efter offentliggørelse på Platformen. Den dato, hvor Vilkårene sidst blev opdateret, vil fremgå øverst. Din fortsatte brug af Platformen efter sådanne ændringer udgør din accept af de nye Vilkår. Vi opfordrer dig til jævnligt at gennemgå disse Vilkår.
 
 ## 9. Ophør af Brugsret
 
-Klimabevægelsen forbeholder sig retten til, uden varsel og efter eget skøn, at begrænse, suspendere eller permanent ophæve din adgang til og brug af hele eller dele af Platformen, hvis du overtræder disse Vilkår eller gældende lovgivning, eller hvis din brug på anden måde vurderes at være skadelig for Platformen, Klimabevægelsen eller andre brugere.
+Bureau 10 forbeholder sig retten til, uden varsel og efter eget skøn, at begrænse, suspendere eller permanent ophæve din adgang til og brug af hele eller dele af Platformen, hvis du overtræder disse Vilkår eller gældende lovgivning, eller hvis din brug på anden måde vurderes at være skadelig for Platformen, Bureau 10 eller andre brugere.
 
 ## 10. Lovvalg og Værneting
 
@@ -134,7 +134,6 @@ Hvis en bestemmelse i disse Vilkår findes at være ugyldig, ulovlig eller uden 
 
 Hvis du har spørgsmål vedrørende disse Brugsvilkår, bedes du kontakte:
 
-**Klimabevægelsen i Danmark**  
-Bragesgade 8 B, 2200 København N  
-CVR-nr.: 34364672  
-Email: kontakt@klimabev.dk
+**Bureau 10**  
+Nørre Søgade 37D, 1370 København K  
+Email: hej@bureau10.dk


### PR DESCRIPTION
## Formål

Driften af Landbruget.dk overdrages fra foreningen **Klimabevægelsen** til den nye almennyttige forening **Bureau 10**. Denne PR opdaterer udelukkende **tekst/indhold** på de tre relevante sider og deres metadata. Ingen funktionelle ændringer, ingen ændringer i datapipelines, beregninger eller GDPR-tekstens juridiske substans.

## Ændringer

**Afsenderskift**
- `Klimabevægelsen i Danmark` / `Klimabevægelsen` → **Bureau 10** (brødtekst, `<title>`/meta-description og juridiske referencer)

**Ny kontakt / dataansvarlig** (Brugsvilkår §12 og Privatlivspolitik §1)
- Bureau 10
- Nørre Søgade 37D, 1370 København K
- Email: **hej@bureau10.dk**
- ⚠️ CVR-nummeret er **udeladt for nu** (CVR-linjen fjernet) — skal tilføjes, når det foreligger.

**E-mail**
- `kontakt@klimabev.dk` → **hej@bureau10.dk** overalt
- `info@landbruget.dk` er **bevaret** som sidens generelle kontakt (Om os + footer)

**Publicistisk sprog (aktivisme/politik fjernet)**
- Om os: ny brødtekst; afsnittet *"Understøtte den grønne omstilling"* (Den Grønne Trepartsaftale) er fjernet, ligesom formuleringer om *"den nødvendige grønne omstilling"*, *"bæredygtige løsninger"* og de stillingtagende eksempler (grundvand/pesticider, *"de landmænd der tidligt plantede træer"*).
- Brugsvilkår §2 og Privatlivspolitik §2: formålsbeskrivelsen omformuleret fra *"…demokratisk debat … samt at understøtte sektorens grønne omstilling"* til et rent oplysnings-/transparensformål. **GDPR-retsgrundlaget (art. 6, stk. 1, litra f) er uændret.**
- pesticidkortet.dk's forbehold er bevaret uændret (kun afsendernavn).

**Berørte filer**
- `frontend/src/app/(main)/om-os/page.tsx` (inline JSX-indhold + metadata)
- `frontend/src/app/(main)/brugsvilkaar/page.tsx` (metadata) → indhold i `frontend/src/content/terms-of-use.md`
- `frontend/src/app/(main)/privatlivspolitik/page.tsx` → indhold i `frontend/src/content/privacy-policy.md`
- `frontend/src/content/about.md` — opdateret for konsistens. **NB:** denne fil ser ud til at være legacy/ubrugt (Om os-siden renderes fra inline JSX i `page.tsx`, ikke fra `about.md`). Bør verificeres af et menneske.

## Verifikation
- `npm run lint` ✅ (kun præeksisterende warnings, ingen i de berørte filer)
- `npm run format` ✅
- `npm run build` ✅ (/om-os, /brugsvilkaar, /privatlivspolitik prerenderes statisk)

## ⚠️ Til menneskelig stillingtagen (UDEN for denne PR's scope)

Følgende forekomster af `Klimabevægelsen` / `klimabev` / `klimabevaegelsen` ligger **uden for de tre sider** og er **bevidst ikke ændret** her — de bør vurderes separat:

**GitHub-org-navn i repo-URL'er** (skift kræver flytning/omdøbning af selve GitHub-org/repo'et):
- `frontend/src/components/layout/templates/navbar.tsx:57, :96`
- `frontend/src/components/layout/templates/nav-banner.tsx:17`
- `frontend/src/components/page-sections/hero.tsx:199`
- `frontend/src/components/pagebuilder/pageBlocks/category-placeholder.tsx:8`
- `frontend/src/components/pagebuilder/pageBlocks/no-data-placeholder.tsx:8`
- `frontend/src/components/pagebuilder/pageBlocks/placeholder-chart.tsx:13, :18, :23, :29, :87`
- `frontend/src/app/admin/pipeline/page.tsx:51`
- Også internt i de tre sider: open-source-links peger fortsat på `github.com/klimabevaegelsen/landbruget.dk/`.

**Pipeline-/CI-reference** (funktionel — owner til GitHub Actions API-kald, må IKKE ændres uden at org/repo faktisk flyttes):
- `frontend/src/app/api/trigger-h3-pfas/route.ts:17` — `const owner = 'Klimabevaegelsen';`

**Tidligere CVR-nummer** (34364672) forekommer ikke længere i de tre sider efter denne PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)