### PR TITLE
fix(frontend): stop API 500s on partial/missing R2 data (+ hydration & mobile overflow)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1888,9 +1888,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1908,9 +1905,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1928,9 +1922,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1948,9 +1939,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1968,9 +1956,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1988,9 +1973,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2008,9 +1990,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2028,9 +2007,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2235,9 +2211,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2255,9 +2228,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2275,9 +2245,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2295,9 +2262,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2315,9 +2279,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2335,9 +2296,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2355,9 +2313,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,9 +2330,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6065,9 +6017,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6085,9 +6034,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6105,9 +6051,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6125,9 +6068,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15221,6 +15161,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/frontend/src/app/api/data/homepage-rankings/route.ts
+++ b/frontend/src/app/api/data/homepage-rankings/route.ts
@@ -32,6 +32,15 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('Error in homepage-rankings proxy:', error);
 
+    if (error instanceof Error && error.message.includes('(404)')) {
+      return NextResponse.json(
+        { rankings: [] },
+        {
+          headers: CACHE_HEADERS,
+        }
+      );
+    }
+
     return NextResponse.json(
       {
         error: 'Failed to fetch rankings',

--- a/frontend/src/app/api/data/kommuner/route.ts
+++ b/frontend/src/app/api/data/kommuner/route.ts
@@ -30,6 +30,15 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('Municipality rankings API error:', error);
 
+    if (error instanceof Error && error.message.includes('(404)')) {
+      return NextResponse.json(
+        { rankings: [] },
+        {
+          headers: CACHE_HEADERS,
+        }
+      );
+    }
+
     return NextResponse.json(
       {
         error: 'Internal server error',

--- a/frontend/src/app/api/data/pesticide-analysis/route.ts
+++ b/frontend/src/app/api/data/pesticide-analysis/route.ts
@@ -35,6 +35,24 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('Error in pesticide-analysis proxy:', error);
 
+    if (error instanceof Error && error.message.includes('(404)')) {
+      return NextResponse.json(
+        {
+          companies: [],
+          total_count: 0,
+          page: 1,
+          limit: 50,
+          filters: {
+            available_years: [],
+            available_municipalities: [],
+          },
+        },
+        {
+          headers: CACHE_HEADERS,
+        }
+      );
+    }
+
     return NextResponse.json(
       {
         error: 'Failed to fetch pesticide analysis data',

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
   return (
     <html lang="da" suppressHydrationWarning>
       <body
-        className={`${plusJakartaSans.variable} ${fraunces.variable} antialiased`}
+        className={`${plusJakartaSans.variable} ${fraunces.variable} overflow-x-hidden antialiased`}
       >
         <ThemeProvider defaultTheme="system" storageKey="landbruget-theme">
           {children}

--- a/frontend/src/components/global-search.tsx
+++ b/frontend/src/components/global-search.tsx
@@ -37,7 +37,7 @@ export function GlobalSearch({
   return (
     <div
       className={cn(
-        'overflow relative flex w-full flex-col items-center gap-y-4',
+        'relative flex w-full flex-col items-center gap-y-4 overflow-hidden',
         className,
         parentOpen === false && 'hidden'
       )}
@@ -56,7 +56,7 @@ export function GlobalSearch({
         data-testid="global-search-input"
       />
       {searchSuggestions && (
-        <div className="flex items-center justify-center gap-x-2">
+        <div className="flex max-w-full flex-wrap items-center justify-center gap-2">
           {searchSuggestions.map((suggestion) => (
             <Button
               key={suggestion}

--- a/frontend/src/components/homepage/AllRankings.tsx
+++ b/frontend/src/components/homepage/AllRankings.tsx
@@ -204,8 +204,7 @@ export function AllRankings() {
       {/* Footer */}
       <div className="border-border border-t pt-8 text-center">
         <p className="text-muted-foreground text-xs">
-          Data opdateret: {new Date().toLocaleDateString('da-DK')} • 26
-          ranglister baseret på officielle data fra 2024-2025
+          26 ranglister baseret på officielle data fra 2024-2025
         </p>
       </div>
     </div>

--- a/frontend/src/lib/server-cache.ts
+++ b/frontend/src/lib/server-cache.ts
@@ -8,6 +8,11 @@ import { unstable_cache } from 'next/cache';
 
 import { DATA_URL } from '@/lib/env';
 
+type HomepageRanking = {
+  items: { cvr_number: string; company_id?: string }[];
+  [k: string]: unknown;
+};
+
 async function fetchR2Json<T>(path: string): Promise<T> {
   const url = `${DATA_URL}${path}`;
   const response = await fetch(url);
@@ -33,19 +38,20 @@ export const getCachedHomepageRankings = unstable_cache(
   ) => {
     // Pre-computed JSON per category; limit/rankingId filtering done client-side
     const data = await fetchR2Json<{
-      rankings: {
-        items: { cvr_number: string; company_id?: string }[];
-        [k: string]: unknown;
-      }[];
+      rankings: (HomepageRanking | null)[];
       [k: string]: unknown;
     }>(`/homepage/rankings/${category}.json`);
+    const rankings = (data.rankings ?? []).filter(
+      (ranking): ranking is HomepageRanking =>
+        ranking != null && Array.isArray(ranking.items)
+    );
     // Map cvr_number to company_id for frontend compatibility
-    for (const ranking of data.rankings ?? []) {
-      for (const item of ranking.items ?? []) {
+    for (const ranking of rankings) {
+      for (const item of ranking.items) {
         item.company_id = item.cvr_number;
       }
     }
-    return data;
+    return { ...data, rankings };
   },
   ['homepage-rankings'],
   { revalidate: 604800, tags: ['homepage-rankings'] }
@@ -75,9 +81,10 @@ export const getCachedMunicipalityDetails = unstable_cache(
 export const getCachedPesticideAnalysis = unstable_cache(
   async (searchParams: Record<string, string> = {}) => {
     const municipality = searchParams.geography;
-    const path = municipality
-      ? `/pesticides/analysis/${encodeURIComponent(municipality)}.json`
-      : '/pesticides/analysis/index.json';
+    const isNational = !municipality || municipality === 'country';
+    const path = isNational
+      ? '/pesticides/analysis/index.json'
+      : `/pesticides/analysis/${encodeURIComponent(municipality)}.json`;
     return fetchR2Json(path);
   },
   ['pesticide-analysis'],


### PR DESCRIPTION
## Why

An in-depth live verification of production `landbruget.dk` found visitor-facing **HTTP 500s** plus two small bugs. This PR makes the frontend resilient so a partial/missing R2 data file never surfaces as a 500, and fixes the small bugs. (Backend pipeline fix that regenerates the missing data is a separate PR.)

## What was broken (confirmed live)

- **Homepage: 11 rankings showed red "API error: 500"** — the whole **animal** (6) and **worker** (5) categories. `homepage/rankings/{animal,worker}.json` exist but contain **`null` entries** inside `rankings` (sub-rankings the exporter emits as `None`), so the cache loop crashed on `ranking.items` of null and the route 500'd for the whole category.
- **`/pesticidanalyse` main list: 500** — a path mismatch: the backend writes the national aggregate to `pesticides/analysis/index.json`, but the frontend requested `…/country.json` for `geography=country` → 404 → 500.
- **React hydration error #418** on `/` from `new Date().toLocaleDateString()` in render (also a misleading "updated today" label).
- **Mobile homepage scrolled sideways ~170px** — invalid Tailwind class `overflow` (not a utility) + an unconstrained example-company chip row.

## Changes

- `lib/server-cache.ts`: filter null/malformed entries out of homepage rankings (partial file → clean payload, missing rankings fall through to the existing empty state); national pesticide view reads `index.json`.
- `api/data/{homepage-rankings,pesticide-analysis,kommuner}/route.ts`: on a missing-file (`404`) error, return a valid **empty 200** shape instead of 500 (mirrors the existing graceful pattern in `pesticide-company-details`/`burden-histogram`).
- `components/homepage/AllRankings.tsx`: drop the render-time `new Date()` (fixes #418).
- `components/global-search.tsx` + `app/layout.tsx`: `overflow` → `overflow-hidden`, wrap/constrain the chip row, add body `overflow-x-hidden`.
- `package-lock.json`: synced with `package.json` (`typescript@5.9.3`) — required so the `oxfmt`/`oxlint` pre-commit hooks (which run `npm ci`) pass; they were broken on `main`.

## Validation

`npm run lint`, `npm run format`, and `npm run build` all green. Pre-commit Playwright smoke test passed. Ran the production build locally against **live production R2 data** and confirmed the previously-500 routes now return 200:

| Route | Before | After |
|---|---|---|
| `/api/data/homepage-rankings?category=animal` | 500 | **200** (valid rankings; null sub-rankings dropped) |
| `/api/data/homepage-rankings?category=worker` | 500 | **200** |
| `/api/data/pesticide-analysis?geography=country` | 500 | **200** with real data (1,572,790 applications, 12,876 companies) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)