### PR TITLE
fix(ci): harden data pipeline actions

### DIFF
--- a/.github/workflows/fvm_wfs_matrix_download.yml
+++ b/.github/workflows/fvm_wfs_matrix_download.yml
@@ -84,28 +84,39 @@ jobs:
           capabilities_url = (
               f"{wfs_url}?service=WFS&version=2.0.0&request=GetCapabilities"
           )
+          fallback_dynamic_years = {
+              "markblokke": list(range(2005, 2027)),
+              "marker": list(range(2008, 2027)),
+              "smaabiotoper": [2023, 2024, 2025, 2026],
+          }
           try:
               with urllib.request.urlopen(capabilities_url, timeout=30) as response:
                   capabilities_xml = response.read().decode("utf-8", errors="ignore")
           except Exception as exc:  # noqa: BLE001
-              raise SystemExit(f"Failed to fetch WFS capabilities from {wfs_url}: {exc}") from exc
-
-          dynamic_years = {
-              "markblokke": sorted(
-                  {int(year) for year in re.findall(r"\bMarkblokke:Markblokke_(\d{4})\b", capabilities_xml)}
-              ),
-              "marker": sorted(
-                  {int(year) for year in re.findall(r"\bMarker:Marker_(\d{4})\b", capabilities_xml)}
-              ),
-              "smaabiotoper": sorted(
-                  {int(year) for year in re.findall(r"\bMarker:Smaabiotoper_(\d{4})\b", capabilities_xml)}
-              ),
-          }
-          for layer_name in ("markblokke", "marker", "smaabiotoper"):
-              if layer_name in layer_types and not dynamic_years[layer_name]:
-                  raise SystemExit(
-                      f"Live year discovery failed for required layer '{layer_name}' from {wfs_url}"
-                  )
+              print(
+                  f"Warning: failed to fetch WFS capabilities from {wfs_url}; "
+                  f"using configured fallback years: {exc}"
+              )
+              dynamic_years = fallback_dynamic_years
+          else:
+              dynamic_years = {
+                  "markblokke": sorted(
+                      {int(year) for year in re.findall(r"\bMarkblokke:Markblokke_(\d{4})\b", capabilities_xml)}
+                  ),
+                  "marker": sorted(
+                      {int(year) for year in re.findall(r"\bMarker:Marker_(\d{4})\b", capabilities_xml)}
+                  ),
+                  "smaabiotoper": sorted(
+                      {int(year) for year in re.findall(r"\bMarker:Smaabiotoper_(\d{4})\b", capabilities_xml)}
+                  ),
+              }
+              for layer_name in ("markblokke", "marker", "smaabiotoper"):
+                  if layer_name in layer_types and not dynamic_years[layer_name]:
+                      print(
+                          f"Warning: live year discovery returned no {layer_name} years; "
+                          "using configured fallback years"
+                      )
+                      dynamic_years[layer_name] = fallback_dynamic_years[layer_name]
 
           print("Discovered dynamic year ranges:")
           for layer_name, years in dynamic_years.items():

--- a/backend/pipelines/arbejdstilsynet_inspections/bronze/export.py
+++ b/backend/pipelines/arbejdstilsynet_inspections/bronze/export.py
@@ -21,6 +21,7 @@ except ImportError:
     logging.warning("⚠️  Pipeline metadata system not available - continuing without metadata")
     MetadataManager = None
     METADATA_AVAILABLE = False
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from playwright.async_api import async_playwright
 
 # Load environment variables from .env file
@@ -271,7 +272,13 @@ class BronzePipeline:
                 page.on("crash", lambda: logging.error("Browser page crashed"))
                 page.on("pageerror", lambda error: logging.error(f"Page error: {error}"))
 
-                await page.goto(self.source_url, wait_until="networkidle", timeout=120000)
+                await page.goto(self.source_url, wait_until="domcontentloaded", timeout=120000)
+                try:
+                    await page.wait_for_load_state("load", timeout=60000)
+                except PlaywrightTimeoutError:
+                    logging.warning(
+                        "PowerBI page did not reach load state; continuing after DOM load"
+                    )
                 await page.wait_for_timeout(5000)
 
                 await page.wait_for_selector(

--- a/backend/pipelines/bbr_buildings/bronze/bulk_geodanmark_graphql_fetcher.py
+++ b/backend/pipelines/bbr_buildings/bronze/bulk_geodanmark_graphql_fetcher.py
@@ -8,7 +8,7 @@ Replaces the WFS-based BulkGeoDanmarkFetcher since the WFS endpoint
 (wfs.datafordeler.dk/GeoDanmarkVektor/...) is no longer working.
 
 GraphQL API details:
-  - Endpoint: https://graphql.datafordeler.dk/GEODKV/v1?apiKey=<key>
+  - Endpoint: https://graphql.datafordeler.dk/GEODKV/v2?apiKey=<key>
   - Entity: GEODKV_Bygning (37 fields)
   - Geometry: SpatialPolygonZEpsg25832Type → { wkt } returns WKT POLYGON Z(...)
   - Pagination: cursor-based, first (max 1000) + after
@@ -85,9 +85,13 @@ _COMBINE_COLUMNS = [c for c in BUILDING_COLUMNS if c != "geometri_wkt"]
 
 
 class BulkGeoDanmarkGraphQLFetcher:
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, endpoint_base: str | None = None) -> None:
         self.api_key = api_key
-        self.endpoint = f"https://graphql.datafordeler.dk/GEODKV/v1?apiKey={api_key}"
+        self.endpoint_base = (
+            endpoint_base
+            or os.getenv("GEODKV_GRAPHQL_ENDPOINT")
+            or "https://graphql.datafordeler.dk/GEODKV/v2"
+        )
         self.session = self._create_session()
         self.output_dir = Path("data")
         self.output_dir.mkdir(exist_ok=True)
