### PR TITLE
fix(api_export): never emit null homepage rankings + real municipalities

### DIFF
--- a/backend/pipelines/api_export/exporters/animal.py
+++ b/backend/pipelines/api_export/exporters/animal.py
@@ -5,14 +5,35 @@ from common.logging_utils import get_pipeline_logger
 logger = get_pipeline_logger("api_export.animal")
 
 
+def create_company_municipality_lookup(conn) -> bool:
+    if "production_sites" not in _table_names(conn):
+        return False
+
+    columns = _table_columns(conn, "production_sites")
+    if not {"company_id", "municipality", "capacity"}.issubset(columns):
+        return False
+
+    conn.execute("""
+        CREATE OR REPLACE TABLE company_municipality AS
+        SELECT
+            CAST(company_id AS VARCHAR) AS cvr_number,
+            arg_max(
+                NULLIF(TRIM(CAST(municipality AS VARCHAR)), ''),
+                COALESCE(TRY_CAST(capacity AS DOUBLE), 0)
+            ) AS municipality
+        FROM production_sites
+        WHERE company_id IS NOT NULL
+          AND NULLIF(TRIM(CAST(municipality AS VARCHAR)), '') IS NOT NULL
+          AND NULLIF(TRIM(CAST(municipality AS VARCHAR)), '') <> 'Unknown'
+        GROUP BY 1
+    """)
+    return True
+
+
 def create_production_sites(conn) -> bool:
-    tables = {
-        row[0]
-        for row in conn.execute(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-        ).fetchall()
-    }
+    tables = _table_names(conn)
     if "production_sites" in tables:
+        create_company_municipality_lookup(conn)
         return True
     if "chr_properties" not in tables:
         logger.warning("Skipping production site derivation — missing chr_properties")