@@ -113,12 +117,14 @@ class BulkGeoDanmarkGraphQLFetcher:
     def _graphql_query(self, query: str) -> dict:
         """Execute a GraphQL query with error handling."""
         resp = self.session.post(
-            self.endpoint,
+            self.endpoint_base,
+            params={"apiKey": self.api_key},
             headers={"Content-Type": "application/json; charset=utf-8"},
             json={"query": query},
             timeout=120,
         )
-        resp.raise_for_status()
+        if not resp.ok:
+            raise RuntimeError(f"GraphQL request failed: HTTP {resp.status_code}")
         data = resp.json()
         if "errors" in data:
             error_msgs = [e.get("message", "?") for e in data["errors"]]
@@ -224,19 +230,35 @@ class BulkGeoDanmarkGraphQLFetcher:
             while True:
                 progress_bar.set_description(f"Page {page_num + 1} (total: {total_buildings:,})")
 
-                try:
-                    nodes, has_next, end_cursor = self.fetch_buildings_page(cursor)
-                except Exception as e:
-                    logger.error(f"Failed to fetch page {page_num + 1}: {e}")
-                    # Retry once after a pause
-                    time.sleep(5)
+                max_page_retries = 5
+                last_fetch_error = None
+                for attempt in range(1, max_page_retries + 1):
                     try:
                         nodes, has_next, end_cursor = self.fetch_buildings_page(cursor)
-                    except Exception as e2:
-                        logger.error(f"Retry also failed: {e2}, stopping")
+                        last_fetch_error = None
                         break
+                    except Exception as e:
+                        last_fetch_error = e
+                        if attempt == max_page_retries:
+                            break
+                        wait = min(60, 5 * attempt)
+                        logger.warning(
+                            f"Failed to fetch page {page_num + 1} "
+                            f"(attempt {attempt}/{max_page_retries}): {e}. "
+                            f"Retrying in {wait}s..."
+                        )
+                        time.sleep(wait)
+                else:
+                    nodes, has_next, end_cursor = [], False, None
+
+                if last_fetch_error is not None:
+                    raise RuntimeError(
+                        f"Failed to fetch page {page_num + 1} after {max_page_retries} attempts"
+                    ) from last_fetch_error
 
                 if not nodes:
+                    if page_num == 0 and total_buildings == 0:
+                        raise RuntimeError("GraphQL API returned no buildings on the first page")
                     logger.info("No more buildings — reached end of dataset")
                     break
 
@@ -339,8 +361,7 @@ class BulkGeoDanmarkGraphQLFetcher:
         intermediate_files = sorted(self.output_dir.glob("geodanmark_buildings_batch_*.geoparquet"))
 
         if not intermediate_files:
-            logger.warning("No intermediate files found")
-            return
+            raise RuntimeError("No intermediate GeoDanmark files were produced")
 
         logger.info(f"Validating {len(intermediate_files)} intermediate files")
 

--- a/backend/pipelines/bbr_buildings/bronze/graphql_datafordeler_poc.py
+++ b/backend/pipelines/bbr_buildings/bronze/graphql_datafordeler_poc.py
@@ -23,7 +23,7 @@ BBR_Bygning (94 fields):
   - Full list: see .context/BBR_schema.graphql
 
 API details:
-  - Endpoints: https://graphql.datafordeler.dk/{GEODKV,BBR}/v1?apiKey=<key>
+  - Endpoints: https://graphql.datafordeler.dk/{GEODKV,BBR}/v2?apiKey=<key>
   - Auth: API key + IP whitelisting required
   - Pagination: cursor-based, first (max 1000) + after
   - Bitemporal: registreringstid required (or id_lokalId filter)
@@ -46,8 +46,8 @@ if not API_KEY and __name__ == "__main__":
     print("ERROR: Set DATAFORDELER_GRAPHQL_API_KEY environment variable")
     sys.exit(1)
 
-GEODKV_URL = f"https://graphql.datafordeler.dk/GEODKV/v1?apiKey={API_KEY}"
-BBR_URL = f"https://graphql.datafordeler.dk/BBR/v1?apiKey={API_KEY}"
+GEODKV_URL = f"https://graphql.datafordeler.dk/GEODKV/v2?apiKey={API_KEY}"
+BBR_URL = f"https://graphql.datafordeler.dk/BBR/v2?apiKey={API_KEY}"
 
 NOW = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 

--- a/backend/pipelines/bbr_buildings/bronze/inspire_bbr_fetcher.py
+++ b/backend/pipelines/bbr_buildings/bronze/inspire_bbr_fetcher.py
@@ -547,10 +547,7 @@ class InspireBBRFetcher:
         """
         Query GraphQL API to get BBR usage codes for building UUIDs using proper batch queries.
         """
-        graphql_url = (
-            f"https://graphql.datafordeler.dk/BBR/v1?"
-            f"apikey={self.settings.datafordeler_graphql_api_key}"
-        )
+        graphql_url = self.settings.bbr_graphql_endpoint
 
         all_results = []
         total_batches = (len(uuids) + batch_size - 1) // batch_size
@@ -602,6 +599,7 @@ class InspireBBRFetcher:
                 try:
                     response = requests.post(
                         graphql_url,
+                        params={"apiKey": self.settings.datafordeler_graphql_api_key},
                         headers={"Content-Type": "application/json"},
                         json={"query": batch_query},
                         timeout=60,  # Longer timeout for batch queries
@@ -750,13 +748,13 @@ class InspireBBRFetcher:
         """
         self.logger.info(f"Parsing FTP page: {self.settings.sdfe_ftp_base_url}")
 
-        max_retries = 3
-        retry_delays = [10, 30, 60]
+        max_retries = 5
+        retry_delays = [10, 30, 60, 120]
         last_error = None
 
         for attempt in range(max_retries):
             try:
-                response = self.session.get(self.settings.sdfe_ftp_base_url, timeout=60)
+                response = self.session.get(self.settings.sdfe_ftp_base_url, timeout=180)
                 response.raise_for_status()
                 break
             except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
@@ -887,48 +885,64 @@ class InspireBBRFetcher:
         self.logger.info(f"Downloading file from {url} to {output_path}")
 
         try:
-            with self.session.get(url, stream=True, timeout=60) as response:
-                response.raise_for_status()
-
-                # Get file size from headers if available
-                content_length = response.headers.get("content-length")
-                if content_length:
-                    file_size = int(content_length)
-                    self.logger.info(f"File size: {file_size / (1024**2):.2f} MB")
-
-                    # Validate against expected size if provided
-                    if expected_size and abs(file_size - expected_size) > (
-                        expected_size * 0.05
-                    ):  # 5% tolerance
-                        self.logger.warning(
-                            f"File size mismatch: expected {expected_size}, got {file_size}"
-                        )
-                else:
-                    file_size = None
-
-                # Initialize tqdm progress bar
-                progress_bar = tqdm(
-                    total=file_size,
-                    unit="B",
-                    unit_scale=True,
-                    unit_divisor=1024,
-                    desc="Downloading INSPIRE BBR",
-                    ncols=80,
-                    disable=False,  # Always show progress for downloads
-                )
-
-                downloaded = 0
+            max_retries = 5
+            retry_delays = [10, 30, 60, 120]
+            for attempt in range(max_retries):
                 try:
-                    with open(output_path, "wb") as f:
-                        for chunk in response.iter_content(chunk_size=8192):
-                            if chunk:
-                                f.write(chunk)
-                                downloaded += len(chunk)
-                                progress_bar.update(len(chunk))
-                finally:
-                    progress_bar.close()
+                    with self.session.get(url, stream=True, timeout=180) as response:
+                        response.raise_for_status()
 
-                self.logger.info(f"Download completed: {downloaded / (1024**2):.2f} MB")
+                        # Get file size from headers if available
+                        content_length = response.headers.get("content-length")
+                        if content_length:
+                            file_size = int(content_length)
+                            self.logger.info(f"File size: {file_size / (1024**2):.2f} MB")
+
+                            # Validate against expected size if provided
+                            if expected_size and abs(file_size - expected_size) > (
+                                expected_size * 0.05
+                            ):  # 5% tolerance
+                                self.logger.warning(
+                                    f"File size mismatch: expected {expected_size}, got {file_size}"
+                                )
+                        else:
+                            file_size = None
+
+                        # Initialize tqdm progress bar
+                        progress_bar = tqdm(
+                            total=file_size,
+                            unit="B",
+                            unit_scale=True,
+                            unit_divisor=1024,
+                            desc="Downloading INSPIRE BBR",
+                            ncols=80,
+                            disable=False,  # Always show progress for downloads
+                        )
+
+                        downloaded = 0
+                        try:
+                            with open(output_path, "wb") as f:
+                                for chunk in response.iter_content(chunk_size=8192):
+                                    if chunk:
+                                        f.write(chunk)
+                                        downloaded += len(chunk)
+                                        progress_bar.update(len(chunk))
+                        finally:
+                            progress_bar.close()
+
+                        self.logger.info(f"Download completed: {downloaded / (1024**2):.2f} MB")
+                        return
+                except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                    if output_path.exists():
+                        output_path.unlink()
+                    if attempt == max_retries - 1:
+                        raise
+                    delay = retry_delays[attempt]
+                    self.logger.warning(
+                        f"Download attempt {attempt + 1}/{max_retries} failed: {e}. "
+                        f"Retrying in {delay}s..."
+                    )
+                    time.sleep(delay)
 
         except Exception as e:
             if output_path.exists():

--- a/backend/pipelines/bbr_buildings/config/settings.py
+++ b/backend/pipelines/bbr_buildings/config/settings.py
@@ -41,11 +41,11 @@ class Settings:
         # Datafordeleren GraphQL endpoints (replaces broken WFS)
         self.geodkv_graphql_endpoint = os.getenv(
             "GEODKV_GRAPHQL_ENDPOINT",
-            "https://graphql.datafordeler.dk/GEODKV/v1",
+            "https://graphql.datafordeler.dk/GEODKV/v2",
         )
         self.bbr_graphql_endpoint = os.getenv(
             "BBR_GRAPHQL_ENDPOINT",
-            "https://graphql.datafordeler.dk/BBR/v1",
+            "https://graphql.datafordeler.dk/BBR/v2",
         )
 
         # Cloud Storage

--- a/backend/pipelines/bbr_buildings/tests/test_graphql_fetcher.py
+++ b/backend/pipelines/bbr_buildings/tests/test_graphql_fetcher.py
@@ -16,7 +16,7 @@ def fetcher(tmp_path, monkeypatch):
     monkeypatch.setattr(BulkGeoDanmarkGraphQLFetcher, "__init__", lambda self, api_key: None)
     f = BulkGeoDanmarkGraphQLFetcher.__new__(BulkGeoDanmarkGraphQLFetcher)
     f.api_key = "test"
-    f.endpoint = "https://example.com"
+    f.endpoint_base = "https://example.com"
     f.output_dir = tmp_path
     f.conn = duckdb.connect()
     f.conn.execute("INSTALL spatial")
@@ -73,8 +73,8 @@ class TestCombineIntermediateFiles:
             fetcher._combine_intermediate_files()
 
     def test_no_intermediate_files(self, fetcher):
-        # Should return without error
-        fetcher._combine_intermediate_files()
+        with pytest.raises(RuntimeError, match="No intermediate GeoDanmark files were produced"):
+            fetcher._combine_intermediate_files()
 
     def test_cleans_up_all_files_including_skipped(self, fetcher):
         _create_valid_parquet(fetcher, "geodanmark_buildings_batch_0000.geoparquet")
@@ -155,6 +155,37 @@ class TestSaveIntermediateResults:
 
         # Restore real conn so __del__ doesn't error
         fetcher.conn = original_conn
+
+
+class TestGraphQLRequest:
+    def test_http_error_does_not_expose_api_key(self):
+        fetcher = BulkGeoDanmarkGraphQLFetcher.__new__(BulkGeoDanmarkGraphQLFetcher)
+        sentinel = "sentinel-value-123"
+        fetcher.api_key = sentinel
+        fetcher.endpoint_base = "https://example.com/graphql"
+
+        class FakeResponse:
+            ok = False
+            status_code = 404
+
+            def json(self):
+                return {}
+
+        class FakeSession:
+            last_params = None
+
+            def post(self, *_args, **kwargs):
+                self.last_params = kwargs.get("params")
+                return FakeResponse()
+
+        session = FakeSession()
+        fetcher.session = session
+
+        with pytest.raises(RuntimeError, match="HTTP 404") as exc_info:
+            fetcher._graphql_query("{ __typename }")
+
+        assert session.last_params == {"apiKey": sentinel}
+        assert sentinel not in str(exc_info.value)
 
 
 class TestSchemaConsistency:

--- a/backend/pipelines/bmd_scraper/bronze/export.py
+++ b/backend/pipelines/bmd_scraper/bronze/export.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from datetime import datetime
 
 import requests
@@ -34,6 +35,9 @@ OptimizedStorageAccess = _get_optimized_storage_access()
 
 
 class BMDScraper:
+    REQUEST_TIMEOUT = (30, 180)
+    REQUEST_RETRIES = 3
+
     def __init__(self, base_url="https://bmd.mst.dk", output_dir="data"):
         self.base_url = base_url
         self.output_dir = output_dir
@@ -43,6 +47,31 @@ class BMDScraper:
 
         # Create output directory if it doesn't exist
         os.makedirs(output_dir, exist_ok=True)
+
+    def _request_with_retries(self, method, url, **kwargs):
+        """Run a BMD HTTP request with bounded timeout and retry on transient failures."""
+        kwargs.setdefault("timeout", self.REQUEST_TIMEOUT)
+        last_error = None
+        for attempt in range(1, self.REQUEST_RETRIES + 1):
+            try:
+                response = self.session.request(method, url, **kwargs)
+                if response.status_code in {500, 502, 503, 504}:
+                    response.raise_for_status()
+                return response
+            except (requests.ConnectionError, requests.HTTPError, requests.Timeout) as exc:
+                last_error = exc
+                if attempt == self.REQUEST_RETRIES:
+                    break
+                sleep_seconds = 5 * attempt
+                logging.warning(
+                    "BMD request failed on attempt %s/%s (%s); retrying in %ss",
+                    attempt,
+                    self.REQUEST_RETRIES,
+                    exc,
+                    sleep_seconds,
+                )
+                time.sleep(sleep_seconds)
+        raise RuntimeError("BMD request failed without an exception") from last_error
 
     def get_verification_token(self) -> str | None:
         """Get the __RequestVerificationToken from the export dialog."""
@@ -68,7 +97,7 @@ class BMDScraper:
         }
 
         logging.info("Requesting export dialog to get verification token...")
-        response = self.session.get(url, params=params)
+        response = self._request_with_retries("GET", url, params=params)
 
         if response.status_code != 200:
             logging.error(f"Failed to get export dialog: {response.status_code}")
@@ -114,7 +143,7 @@ class BMDScraper:
         }
 
         logging.info("Requesting document generation...")
-        response = self.session.post(url, data=form_data)
+        response = self._request_with_retries("POST", url, data=form_data)
 
         if response.status_code != 200:
             logging.error(f"Failed to generate document: {response.status_code}")
@@ -142,7 +171,7 @@ class BMDScraper:
         full_url = f"{self.base_url}{download_url}"
 
         logging.info(f"Downloading file from {full_url}...")
-        response = self.session.get(full_url, stream=True)
+        response = self._request_with_retries("GET", full_url, stream=True)
 
         if response.status_code != 200:
             logging.error(f"Failed to download file: {response.status_code}")

--- a/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
+++ b/backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh
@@ -82,7 +82,7 @@ pip3 install uv
 
 # Install required Python packages
 log_with_timestamp "Installing Python packages (ijson, pyarrow, geopandas, etc.)..."
-uv pip install google-cloud-storage google-cloud-secret-manager paramiko ijson pyarrow geopandas shapely pyproj
+uv pip install google-cloud-storage google-cloud-secret-manager "paramiko<4" ijson pyarrow geopandas shapely pyproj
 
 log_with_timestamp "✅ Python packages installed"
 check_resources

--- a/backend/pipelines/property_owners_sftp/sftp-transfer-startup.sh
+++ b/backend/pipelines/property_owners_sftp/sftp-transfer-startup.sh
@@ -22,7 +22,7 @@ source /opt/transfer-env/bin/activate
 pip3 install uv
 
 # Install required Python packages
-uv pip install --system google-cloud-storage google-cloud-secret-manager paramiko
+uv pip install --system google-cloud-storage google-cloud-secret-manager "paramiko<4"
 
 # Create the transfer script
 cat > /opt/transfer_script.py << 'EOF'

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/fvm_wfs.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/fvm_wfs.py
@@ -17,6 +17,7 @@ The data is fetched using WFS GetFeature requests for each year's layer,
 with proper error handling and retry logic for robustness.
 """
 
+import logging
 import ssl
 from asyncio import Semaphore
 from typing import ClassVar
@@ -28,8 +29,13 @@ from pydantic import ConfigDict
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from unified_pipeline.common.base import BaseJobConfig, BaseSource, BronzeJobInterface
-from unified_pipeline.util.fvm_wfs_year_discovery import discover_fvm_layer_years
+from unified_pipeline.util.fvm_wfs_year_discovery import (
+    FVMWFSYearDiscoveryError,
+    discover_fvm_layer_years,
+)
 from unified_pipeline.util.timing import AsyncTimer
+
+logger = logging.getLogger(__name__)
 
 
 class FVMWFSBronzeConfig(BaseJobConfig):
@@ -130,7 +136,29 @@ class FVMWFSBronzeConfig(BaseJobConfig):
         """
         Discover live year ranges from WFS capabilities and apply required layers.
         """
-        discovered_years = discover_fvm_layer_years(self.wfs_url)
+        fallback_years = {
+            "markblokke": list(self.markblokke_years),
+            "marker": list(self.marker_years),
+            "smaabiotoper": list(self.smaabiotoper_years),
+        }
+        try:
+            discovered_years = discover_fvm_layer_years(self.wfs_url)
+        except FVMWFSYearDiscoveryError as exc:
+            logger.warning(
+                "FVM WFS live year discovery failed for %s; using configured fallback years: %s",
+                self.wfs_url,
+                exc,
+            )
+            discovered_years = fallback_years
+        else:
+            for layer_name, fallback in fallback_years.items():
+                if not discovered_years[layer_name]:
+                    logger.warning(
+                        "FVM WFS live year discovery returned no %s years; "
+                        "using configured fallback years",
+                        layer_name,
+                    )
+                    discovered_years[layer_name] = fallback
 
         required_layers = {
             "markblokke": require_markblokke,

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/jordbrugsanalyser.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/jordbrugsanalyser.py
@@ -186,6 +186,40 @@ class JordbrugsanalyserBronze(BaseSource[JordbrugsanalyserBronzeConfig], BronzeJ
 
         return params
 
+    def _decode_response_content(self, content_bytes: bytes) -> str:
+        """Decode WFS response bytes while preserving Danish characters."""
+        try:
+            return content_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            return content_bytes.decode("latin-1")
+
+    def _parse_valid_wfs_response(
+        self, content: str, layer_name: str, request_description: str
+    ) -> ET.Element:
+        """Parse and validate a WFS XML response before storing it."""
+        try:
+            root = ET.fromstring(content)
+        except ET.ParseError as exc:
+            snippet = content[:300].replace("\n", " ")
+            raise ValueError(
+                f"Invalid XML response for {layer_name} ({request_description}): {snippet}"
+            ) from exc
+
+        if root.tag.endswith("ExceptionReport"):
+            exception_text = " ".join(root.itertext()).strip()
+            raise ValueError(
+                f"WFS exception for {layer_name} ({request_description}): {exception_text[:500]}"
+            )
+
+        if not root.tag.endswith("FeatureCollection"):
+            snippet = content[:300].replace("\n", " ")
+            raise ValueError(
+                f"Unexpected WFS response root {root.tag!r} for {layer_name} "
+                f"({request_description}): {snippet}"
+            )
+
+        return root
+
     async def _get_total_count(self, session: aiohttp.ClientSession, layer_name: str) -> int:
         """
         Get total number of features available for a specific layer.
@@ -214,12 +248,8 @@ class JordbrugsanalyserBronze(BaseSource[JordbrugsanalyserBronzeConfig], BronzeJ
                 if response.status == 200:
                     # Handle Danish characters properly by reading as bytes first
                     content_bytes = await response.read()
-                    try:
-                        content = content_bytes.decode("utf-8")
-                    except UnicodeDecodeError:
-                        # Fallback to latin-1 for Danish characters
-                        content = content_bytes.decode("latin-1")
-                    root = ET.fromstring(content)
+                    content = self._decode_response_content(content_bytes)
+                    root = self._parse_valid_wfs_response(content, layer_name, "count request")
 
                     # Parse numberMatched from WFS response
                     number_matched = root.get("numberMatched", "0")
@@ -293,17 +323,8 @@ class JordbrugsanalyserBronze(BaseSource[JordbrugsanalyserBronzeConfig], BronzeJ
                 if response.status == 200:
                     # Handle Danish characters properly by reading as bytes first
                     content_bytes = await response.read()
-                    try:
-                        content = content_bytes.decode("utf-8")
-                    except UnicodeDecodeError:
-                        # Fallback to latin-1 for Danish characters
-                        content = content_bytes.decode("latin-1")
-
-                    # Basic validation - check if we got a valid WFS response
-                    if "wfs:FeatureCollection" not in content:
-                        raise Exception(
-                            f"Invalid WFS response for {layer_name} ({request_type.lower()})"
-                        )
+                    content = self._decode_response_content(content_bytes)
+                    self._parse_valid_wfs_response(content, layer_name, request_type.lower())
 
                     return content
                 # Handle encoding for error messages too

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/kemidata_surface_water.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/kemidata_surface_water.py
@@ -234,6 +234,8 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
         cloud_file: Any,
         batch_idx: int,
         attempt: int,
+        *,
+        skip_header: bool,
     ) -> int:
         """Download a single batch of parameters as CSV, appending to cloud_file."""
         async with session.post(
@@ -252,7 +254,7 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
             is_first_line = True
             async for chunk in resp.content.iter_chunked(8 * 1024 * 1024):
                 # Skip CSV header line for batches after the first
-                if batch_idx > 1 and is_first_line:
+                if skip_header and is_first_line:
                     newline_pos = chunk.find(b"\n")
                     if newline_pos >= 0:
                         chunk = chunk[newline_pos + 1 :]
@@ -273,12 +275,19 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
         cloud_file: Any,
         batch_counter: int,
         max_retries: int,
+        *,
+        skip_header: bool,
     ) -> int:
         """Try downloading a batch with retries on transient errors."""
         for attempt in range(1, max_retries + 1):
             try:
                 return await self._download_single_batch(
-                    session, body, cloud_file, batch_counter, attempt
+                    session,
+                    body,
+                    cloud_file,
+                    batch_counter,
+                    attempt,
+                    skip_header=skip_header,
                 )
             except Exception:
                 if attempt == max_retries:
@@ -291,6 +300,17 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
                 await asyncio.sleep(wait)
         return 0  # unreachable, but satisfies type checker
 
+    def _should_split_download_error(self, exc: Exception) -> bool:
+        """Return true when a failed Kemidata download may succeed in smaller slices."""
+        text = str(exc).lower()
+        return (
+            "200000 records" in text
+            or "http 500" in text
+            or "request timed out" in text
+            or "timed out" in text
+            or "timeout" in text
+        )
+
     async def _download_by_date_range(
         self,
         session: aiohttp.ClientSession,
@@ -298,6 +318,8 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
         params: list[dict],
         cloud_file: Any,
         batch_counter: int,
+        *,
+        has_existing_content: bool,
     ) -> int:
         """
         Download a parameter that exceeds 200k records by splitting into yearly date ranges.
@@ -315,6 +337,7 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
             start = end + 1
 
         total_bytes = 0
+        has_written_content = has_existing_content
         for win_idx, (from_date, to_date) in enumerate(windows, 1):
             self.log.info(f"      Date range {win_idx}/{len(windows)}: {from_date} to {to_date}")
             body = self._build_download_body(session_id, params)
@@ -325,15 +348,22 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
             }
             try:
                 win_bytes = await self._download_batch_with_retry(
-                    session, body, cloud_file, batch_counter + win_idx, 3
+                    session,
+                    body,
+                    cloud_file,
+                    batch_counter + win_idx,
+                    3,
+                    skip_header=has_written_content,
                 )
                 total_bytes += win_bytes
+                if win_bytes > 0:
+                    has_written_content = True
             except Exception as win_exc:
-                if "200000 records" not in str(win_exc):
+                if not self._should_split_download_error(win_exc):
                     raise
-                # Even 5-year window too big — split into individual years
+                # Even 5-year window too big or timed out — split into individual years
                 self.log.warning(
-                    f"      Window {from_date}–{to_date} still exceeds 200k, "
+                    f"      Window {from_date}–{to_date} failed for a splittable reason, "
                     f"splitting into individual years..."
                 )
                 y_start = int(from_date[:4])
@@ -347,9 +377,16 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
                     }
                     self.log.info(f"        Year {year}")
                     yr_bytes = await self._download_batch_with_retry(
-                        session, yr_body, cloud_file, batch_counter + year, 3
+                        session,
+                        yr_body,
+                        cloud_file,
+                        batch_counter + year,
+                        3,
+                        skip_header=has_written_content,
                     )
                     total_bytes += yr_bytes
+                    if yr_bytes > 0:
+                        has_written_content = True
 
         return total_bytes
 
@@ -403,25 +440,36 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
 
                     try:
                         batch_bytes = await self._download_batch_with_retry(
-                            session, body, tmp, batch_counter, max_retries
+                            session,
+                            body,
+                            tmp,
+                            batch_counter,
+                            max_retries,
+                            skip_header=total_bytes > 0,
                         )
                         total_bytes += batch_bytes
                     except Exception as exc:
-                        if "200000 records" not in str(exc):
+                        if not self._should_split_download_error(exc):
                             raise
                         if len(batch) <= 1:
-                            # Single param exceeds 200k — split by date range
+                            # Single param exceeds 200k or times out — split by date range
                             self.log.warning(
-                                "  Single parameter exceeds 200k limit, splitting by date range..."
+                                "  Single parameter failed for a splittable reason, "
+                                "splitting by date range..."
                             )
                             sub_bytes = await self._download_by_date_range(
-                                session, session_id, batch, tmp, batch_counter
+                                session,
+                                session_id,
+                                batch,
+                                tmp,
+                                batch_counter,
+                                has_existing_content=total_bytes > 0,
                             )
                             total_bytes += sub_bytes
                         else:
-                            # Batch exceeds 200k — split into individual params
+                            # Batch exceeds 200k or times out — split into individual params
                             self.log.warning(
-                                f"  Batch {idx} exceeds 200k record limit, "
+                                f"  Batch {idx} failed for a splittable reason, "
                                 f"splitting {len(batch)} params into individual downloads..."
                             )
                             for sub_idx, param in enumerate(batch, 1):
@@ -433,18 +481,29 @@ class KemidataSurfaceWaterBronze(BaseSource[KemidataSurfaceWaterBronzeConfig], B
                                 )
                                 try:
                                     sub_bytes = await self._download_batch_with_retry(
-                                        session, sub_body, tmp, batch_counter, max_retries
+                                        session,
+                                        sub_body,
+                                        tmp,
+                                        batch_counter,
+                                        max_retries,
+                                        skip_header=total_bytes > 0,
                                     )
                                     total_bytes += sub_bytes
                                 except Exception as sub_exc:
-                                    if "200000 records" not in str(sub_exc):
+                                    if not self._should_split_download_error(sub_exc):
                                         raise
                                     self.log.warning(
                                         f"    Single param {param.get('name', 'unknown')} "
-                                        f"exceeds 200k, splitting by date range..."
+                                        f"failed for a splittable reason, "
+                                        f"splitting by date range..."
                                     )
                                     dr_bytes = await self._download_by_date_range(
-                                        session, session_id, [param], tmp, batch_counter
+                                        session,
+                                        session_id,
+                                        [param],
+                                        tmp,
+                                        batch_counter,
+                                        has_existing_content=total_bytes > 0,
                                     )
                                     total_bytes += dr_bytes
 

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_drift_exposure.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pesticide_drift_exposure.py
@@ -219,6 +219,12 @@ class PesticideDriftExposureGold(BaseSource[PesticideDriftExposureGoldConfig], G
         datasets = await self._load_datasets()
 
         if self.config.pesticide_year:
+            if self.config.pesticide_year not in datasets["disaggregation"]:
+                self.log.warning(
+                    "No disaggregation data found for year "
+                    f"{self.config.pesticide_year}; skipping pesticide drift exposure"
+                )
+                return
             years = [self.config.pesticide_year]
             self.log.info(f"Matrix job mode: processing year {self.config.pesticide_year}")
         else:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/year_detector.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/year_detector.py
@@ -301,15 +301,18 @@ class DataSourceYearDetector:
             # Only FVM marker is required; other data sources are optional enhancements
             production_years = set(available_years.get("field_production", []))
 
-            # Use FVM years as the base (production is optional)
-            target_years = fvm_years
+            # A PMTiles target year uses next-year field boundaries (Y+1 pattern).
+            # Do not include the newest boundary year until the following year exists.
+            target_years = {year for year in fvm_years if year + 1 in fvm_years}
             logger.info(f"FVM marker years: {sorted(fvm_years)}")
             if production_years:
                 logger.info(f"Field production years: {sorted(production_years)}")
                 logger.info(f"Years with production data: {sorted(fvm_years & production_years)}")
             else:
                 logger.info("Field production data not found (optional)")
-            logger.info(f"Auto-detected years (based on FVM marker): {sorted(target_years)}")
+            logger.info(
+                f"Auto-detected years (requiring next-year FVM boundaries): {sorted(target_years)}"
+            )
 
         # Apply exclusions
         if self.config.exclude_years:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/fvm_wfs.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/fvm_wfs.py
@@ -22,6 +22,7 @@ The module consists of two main components:
 
 import asyncio
 import json
+import logging
 from typing import Any, ClassVar
 
 from common.geometry_validator import (
@@ -32,7 +33,12 @@ from pydantic import ConfigDict
 
 from unified_pipeline.common.base import BaseJobConfig, BaseSource, SilverJobInterface
 from unified_pipeline.common.uuid_utils import LandbrugsdataUUID
-from unified_pipeline.util.fvm_wfs_year_discovery import discover_fvm_layer_years
+from unified_pipeline.util.fvm_wfs_year_discovery import (
+    FVMWFSYearDiscoveryError,
+    discover_fvm_layer_years,
+)
+
+logger = logging.getLogger(__name__)
 
 # CRS Strategy: Use EPSG:25832 for processing, transform to EPSG:4326 only at Supabase upload
 USE_UTM_PROCESSING = True
@@ -264,7 +270,29 @@ class FVMWFSSilverConfig(BaseJobConfig):
         """
         Discover live year ranges from WFS capabilities and apply required layers.
         """
-        discovered_years = discover_fvm_layer_years(self.wfs_url)
+        fallback_years = {
+            "markblokke": list(self.markblokke_years),
+            "marker": list(self.marker_years),
+            "smaabiotoper": list(self.smaabiotoper_years),
+        }
+        try:
+            discovered_years = discover_fvm_layer_years(self.wfs_url)
+        except FVMWFSYearDiscoveryError as exc:
+            logger.warning(
+                "FVM WFS live year discovery failed for %s; using configured fallback years: %s",
+                self.wfs_url,
+                exc,
+            )
+            discovered_years = fallback_years
+        else:
+            for layer_name, fallback in fallback_years.items():
+                if not discovered_years[layer_name]:
+                    logger.warning(
+                        "FVM WFS live year discovery returned no %s years; "
+                        "using configured fallback years",
+                        layer_name,
+                    )
+                    discovered_years[layer_name] = fallback
 
         required_layers = {
             "markblokke": require_markblokke,

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/jordbrugsanalyser.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/jordbrugsanalyser.py
@@ -364,6 +364,7 @@ class JordbrugsanalyserSilver(BaseSource[JordbrugsanalyserSilverConfig], SilverJ
         """
         try:
             # Read data with support for in-memory passing
+            use_storage = bronze_data is None
             if bronze_data is not None:
                 self.log.info(
                     f"Using bronze data from memory for year {year} (in-memory data passing)"
@@ -371,21 +372,34 @@ class JordbrugsanalyserSilver(BaseSource[JordbrugsanalyserSilverConfig], SilverJ
                 # Bronze data is a dict mapping year to list of raw WFS responses
                 if isinstance(bronze_data, dict) and str(year) in bronze_data:
                     raw_responses = bronze_data[str(year)]
-                    # ✅ MIGRATION: Create table with DuckDB instead of
-                    temp_conn = duckdb.connect()
-                    temp_conn.execute("CREATE OR REPLACE TABLE temp_responses (payload VARCHAR)")
+                    if all(
+                        isinstance(resp, str) and resp.startswith("saved_to_storage_")
+                        for resp in raw_responses
+                    ):
+                        self.log.info(
+                            f"Bronze year {year} was saved to storage; reading from storage"
+                        )
+                        use_storage = True
+                    else:
+                        # ✅ MIGRATION: Create table with DuckDB instead of
+                        temp_conn = duckdb.connect()
+                        temp_conn.execute(
+                            "CREATE OR REPLACE TABLE temp_responses (payload VARCHAR)"
+                        )
 
-                    # Insert responses directly into table
-                    for resp in raw_responses:
-                        temp_conn.execute("INSERT INTO temp_responses VALUES (?)", [resp])
+                        # Insert responses directly into table
+                        for resp in raw_responses:
+                            temp_conn.execute("INSERT INTO temp_responses VALUES (?)", [resp])
 
-                    # Keep as table name for processing
-                    bronze_table = "temp_responses"
-                    bronze_conn = temp_conn
+                        # Keep as table name for processing
+                        bronze_table = "temp_responses"
+                        bronze_conn = temp_conn
+                        use_storage = False
                 else:
                     self.log.warning(f"No in-memory data found for year {year}")
                     return None
-            else:
+
+            if use_storage:
                 # Fallback to reading from storage
                 self.log.info(f"Reading bronze data from storage for year {year} (fallback)")
                 bronze_dataset_name = f"{self.config.bronze_dataset}_{year}"

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/kemidata_surface_water.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/kemidata_surface_water.py
@@ -322,11 +322,28 @@ class KemidataSurfaceWaterSilver(BaseSource[KemidataSurfaceWaterSilverConfig], S
                         self.log.error("No manifest files found. Run bronze stage first.")
                         return None
 
-                    latest = sorted(manifest_files, reverse=True)[0]
-                    self.log.info(f"Reading manifest from {latest}")
-                    manifest = self.storage.download_json(latest)
-                    csv_path = manifest.get("csv_path")
-                    stations_path = manifest.get("stations_path")
+                    for manifest_file in sorted(manifest_files, reverse=True):
+                        self.log.info(f"Reading manifest from {manifest_file}")
+                        manifest = self.storage.download_json(manifest_file)
+                        candidate_csv_path = manifest.get("csv_path")
+                        if not candidate_csv_path:
+                            self.log.warning(f"Manifest {manifest_file} has no csv_path; skipping")
+                            continue
+
+                        candidate_storage_uri = f"{self.config.bucket}/{candidate_csv_path}"
+                        if not self.storage.file_exists(candidate_storage_uri):
+                            self.log.warning(
+                                f"Manifest {manifest_file} points to missing CSV "
+                                f"{candidate_storage_uri}; trying older manifest"
+                            )
+                            continue
+
+                        csv_path = candidate_csv_path
+                        stations_path = manifest.get("stations_path")
+                        break
+                    else:
+                        self.log.error("No manifest with an existing CSV export found.")
+                        return None
 
                 if not csv_path:
                     self.log.error("Missing csv_path in manifest")

--- a/backend/pipelines/unified_pipeline/tests/gold/test_pesticide_drift_exposure.py
+++ b/backend/pipelines/unified_pipeline/tests/gold/test_pesticide_drift_exposure.py
@@ -4,6 +4,8 @@ Tests the Rautmann drift curve, wind direction weighting, meteorological
 region assignment, and end-to-end drift dose calculations.
 """
 
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 
 from unified_pipeline.gold.pesticide_drift_exposure import (
@@ -11,12 +13,37 @@ from unified_pipeline.gold.pesticide_drift_exposure import (
     MIN_DISTANCE_M,
     RAUTMANN_A,
     RAUTMANN_B,
+    PesticideDriftExposureGold,
+    PesticideDriftExposureGoldConfig,
     _build_direction_frequency_table,
     _load_data_file,
     nearest_region_id,
     rautmann_drift_pct,
     wind_direction_weight,
 )
+
+
+@pytest.mark.asyncio
+async def test_matrix_year_without_disaggregation_data_is_skipped():
+    processor = object.__new__(PesticideDriftExposureGold)
+    processor.config = PesticideDriftExposureGoldConfig(pesticide_year=2014)
+    processor.log = Mock()
+    processor._setup_duckdb = AsyncMock()
+    processor._load_wind_data = Mock()
+    processor._load_datasets = AsyncMock(return_value={"disaggregation": {2015: "path.parquet"}})
+    processor._load_year_data = AsyncMock()
+    processor._compute_drift_exposure = AsyncMock()
+    processor._save_year_results = AsyncMock()
+
+    await processor.run()
+
+    processor._setup_duckdb.assert_awaited_once()
+    processor._load_wind_data.assert_called_once()
+    processor._load_datasets.assert_awaited_once()
+    processor._load_year_data.assert_not_awaited()
+    processor._compute_drift_exposure.assert_not_awaited()
+    processor._save_year_results.assert_not_awaited()
+    processor.log.warning.assert_called_once()
 
 
 class TestRautmannDriftFunction:

--- a/backend/pipelines/unified_pipeline/tests/gold/test_pmtiles_generator.py
+++ b/backend/pipelines/unified_pipeline/tests/gold/test_pmtiles_generator.py
@@ -130,7 +130,21 @@ class TestDataSourceYearDetector:
         available_years = {"fvm_marker": [2020, 2021, 2022]}
 
         years = detector.get_years_to_process(available_years)
-        assert years == [2021, 2022]
+        assert years == [2021]
+
+    @pytest.mark.asyncio
+    async def test_get_years_to_process_requires_next_year_boundaries(
+        self, test_config, mock_storage_access
+    ):
+        """Auto-detected PMTiles years require FVM marker data for year + 1."""
+        test_config.target_years = None
+        test_config.exclude_years = []
+
+        detector = DataSourceYearDetector(test_config, mock_storage_access)
+        available_years = {"fvm_marker": [2024, 2025, 2026]}
+
+        years = detector.get_years_to_process(available_years)
+        assert years == [2024, 2025]
 
 
 class TestPMTilesDataLoader:


### PR DESCRIPTION
## 🛠️ Issue Fix
No issue linked.

## 💡 Solution
- Harden failing data pipeline Actions with bounded retries, FVM WFS capability fallback for matrix generation, WFS XML validation, and correctness-first handling that fails instead of writing stale or zero-derived data.
- Fix PMTiles year detection to require next-year FVM boundaries and skip pesticide drift years with no disaggregation output.
- Update Datafordeler GraphQL defaults from retired `GEODKV/BBR v1` endpoints to live `v2` endpoints, and sanitize HTTP failures so API keys are not exposed in exceptions.
- Pin Paramiko below 4 in SFTP VM startup scripts for compatibility with the current SFTP host.

## ✅ How to Do Self-Test
- `uv run ruff check` on the touched Python files.
- `uv run pytest backend/pipelines/bbr_buildings/tests/test_graphql_fetcher.py backend/pipelines/bbr_buildings/tests/test_config.py backend/pipelines/unified_pipeline/tests/gold/test_pmtiles_generator.py backend/pipelines/unified_pipeline/tests/gold/test_pesticide_drift_exposure.py backend/pipelines/unified_pipeline/src/tests/util/test_fvm_wfs_year_discovery.py`
- `uv run --all-packages --group dev pytest` (`1366 passed, 3 skipped`).
- `cd frontend && npm ci && npm test && npm run lint` (`653 passed, 57 skipped`; oxlint warnings only).
- Live read-only smoke tests using secrets from Google Secret Manager project `landbrugsdata-1`: R2 PMTiles year detection, GEODKV GraphQL page fetch, BBR GraphQL usage-code enrichment, SDFE INSPIRE page parsing, BMD token fetch, Kemidata metadata/search, Jordbrugsanalyser WFS XML validation, and Paramiko/private-key compatibility.
- `bash -n backend/pipelines/property_owners_sftp/sftp-transfer-startup.sh backend/pipelines/property_owners_sftp/sftp-transfer-startup-with-processing.sh`
- YAML parse for `.github/workflows/fvm_wfs_matrix_download.yml` and `git diff --check`.

## 📷 Screenshots (if applicable)
Not applicable.

## 📝 Additional Notes
Full cloud data workflows were not dispatched from this workspace because they mutate shared storage and cost resources; the live checks above were read-only probes.