@@ -159,6 +180,7 @@ def create_production_sites(conn) -> bool:
         WHERE sc.company_id IS NOT NULL
           AND sc.chr IS NOT NULL
     """)
+    create_company_municipality_lookup(conn)
     return True
 
 
@@ -220,15 +242,22 @@ def site_yearly_summary_count_query(
 
 
 def create_company_animal_summary(conn) -> bool:
-    tables = {
-        row[0]
-        for row in conn.execute(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-        ).fetchall()
-    }
+    tables = _table_names(conn)
     if "companies" not in tables or "production_sites" not in tables:
         logger.warning("Skipping animal summary — missing companies or production_sites")
         return False
+
+    if "company_municipality" not in tables and create_company_municipality_lookup(conn):
+        tables.add("company_municipality")
+
+    municipality_join = ""
+    municipality_expr = "COALESCE(NULLIF(TRIM(c.current_municipality_name), ''), 'Ukendt kommune')"
+    if "company_municipality" in tables:
+        municipality_join = "LEFT JOIN company_municipality cm ON cm.cvr_number = ps.company_id"
+        municipality_expr = (
+            "COALESCE(NULLIF(TRIM(c.current_municipality_name), ''), "
+            "cm.municipality, 'Ukendt kommune')"
+        )
 
     herd_join = ""
     herd_select = "0 AS total_herds, 0 AS total_animals_registered,"
@@ -276,12 +305,13 @@ def create_company_animal_summary(conn) -> bool:
             SELECT
                 ps.company_id AS cvr_number,
                 c.company_name,
-                c.current_municipality_name AS municipality,
+                {municipality_expr} AS municipality,
                 COUNT(DISTINCT ps.chr) AS production_site_count,
                 SUM(COALESCE(ps.capacity, 0)) AS total_capacity
             FROM production_sites ps
             JOIN companies c
               ON ps.company_id = c.cvr_number::VARCHAR
+            {municipality_join}
             GROUP BY 1, 2, 3
         )
         SELECT
@@ -301,15 +331,22 @@ def create_company_animal_summary(conn) -> bool:
 
 
 def create_company_transport_summaries(conn) -> bool:
-    tables = {
-        row[0]
-        for row in conn.execute(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-        ).fetchall()
-    }
+    tables = _table_names(conn)
     if "companies" not in tables or "production_sites" not in tables:
         logger.warning("Skipping transport summaries — missing companies or production_sites")
         return False
+
+    if "company_municipality" not in tables and create_company_municipality_lookup(conn):
+        tables.add("company_municipality")
+
+    municipality_join = ""
+    municipality_expr = "COALESCE(NULLIF(TRIM(c.current_municipality_name), ''), 'Ukendt kommune')"
+    if "company_municipality" in tables:
+        municipality_join = "LEFT JOIN company_municipality cm ON cm.cvr_number = ps.company_id"
+        municipality_expr = (
+            "COALESCE(NULLIF(TRIM(c.current_municipality_name), ''), "
+            "cm.municipality, 'Ukendt kommune')"
+        )
 
     raw_queries: list[str] = []
 
@@ -339,7 +376,7 @@ def create_company_transport_summaries(conn) -> bool:
                 SELECT
                     ps.company_id AS cvr_number,
                     c.company_name,
-                    c.current_municipality_name AS municipality,
+                    {municipality_expr} AS municipality,
                     CAST(t.{species_column} AS VARCHAR) AS species_code,
                     {year_expr} AS year,
                     SUM(COALESCE(t.{animal_column}, 0)) AS transported_animals
@@ -348,6 +385,7 @@ def create_company_transport_summaries(conn) -> bool:
                   ON TRY_CAST(ps.chr AS BIGINT) = TRY_CAST(t.{sender_column} AS BIGINT)
                 JOIN companies c
                   ON ps.company_id = c.cvr_number::VARCHAR
+                {municipality_join}
                 WHERE {deleted_filter}
                   AND {year_expr} IS NOT NULL
                 GROUP BY 1, 2, 3, 4, 5
@@ -365,7 +403,7 @@ def create_company_transport_summaries(conn) -> bool:
                     SELECT
                         ps.company_id AS cvr_number,
                         c.company_name,
-                        c.current_municipality_name AS municipality,
+                        {municipality_expr} AS municipality,
                         '15' AS species_code,
                         {year_expr} AS year,
                         SUM(COALESCE(m.total_animals, 0)) AS transported_animals
@@ -374,6 +412,7 @@ def create_company_transport_summaries(conn) -> bool:
                       ON TRY_CAST(ps.chr AS BIGINT) = TRY_CAST(m.sender_chr_number AS BIGINT)
                     JOIN companies c
                       ON ps.company_id = c.cvr_number::VARCHAR
+                    {municipality_join}
                     WHERE {deleted_filter}
                       AND {year_expr} IS NOT NULL
                     GROUP BY 1, 2, 3, 4, 5
@@ -401,7 +440,7 @@ def create_company_transport_summaries(conn) -> bool:
                 SELECT
                     ps.company_id AS cvr_number,
                     c.company_name,
-                    c.current_municipality_name AS municipality,
+                    {municipality_expr} AS municipality,
                     '12' AS species_code,
                     {year_expr} AS year,
                     SUM(COALESCE(m.{animal_column}, 0)) AS transported_animals
@@ -410,6 +449,7 @@ def create_company_transport_summaries(conn) -> bool:
                   ON TRY_CAST(ps.chr AS BIGINT) = TRY_CAST(m.{sender_column} AS BIGINT)
                 JOIN companies c
                   ON ps.company_id = c.cvr_number::VARCHAR
+                {municipality_join}
                 WHERE {year_expr} IS NOT NULL
                 GROUP BY 1, 2, 3, 4, 5
             """)
@@ -452,6 +492,15 @@ def _table_columns(conn, table_name: str) -> set[str]:
         return {row[0] for row in conn.execute(f"DESCRIBE {table_name}").fetchall()}
     except Exception:
         return set()
+
+
+def _table_names(conn) -> set[str]:
+    return {
+        row[0]
+        for row in conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+        ).fetchall()
+    }
 
 
 def _movement_year_expr(columns: set[str], *, table_alias: str) -> str | None:

--- a/backend/pipelines/api_export/exporters/homepage.py
+++ b/backend/pipelines/api_export/exporters/homepage.py
@@ -29,6 +29,7 @@ from common.logging_utils import get_pipeline_logger
 
 from exporters.animal import (
     create_company_animal_summary,
+    create_company_municipality_lookup,
     create_company_transport_summaries,
     create_production_sites,
     site_yearly_summary_count_query,
@@ -1611,8 +1612,30 @@ class HomepageExporter(BaseExporter):
         if "company_id" not in production_columns:
             return False
 
+        if not self._table_exists("company_municipality"):
+            create_company_municipality_lookup(self.conn)
+
+        combined_municipality_join = ""
+        site_municipality_join = ""
+        combined_municipality_expr = (
+            "COALESCE(NULLIF(TRIM(c.current_municipality_name), ''), 'Ukendt kommune')"
+        )
+        site_municipality_expr = combined_municipality_expr
+        if self._table_exists("company_municipality"):
+            combined_municipality_join = (
+                "LEFT JOIN company_municipality cm ON cm.cvr_number = combined.cvr_number"
+            )
+            site_municipality_join = (
+                "LEFT JOIN company_municipality cm ON cm.cvr_number = ps.company_id"
+            )
+            combined_municipality_expr = (
+                "COALESCE(NULLIF(TRIM(c.current_municipality_name), ''), "
+                "cm.municipality, 'Ukendt kommune')"
+            )
+            site_municipality_expr = combined_municipality_expr
+
         if self._table_exists("herd_sizes") and "main_species_code" in production_columns:
-            self.conn.execute("""
+            self.conn.execute(f"""
                 CREATE OR REPLACE TABLE animal_species_summary AS
                 WITH site_capacity AS (
                     SELECT
@@ -1650,7 +1673,7 @@ class HomepageExporter(BaseExporter):
                 SELECT
                     combined.cvr_number,
                     c.company_name,
-                    c.current_municipality_name AS municipality,
+                    {combined_municipality_expr} AS municipality,
                     combined.species_code,
                     combined.site_capacity,
                     combined.registered_animals,
@@ -1661,16 +1684,17 @@ class HomepageExporter(BaseExporter):
                 FROM combined
                 JOIN companies c
                   ON combined.cvr_number = c.cvr_number::VARCHAR
+                {combined_municipality_join}
             """)
             return True
 
         if "main_species_code" in production_columns:
-            self.conn.execute("""
+            self.conn.execute(f"""
                 CREATE OR REPLACE TABLE animal_species_summary AS
                 SELECT
                     ps.company_id AS cvr_number,
                     c.company_name,
-                    c.current_municipality_name AS municipality,
+                    {site_municipality_expr} AS municipality,
                     CAST(ps.main_species_code AS VARCHAR) AS species_code,
                     SUM(COALESCE(ps.capacity, 0)) AS site_capacity,
                     0 AS registered_animals,
@@ -1678,6 +1702,7 @@ class HomepageExporter(BaseExporter):
                 FROM production_sites ps
                 JOIN companies c
                   ON ps.company_id = c.cvr_number::VARCHAR
+                {site_municipality_join}
                 WHERE ps.main_species_code IS NOT NULL
                 GROUP BY 1, 2, 3, 4
             """)

--- a/backend/pipelines/api_export/exporters/homepage.py
+++ b/backend/pipelines/api_export/exporters/homepage.py
@@ -93,6 +93,33 @@ class HomepageExporter(BaseExporter):
         return stats
 
     def _wrap_rankings(self, rankings: list[dict]) -> dict:
+        invalid_rankings = []
+        empty_ranking_ids = []
+
+        for index, ranking in enumerate(rankings):
+            ranking_id = ranking.get("id") if isinstance(ranking, dict) else None
+            if not isinstance(ranking, dict) or not isinstance(ranking.get("items"), list):
+                label = f"index {index}"
+                if ranking_id:
+                    label = f"{label} ({ranking_id})"
+                invalid_rankings.append(label)
+                continue
+
+            if not ranking["items"] or ranking.get("status") in {"missing", "empty", "error"}:
+                empty_ranking_ids.append(ranking.get("id", f"index {index}"))
+
+        if invalid_rankings:
+            raise ValueError(
+                "Homepage export received invalid rankings: " + ", ".join(invalid_rankings)
+            )
+
+        if empty_ranking_ids:
+            logger.warning(
+                "Homepage export: %s rankings have no data: %s",
+                len(empty_ranking_ids),
+                empty_ranking_ids,
+            )
+
         return {
             "rankings": rankings,
             "metadata": {
@@ -1668,12 +1695,19 @@ class HomepageExporter(BaseExporter):
         description: str,
         unit: str,
         format_fn: Callable,
-    ) -> dict | None:
+    ) -> dict:
         """Generate a ranking from SQL that returns cvr_number, company_name, municipality, value."""
         try:
             rows = self.query_to_dicts(sql)
             if not rows:
-                return None
+                return self._empty_ranking(
+                    id=id,
+                    title=title,
+                    category=category,
+                    description=description,
+                    unit=unit,
+                    note="No rows returned for this ranking.",
+                )
             total = self.conn.execute(count_sql).fetchone()[0]
             return {
                 "id": id,
@@ -1696,7 +1730,14 @@ class HomepageExporter(BaseExporter):
             }
         except Exception:
             logger.exception(f"Failed to generate ranking: {id}")
-            return None
+            return self._empty_ranking(
+                id=id,
+                title=title,
+                category=category,
+                description=description,
+                unit=unit,
+                note="Ranking query failed.",
+            )
 
     def _empty_ranking(
         self,

--- a/backend/pipelines/api_export/tests/test_homepage.py
+++ b/backend/pipelines/api_export/tests/test_homepage.py
@@ -157,9 +157,9 @@ def test_homepage_export_writes_audited_statistics_and_all_categories(tmp_path: 
         """
         SELECT * FROM (
             VALUES
-                ('1001', '12345678', 120, '15'),
-                ('1002', '87654321', 80, '12')
-        ) AS t(chr, company_id, capacity, main_species_code)
+                ('1001', '12345678', 'Aarhus', 120, '15'),
+                ('1002', '87654321', 'Odense', 80, '12')
+        ) AS t(chr, company_id, municipality, capacity, main_species_code)
         """,
     )
     path_map[("gold/chr", "production_sites.parquet")] = production_sites
@@ -329,6 +329,7 @@ def test_homepage_export_writes_audited_statistics_and_all_categories(tmp_path: 
         "most_transported_cattle",
     }
     assert animal_rankings["largest_pig_production"]["items"]
+    assert animal_rankings["largest_pig_production"]["items"][0]["municipality"] == "Aarhus"
     assert animal_rankings["most_transported_pigs"]["items"][0]["value"] == 250
     assert animal_rankings["most_transported_cattle"]["items"][0]["value"] == 40
 
@@ -408,6 +409,33 @@ def test_ranking_from_sql_returns_empty_ranking_for_zero_rows(tmp_path: Path) ->
     assert ranking["company_count"] == 0
     assert ranking["status"] == "missing"
     assert ranking["note"] == "No rows returned for this ranking."
+
+
+def test_animal_ranking_uses_production_site_municipality_when_company_municipality_is_null(
+    tmp_path: Path,
+) -> None:
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE companies AS
+        SELECT * FROM (
+            VALUES
+                ('12345678', 'Alpha Farm', NULL::VARCHAR)
+        ) AS t(cvr_number, company_name, current_municipality_name)
+    """)
+    conn.execute("""
+        CREATE TABLE production_sites AS
+        SELECT * FROM (
+            VALUES
+                ('1001', '12345678', 'Aarhus', 120, '15'),
+                ('1002', '12345678', 'Randers', 40, '15')
+        ) AS t(chr, company_id, municipality, capacity, main_species_code)
+    """)
+    exporter = _StubHomepageExporter(conn=conn, output_dir=str(tmp_path), path_map={})
+
+    rankings = {ranking["id"]: ranking for ranking in exporter._animal_rankings()}
+
+    assert rankings["largest_pig_production"]["items"][0]["municipality"] == "Aarhus"
+    assert rankings["most_production_sites"]["items"][0]["municipality"] == "Aarhus"
 
 
 def test_wrap_rankings_raises_for_none_ranking(tmp_path: Path) -> None:

--- a/backend/pipelines/api_export/tests/test_homepage.py
+++ b/backend/pipelines/api_export/tests/test_homepage.py
@@ -2,7 +2,9 @@ import json
 from pathlib import Path
 
 import duckdb
+import pytest
 
+from exporters import homepage as homepage_module
 from exporters.homepage import HomepageExporter
 
 
@@ -372,3 +374,92 @@ def test_homepage_export_writes_audited_statistics_and_all_categories(tmp_path: 
     categories = {ranking["category"] for ranking in all_payload["rankings"]}
     assert categories == {"financial", "field", "environment", "worker", "animal"}
     assert len(all_payload["rankings"]) == 26
+
+
+def test_ranking_from_sql_returns_empty_ranking_for_zero_rows(tmp_path: Path) -> None:
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE empty_companies (
+            cvr_number VARCHAR,
+            company_name VARCHAR,
+            municipality VARCHAR,
+            value DOUBLE
+        )
+    """)
+    exporter = _StubHomepageExporter(conn=conn, output_dir=str(tmp_path), path_map={})
+
+    ranking = exporter._ranking_from_sql(
+        sql="""
+            SELECT cvr_number, company_name, municipality, value
+            FROM empty_companies
+            WHERE false
+        """,
+        count_sql="SELECT count(*) FROM empty_companies",
+        id="empty_test_ranking",
+        title="Empty test ranking",
+        category="test",
+        description="A ranking with no rows.",
+        unit="companies",
+        format_fn=str,
+    )
+
+    assert isinstance(ranking, dict)
+    assert ranking["items"] == []
+    assert ranking["company_count"] == 0
+    assert ranking["status"] == "missing"
+    assert ranking["note"] == "No rows returned for this ranking."
+
+
+def test_wrap_rankings_raises_for_none_ranking(tmp_path: Path) -> None:
+    exporter = _StubHomepageExporter(
+        conn=duckdb.connect(":memory:"),
+        output_dir=str(tmp_path),
+        path_map={},
+    )
+
+    with pytest.raises(ValueError, match="index 1"):
+        exporter._wrap_rankings(
+            [
+                {
+                    "id": "valid",
+                    "items": [],
+                },
+                None,
+            ]
+        )
+
+
+def test_wrap_rankings_accepts_valid_rankings_and_warns_for_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exporter = _StubHomepageExporter(
+        conn=duckdb.connect(":memory:"),
+        output_dir=str(tmp_path),
+        path_map={},
+    )
+    rankings = [
+        {
+            "id": "populated",
+            "items": [{"rank": 1, "value": 10}],
+        },
+        {
+            "id": "missing",
+            "items": [],
+            "status": "missing",
+        },
+    ]
+    warning_calls = []
+    monkeypatch.setattr(homepage_module.logger, "warning", lambda *args: warning_calls.append(args))
+
+    payload = exporter._wrap_rankings(rankings)
+
+    assert payload["rankings"] == rankings
+    assert payload["metadata"]["total_tables"] == 2
+    assert warning_calls == [
+        (
+            "Homepage export: %s rankings have no data: %s",
+            1,
+            ["missing"],
+        )
+    ]


### PR DESCRIPTION
Two related correctness fixes for the homepage rankings (the backend half; the frontend resilience PR is #1300). Diagnosed against live production R2 data.

## 1. Never emit null rankings (the 500 root cause)
`_ranking_from_sql` returned `None` on zero-rows/exception, and callers appended it directly — so `homepage/rankings/{animal,worker}.json` shipped `null` entries that crashed the frontend (HTTP 500 for the whole category).
- `_ranking_from_sql` now always returns a well-formed empty ranking (via `_empty_ranking`).
- `_wrap_rankings` raises on any invalid/None entry (hard CI failure instead of silent corruption) and logs a warning listing empty/missing rankings.

## 2. Real municipalities (data quality)
Every animal ranking row showed `municipality: "Unknown"` because `companies.current_municipality_name` is **null/empty for all 78,302 companies**. The real municipality lives in `production_sites.municipality` (**100% populated** — Varde, Herning, København…).
- New `company_municipality` lookup = each company's largest-capacity production site municipality.
- COALESCE'd into `create_company_animal_summary`, `create_company_transport_summaries`, and `_prepare_animal_species_summary` (resilient: only joins if the lookup exists).

**Verified against production R2:** `animal_species_summary` went from **4,727/4,727 null-or-"Unknown"** municipalities to **0** — e.g. Prima Svin A/S → Ringkøbing-Skjern, FHM Slagtegrise A/S → Billund.

## Why this matters
A diagnostic against R2 showed **9 of the 11 "broken" rankings already have real data** (pig 703, cattle 1,748, antibiotics/sites 4,681, pig transport 663, foreign workers 8,688, injuries 1,245, inspections 643×2) — they were only hidden by the null-crash. With this PR + #1300 deployed and `api_export` re-run, they populate with real data **and** real municipalities.

## Known gaps (NOT fixed here — flagged)
- `most_transported_cattle`: `cattle_movements` (353k rows) exists but `chr_transportation_analysis` is pig-only; wiring cattle in correctly needs `movement_type` semantics decided deliberately (data accuracy).
- `most_employees_worker`: `silver/cvr_employment` is **empty (0 rows)** — an upstream employment-source gap.

## Tests / checks
```
uv run --frozen --package api-export pytest backend/pipelines/api_export/tests/ -q   # 22 passed
uvx ruff check / format --check  # clean
```
> The documented `uv run --all-packages --group dev pytest` currently fails to resolve on `main` (unrelated `arbejdstilsynet-inspections` dep wants `pytest>=9.1.1`); use `--frozen --package api-export`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)