### PR TITLE
fix(pipelines): stabilize latest action runs

### DIFF
--- a/backend/pipelines/unified_pipeline/src/tests/silver/test_fvm_wfs_silver.py
+++ b/backend/pipelines/unified_pipeline/src/tests/silver/test_fvm_wfs_silver.py
@@ -2,6 +2,8 @@
 Tests for FVM WFS Silver layer.
 """
 
+from unittest.mock import Mock
+
 import duckdb
 import pytest
 
@@ -199,3 +201,51 @@ def test_subsidy_field_uuid_join_avoids_cross_cvr_collisions() -> None:
         )
     """).fetchone()[0]
     assert spurious == 2, "Test fixture is wrong — the spurious-match trap is not set up correctly"
+
+
+@pytest.mark.asyncio
+async def test_subsidy_enrichment_skips_legacy_tables_without_cvr(
+    fvm_wfs_silver: FVMWFSSilver,
+) -> None:
+    """Legacy subsidy tables without CVR must not get ambiguous field_id-only UUID matches."""
+    object.__setattr__(fvm_wfs_silver.config, "marker_years", [2012])
+    object.__setattr__(fvm_wfs_silver.config, "organic_subsidies_years", [])
+    object.__setattr__(fvm_wfs_silver.config, "grassland_subsidies_years", [])
+    object.__setattr__(fvm_wfs_silver.config, "environmental_subsidies_years", [2012])
+
+    def list_files(pattern: str) -> list[str]:
+        if "fvm_environmental_subsidies_2012" in pattern:
+            return ["landbruget-data/silver/fvm_environmental_subsidies_2012/ts/data.parquet"]
+        if "fvm_marker_2012" in pattern:
+            return ["landbruget-data/silver/fvm_marker_2012/ts/data.parquet"]
+        return []
+
+    def query_parquet_direct(_path: str, _query: str, table_name: str) -> None:
+        if table_name == "temp_subsidy_2012":
+            fvm_wfs_silver.conn.execute("""
+                CREATE OR REPLACE TABLE temp_subsidy_2012 AS
+                SELECT
+                    '4-0' AS field_id,
+                    ST_GeomFromText('POLYGON((1 1, 9 1, 9 9, 1 9, 1 1))') AS geometry
+            """)
+            return
+        if table_name == "temp_marker_2012":
+            fvm_wfs_silver.conn.execute("""
+                CREATE OR REPLACE TABLE temp_marker_2012 AS
+                SELECT
+                    '4-0' AS field_id,
+                    '12345678' AS cvr_number,
+                    'marker-uuid' AS field_uuid,
+                    ST_GeomFromText('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))') AS geometry
+            """)
+            return
+        raise AssertionError(f"Unexpected table load: {table_name}")
+
+    fvm_wfs_silver.storage.list_files = Mock(side_effect=list_files)
+    fvm_wfs_silver.storage.query_parquet_direct = Mock(side_effect=query_parquet_direct)
+    fvm_wfs_silver._save_data = Mock()
+
+    await fvm_wfs_silver._enrich_subsidies_with_field_uuid()
+
+    fvm_wfs_silver._save_data.assert_not_called()
+    assert fvm_wfs_silver.storage.query_parquet_direct.call_count == 2

--- a/backend/pipelines/unified_pipeline/src/tests/silver/test_kemidata_surface_water_silver.py
+++ b/backend/pipelines/unified_pipeline/src/tests/silver/test_kemidata_surface_water_silver.py
@@ -1,0 +1,91 @@
+"""Tests for Kemidata surface water silver processing."""
+
+import zipfile
+from pathlib import Path
+
+from unified_pipeline.silver.kemidata_surface_water import (
+    KemidataSurfaceWaterSilver,
+    KemidataSurfaceWaterSilverConfig,
+)
+
+
+def test_load_csv_from_storage_downloads_via_storage_fs(tmp_path: Path) -> None:
+    """Kemidata CSV manifests use storage paths that DuckDB cannot read directly."""
+    csv_file = tmp_path / "kemidata_export.csv"
+    csv_file.write_text("StationName;Value\nStation A;1\n", encoding="utf-8")
+
+    silver = KemidataSurfaceWaterSilver(KemidataSurfaceWaterSilverConfig(save_local=True))
+    opened: list[tuple[str, str]] = []
+
+    def open_csv(path: str, mode: str):
+        opened.append((path, mode))
+        return csv_file.open(mode)
+
+    silver.storage.fs.open.side_effect = open_csv
+
+    table_name = silver._load_csv_from_storage("bronze/kemidata/test/kemidata_export.csv")
+
+    assert table_name == "raw_kemidata"
+    assert opened == [("landbruget-data/bronze/kemidata/test/kemidata_export.csv", "rb")]
+    row = silver.conn.execute('SELECT "StationName", "Value" FROM raw_kemidata').fetchone()
+    assert row == ("Station A", "1")
+
+
+def test_load_csv_from_storage_extracts_zipped_kemidata_export(tmp_path: Path) -> None:
+    """Kemidata bronze files can be ZIP payloads even when the manifest says CSV."""
+    zip_file = tmp_path / "kemidata_export.csv"
+    with zipfile.ZipFile(zip_file, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("Kemi.csv", "StationName;Value\nStation B;2\n")
+
+    silver = KemidataSurfaceWaterSilver(KemidataSurfaceWaterSilverConfig(save_local=True))
+    silver.storage.fs.open.side_effect = lambda _path, mode: zip_file.open(mode)
+
+    table_name = silver._load_csv_from_storage("bronze/kemidata/test/kemidata_export.csv")
+
+    assert table_name == "raw_kemidata"
+    row = silver.conn.execute('SELECT "StationName", "Value" FROM raw_kemidata').fetchone()
+    assert row == ("Station B", "2")
+
+
+def test_transform_data_uses_stedtekst_for_station_geometry() -> None:
+    """The live Kemidata export uses Stedtekst for the station name column."""
+    silver = KemidataSurfaceWaterSilver(KemidataSurfaceWaterSilverConfig(save_local=True))
+    silver.conn.execute("""
+        CREATE OR REPLACE TABLE raw_kemidata AS
+        SELECT
+            'Station' AS "Stedtype",
+            '53000010' AS "StedID",
+            'LL. VEJLE Å, PILEMØLLEN' AS "Stedtekst",
+            '708823' AS "x-koordinat",
+            '6167762' AS "y-koordinat",
+            'Vandløb' AS "Medie"
+    """)
+
+    table_name = silver._transform_data(
+        [
+            {
+                "station_id": "615da609-389f-4d47-a024-71b0177a8da5",
+                "station_name": "LL. VEJLE Å, PILEMØLLEN",
+                "media_name": "Vandløb",
+                "x": 708823.0,
+                "y": 6167762.0,
+            },
+            {
+                "station_id": "duplicate-name",
+                "station_name": "LL. VEJLE Å, PILEMØLLEN",
+                "media_name": "Vandløb",
+                "x": 1.0,
+                "y": 2.0,
+            },
+        ]
+    )
+
+    count, with_geometry, x_coord, y_coord = silver.conn.execute(
+        f"""
+        SELECT COUNT(*), COUNT(CASE WHEN geometry IS NOT NULL THEN 1 END), MIN(x_coord), MIN(y_coord)
+        FROM {table_name}
+        """
+    ).fetchone()
+    assert count == 1
+    assert with_geometry == 1
+    assert (x_coord, y_coord) == (708823.0, 6167762.0)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/utils.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/pmtiles_generator/utils.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -65,23 +66,29 @@ class TippecanoeRunner:
                 "--detect-shared-borders",
                 "--extend-zooms-if-still-dropping",
                 "--force",  # Overwrite existing files
-                geojson_path,
+                "--quiet",
             ]
 
             # Add additional arguments if provided
             if additional_args:
                 cmd.extend(additional_args)
+            cmd.append(geojson_path)
 
             logger.info(f"Running tippecanoe: {' '.join(cmd)}")
 
-            # Run tippecanoe
+            # Run tippecanoe while draining output incrementally. Heavy PMTiles
+            # jobs can emit enough progress output to OOM a hosted runner if
+            # stdout/stderr are buffered until process completion.
             process = await asyncio.create_subprocess_exec(
                 *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
             )
 
-            stdout, stderr = await process.communicate()
+            stdout_task = asyncio.create_task(self._collect_stream_tail(process.stdout))
+            stderr_task = asyncio.create_task(self._collect_stream_tail(process.stderr))
+            return_code = await process.wait()
+            stdout_tail, stderr_tail = await asyncio.gather(stdout_task, stderr_task)
 
-            if process.returncode == 0:
+            if return_code == 0:
                 logger.info(f"Successfully generated PMTiles: {output_path}")
 
                 # Log file size
@@ -90,14 +97,32 @@ class TippecanoeRunner:
                     logger.info(f"PMTiles file size: {size_mb:.1f} MB")
 
                 return True
-            logger.error(f"Tippecanoe failed with return code {process.returncode}")
-            logger.error(f"stdout: {stdout.decode()}")
-            logger.error(f"stderr: {stderr.decode()}")
+            logger.error(f"Tippecanoe failed with return code {return_code}")
+            if stdout_tail:
+                logger.error("stdout tail:\n" + "\n".join(stdout_tail))
+            if stderr_tail:
+                logger.error("stderr tail:\n" + "\n".join(stderr_tail))
             return False
 
         except Exception as e:
             logger.error(f"Error running tippecanoe: {e}")
             return False
+
+    @staticmethod
+    async def _collect_stream_tail(stream: asyncio.StreamReader | None) -> list[str]:
+        """Drain a subprocess stream and keep only the last lines for diagnostics."""
+        if stream is None:
+            return []
+
+        lines: deque[str] = deque(maxlen=80)
+        while True:
+            line = await stream.readline()
+            if not line:
+                break
+            text = line.decode(errors="replace").rstrip()
+            if text:
+                lines.append(text)
+        return list(lines)
 
     def check_tippecanoe_available(self) -> bool:
         """Check if tippecanoe is available on the system.
@@ -163,76 +188,89 @@ class GeoJSONWriter:
             if properties_columns is None:
                 properties_columns = [col for col in columns if col != geometry_col]
 
-            # Stream and build GeoJSON features
-            features = []
             geometry_col_idx = columns.index(geometry_col)
+            property_indices = [
+                (prop_col, columns.index(prop_col))
+                for prop_col in properties_columns
+                if prop_col in columns
+            ]
 
             skipped_count = 0
             geometry_errors = []
             row_count = 0
+            features_written = 0
+            first_feature = None
 
-            # Stream rows instead of loading all into memory
-            while True:
-                batch = result.fetchmany(10000)  # Process in batches of 10k
-                if not batch:
-                    break
+            with open(output_path, "w", encoding="utf-8") as f:
+                f.write('{"type":"FeatureCollection","features":[')
+                first = True
 
-                for row in batch:
-                    row_count += 1
-                    # Parse geometry (assuming WKT format)
-                    geometry_wkt = row[geometry_col_idx]
-                    if not geometry_wkt:
-                        skipped_count += 1
-                        continue
+                # Stream rows instead of loading all features into memory.
+                while True:
+                    batch = result.fetchmany(10000)  # Process in batches of 10k
+                    if not batch:
+                        break
 
-                    # Handle geometry - could be WKT, WKB, or already GeoJSON string
-                    if isinstance(geometry_wkt, str):
-                        try:
-                            # Try to parse as GeoJSON first (from ST_AsGeoJSON)
-                            geometry = json.loads(geometry_wkt)
-                        except json.JSONDecodeError:
-                            # Fall back to WKT parsing
-                            geometry = GeoJSONWriter._wkt_to_geojson_geometry(geometry_wkt)
+                    for row in batch:
+                        row_count += 1
+                        # Parse geometry (assuming WKT format)
+                        geometry_wkt = row[geometry_col_idx]
+                        if not geometry_wkt:
+                            skipped_count += 1
+                            continue
+
+                        # Handle geometry - could be WKT, WKB, or already GeoJSON string
+                        if isinstance(geometry_wkt, str):
+                            try:
+                                # Try to parse as GeoJSON first (from ST_AsGeoJSON)
+                                geometry = json.loads(geometry_wkt)
+                            except json.JSONDecodeError:
+                                # Fall back to WKT parsing
+                                geometry = GeoJSONWriter._wkt_to_geojson_geometry(geometry_wkt)
+                                if not geometry and len(geometry_errors) < 5:
+                                    geometry_errors.append(
+                                        f"Failed to parse WKT: {str(geometry_wkt)[:100]}..."
+                                    )
+                        else:
+                            # Handle WKB or other formats
+                            geometry = GeoJSONWriter._wkt_to_geojson_geometry(str(geometry_wkt))
                             if not geometry and len(geometry_errors) < 5:
                                 geometry_errors.append(
-                                    f"Failed to parse WKT: {str(geometry_wkt)[:100]}..."
+                                    f"Failed to parse non-string geometry: {type(geometry_wkt)}"
                                 )
-                    else:
-                        # Handle WKB or other formats
-                        geometry = GeoJSONWriter._wkt_to_geojson_geometry(str(geometry_wkt))
-                        if not geometry and len(geometry_errors) < 5:
-                            geometry_errors.append(
-                                f"Failed to parse non-string geometry: {type(geometry_wkt)}"
-                            )
 
-                    if not geometry:
-                        skipped_count += 1
-                        continue
+                        if not geometry:
+                            skipped_count += 1
+                            continue
 
-                    # Build properties
-                    properties = {}
-                    for prop_col in properties_columns:
-                        if prop_col in columns:
-                            col_idx = columns.index(prop_col)
-                            properties[prop_col] = row[col_idx]
+                        properties = {
+                            prop_col: row[col_idx] for prop_col, col_idx in property_indices
+                        }
+                        feature = {
+                            "type": "Feature",
+                            "geometry": geometry,
+                            "properties": properties,
+                        }
+                        if first_feature is None:
+                            first_feature = feature
 
-                    # Create feature
-                    feature = {"type": "Feature", "geometry": geometry, "properties": properties}
-                    features.append(feature)
+                        if not first:
+                            f.write(",")
+                        json.dump(feature, f, separators=(",", ":"), ensure_ascii=False)
+                        first = False
+                        features_written += 1
+
+                f.write("]}")
 
             # Check if we got any features
-            if not features:
+            if features_written == 0:
                 logger.warning(f"Query returned no valid features for {output_path}")
                 return False
 
-            # Create GeoJSON FeatureCollection
-            geojson = {"type": "FeatureCollection", "features": features}
-
             # DEBUG: Log coordinate bounds from actual GeoJSON
-            if features:
+            if first_feature:
                 try:
                     # Get first feature's first coordinate to check format
-                    first_feature = features[0]
                     first_coord = first_feature["geometry"]["coordinates"]
                     if first_feature["geometry"]["type"] == "MultiPolygon":
                         sample_coord = first_coord[0][0][0]  # [lon, lat]
@@ -252,11 +290,12 @@ class GeoJSONWriter:
                 except Exception as coord_debug_error:
                     logger.warning(f"Could not debug GeoJSON coordinates: {coord_debug_error}")
 
-            # Write to file
-            with open(output_path, "w") as f:
-                json.dump(geojson, f, separators=(",", ":"))  # Compact format
+            if skipped_count:
+                logger.info(f"Skipped {skipped_count:,} rows without valid geometry")
+            if geometry_errors:
+                logger.warning(f"Geometry parse errors: {geometry_errors}")
 
-            logger.info(f"Wrote {len(features)} features to {output_path}")
+            logger.info(f"Wrote {features_written:,} features to {output_path}")
             return True
 
         except Exception as e:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/fvm_wfs.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/fvm_wfs.py
@@ -2208,6 +2208,26 @@ class FVMWFSSilver(BaseSource[FVMWFSSilverConfig], SilverJobInterface):
                         self.log.warning(f"Insufficient data for {layer_type} {year} - skipping")
                         continue
 
+                    subsidy_columns = self._get_table_columns(f"temp_subsidy_{year}")
+                    marker_columns = self._get_table_columns(f"temp_marker_{year}")
+                    if "cvr_number" not in subsidy_columns:
+                        self.log.warning(
+                            f"Skipping {layer_type} field_uuid enrichment for {year}: "
+                            "subsidy table has no cvr_number column. Field_id-only matching is "
+                            "ambiguous and could assign the wrong field_uuid."
+                        )
+                        self.conn.execute(f"DROP TABLE IF EXISTS temp_subsidy_{year}")
+                        self.conn.execute(f"DROP TABLE IF EXISTS temp_marker_{year}")
+                        continue
+                    if "cvr_number" not in marker_columns:
+                        self.log.warning(
+                            f"Skipping {layer_type} field_uuid enrichment for {year}: "
+                            "marker table has no cvr_number column."
+                        )
+                        self.conn.execute(f"DROP TABLE IF EXISTS temp_subsidy_{year}")
+                        self.conn.execute(f"DROP TABLE IF EXISTS temp_marker_{year}")
+                        continue
+
                     # Pre-filter to remove NULL geometries for optimal performance.
                     # cvr_number is required because the spatial join keys on it (see below).
                     self.conn.execute(f"""
@@ -2310,6 +2330,10 @@ class FVMWFSSilver(BaseSource[FVMWFSSilverConfig], SilverJobInterface):
                 f"Subsidy field UUID enrichment had {len(per_year_failures)} "
                 f"per-year failure(s): {failure_summary}"
             )
+
+    def _get_table_columns(self, table_name: str) -> set[str]:
+        """Return DuckDB column names for an internal temporary table."""
+        return {row[0] for row in self.conn.execute(f"DESCRIBE {table_name}").fetchall()}
 
     async def _extract_and_save_cvr_numbers(self) -> None:
         """

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/kemidata_surface_water.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/silver/kemidata_surface_water.py
@@ -19,7 +19,12 @@ embedded as "x, y" strings in the station data. The silver layer:
 6. Saves as parquet to cloud storage
 """
 
+import shutil
+import struct
+import tempfile
+import zlib
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from common.crs_utils import DENMARK_BOUNDS_UTM
@@ -98,22 +103,45 @@ class KemidataSurfaceWaterSilver(BaseSource[KemidataSurfaceWaterSilverConfig], S
         """
         Load the Kemidata CSV export from storage directly into a DuckDB table.
 
-        Uses DuckDB's registered cloud filesystem (configured by StorageAccess)
-        to read the CSV without temp files or in-memory buffering.
+        The bronze stage stores CSV exports via StorageAccess. Download to a
+        temporary local file first because DuckDB cannot resolve the bare
+        bucket/object path returned by the manifest.
 
         Returns the table name.
         """
         storage_uri = f"{self.config.bucket}/{csv_path}"
         self.log.info(f"Loading CSV from {storage_uri}")
 
-        self.conn.execute(f"""
-            CREATE OR REPLACE TABLE raw_kemidata AS
-            SELECT * FROM read_csv_auto('{storage_uri}',
-                header=true,
-                all_varchar=true,
-                ignore_errors=true
-            )
-        """)
+        tmp_paths: list[str] = []
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+                tmp_paths.append(tmp.name)
+                with self.storage.fs.open(storage_uri, "rb") as src:
+                    shutil.copyfileobj(src, tmp)
+
+            csv_read_path = tmp_paths[0]
+            if self._is_zip_file(csv_read_path):
+                csv_read_path = self._extract_first_zip_member(csv_read_path)
+                tmp_paths.append(csv_read_path)
+
+            escaped_tmp_path = csv_read_path.replace("'", "''")
+            self.conn.execute(f"""
+                CREATE OR REPLACE TABLE raw_kemidata AS
+                SELECT * FROM read_csv_auto('{escaped_tmp_path}',
+                    header=true,
+                    all_varchar=true,
+                    delim=';',
+                    strict_mode=false,
+                    null_padding=true,
+                    ignore_errors=true
+                )
+            """)
+        finally:
+            for tmp_path in tmp_paths:
+                try:
+                    Path(tmp_path).unlink(missing_ok=True)
+                except OSError as e:
+                    self.log.warning(f"Could not remove temporary CSV {tmp_path}: {e}")
 
         row_count = self.conn.execute("SELECT COUNT(*) FROM raw_kemidata").fetchone()[0]
         columns = [col[0] for col in self.conn.execute("DESCRIBE raw_kemidata").fetchall()]
@@ -122,6 +150,78 @@ class KemidataSurfaceWaterSilver(BaseSource[KemidataSurfaceWaterSilverConfig], S
         self.log.info(f"Columns: {columns}")
 
         return "raw_kemidata"
+
+    @staticmethod
+    def _is_zip_file(path: str) -> bool:
+        with Path(path).open("rb") as f:
+            return f.read(4) == b"PK\x03\x04"
+
+    def _extract_first_zip_member(self, zip_path: str) -> str:
+        """Extract the first local ZIP member without trusting the central directory."""
+        with Path(zip_path).open("rb") as src:
+            header = src.read(30)
+            if len(header) != 30:
+                raise ValueError("Kemidata ZIP payload is missing a local file header")
+
+            (
+                signature,
+                _version,
+                _flag_bits,
+                compression_method,
+                _modified_time,
+                _modified_date,
+                _crc32,
+                compressed_size,
+                _uncompressed_size,
+                file_name_length,
+                extra_field_length,
+            ) = struct.unpack("<IHHHHHIIIHH", header)
+
+            if signature != 0x04034B50:
+                raise ValueError("Kemidata ZIP payload has an invalid local file header")
+
+            member_name = src.read(file_name_length).decode("utf-8", errors="replace")
+            src.read(extra_field_length)
+            self.log.info(f"Extracting Kemidata ZIP member {member_name}")
+
+            extracted_path = None
+            try:
+                with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+                    extracted_path = tmp.name
+                    if compression_method == 8:  # deflate
+                        decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
+                        while True:
+                            chunk = src.read(1024 * 1024)
+                            if not chunk:
+                                break
+                            data = decompressor.decompress(chunk)
+                            if data:
+                                tmp.write(data)
+                            if decompressor.eof:
+                                break
+                        tail = decompressor.flush()
+                        if tail:
+                            tmp.write(tail)
+                        if not decompressor.eof:
+                            raise ValueError("Kemidata ZIP deflate stream ended before EOF")
+                    elif compression_method == 0 and compressed_size > 0:  # stored
+                        remaining = compressed_size
+                        while remaining > 0:
+                            chunk = src.read(min(1024 * 1024, remaining))
+                            if not chunk:
+                                raise ValueError("Kemidata ZIP stored member ended before EOF")
+                            tmp.write(chunk)
+                            remaining -= len(chunk)
+                    else:
+                        raise ValueError(
+                            f"Unsupported Kemidata ZIP compression method {compression_method}"
+                        )
+            except Exception:
+                if extracted_path is not None:
+                    Path(extracted_path).unlink(missing_ok=True)
+                raise
+
+        return extracted_path
 
     @timed(name="Transforming Kemidata")
     def _transform_data(self, stations: list[dict]) -> str:
@@ -167,6 +267,8 @@ class KemidataSurfaceWaterSilver(BaseSource[KemidataSurfaceWaterSilverConfig], S
         # Detect the right join column from the CSV
         station_col = None
         for candidate in [
+            "Stedtekst",
+            "Målested navn",
             "Lokalitetsnavn",
             "StationsNavn",
             "Stationsnavn",
@@ -180,6 +282,7 @@ class KemidataSurfaceWaterSilver(BaseSource[KemidataSurfaceWaterSilverConfig], S
 
         station_id_col = None
         for candidate in [
+            "StedID",
             "Lokalitetsnummer",
             "StationsNummer",
             "Stationsnummer",
@@ -192,33 +295,99 @@ class KemidataSurfaceWaterSilver(BaseSource[KemidataSurfaceWaterSilverConfig], S
 
         self.log.info(f"Detected station column: {station_col}, ID column: {station_id_col}")
 
-        # Build the actual transform with the detected columns
+        x_col = self._find_column(
+            columns,
+            col_lower,
+            ["x-koordinat", "Målested, x-koordinat", "x_coord", "x"],
+        )
+        y_col = self._find_column(
+            columns,
+            col_lower,
+            ["y-koordinat", "Målested, y-koordinat", "y_coord", "y"],
+        )
+        media_col = self._find_column(columns, col_lower, ["Medie", "media_name", "Media"])
+
+        # Build the actual transform with the detected columns.
+        # The CSV carries coordinates, so prefer those to avoid duplicate rows
+        # from non-unique station names in the metadata search result.
         if station_col:
             join_clause = f'r."{station_col}" = s.station_name'
         elif station_id_col:
             join_clause = f'r."{station_id_col}" = s.station_id'
         else:
-            # No join possible — just include all data without geometry
+            # No join possible — direct CSV coordinates may still provide geometry.
             self.log.warning(
                 "Could not detect station column for geometry join. "
-                "Data will be saved without geometry."
+                "Falling back to CSV coordinates only."
             )
             join_clause = "1=0"  # No match, all NULLs for station columns
+
+        if x_col and y_col:
+            csv_x_expr = f"TRY_CAST(REPLACE(NULLIF(TRIM(r.\"{x_col}\"), ''), ',', '.') AS DOUBLE)"
+            csv_y_expr = f"TRY_CAST(REPLACE(NULLIF(TRIM(r.\"{y_col}\"), ''), ',', '.') AS DOUBLE)"
+            x_expr = f"COALESCE({csv_x_expr}, s.x)"
+            y_expr = f"COALESCE({csv_y_expr}, s.y)"
+        else:
+            x_expr = "s.x"
+            y_expr = "s.y"
+
+        if media_col:
+            media_expr = f"COALESCE(NULLIF(TRIM(r.\"{media_col}\"), ''), s.media_name)"
+        else:
+            media_expr = "s.media_name"
+
+        if station_col:
+            station_lookup_query = """
+                CREATE OR REPLACE TABLE station_lookup AS
+                SELECT
+                    ANY_VALUE(station_id) AS station_id,
+                    station_name,
+                    ANY_VALUE(media_name) AS media_name,
+                    ANY_VALUE(x) AS x,
+                    ANY_VALUE(y) AS y
+                FROM stations
+                GROUP BY station_name
+            """
+        elif station_id_col:
+            station_lookup_query = """
+                CREATE OR REPLACE TABLE station_lookup AS
+                SELECT
+                    station_id,
+                    ANY_VALUE(station_name) AS station_name,
+                    ANY_VALUE(media_name) AS media_name,
+                    ANY_VALUE(x) AS x,
+                    ANY_VALUE(y) AS y
+                FROM stations
+                GROUP BY station_id
+            """
+        else:
+            station_lookup_query = """
+                CREATE OR REPLACE TABLE station_lookup AS
+                SELECT
+                    NULL::VARCHAR AS station_id,
+                    NULL::VARCHAR AS station_name,
+                    NULL::VARCHAR AS media_name,
+                    NULL::DOUBLE AS x,
+                    NULL::DOUBLE AS y
+                WHERE FALSE
+            """
+
+        self.conn.execute(station_lookup_query)
 
         self.conn.execute(f"""
             CREATE OR REPLACE TABLE kemidata_transformed AS
             SELECT
                 r.*,
-                s.x AS x_coord,
-                s.y AS y_coord,
-                s.media_name AS media_type,
+                {x_expr} AS x_coord,
+                {y_expr} AS y_coord,
+                {media_expr} AS media_type,
                 CASE
-                    WHEN s.x IS NOT NULL AND s.y IS NOT NULL
-                    THEN ST_Point(s.x, s.y)
+                    WHEN {x_expr} IS NOT NULL AND {y_expr} IS NOT NULL
+                    THEN ST_Point({x_expr}, {y_expr})
                     ELSE NULL
                 END AS geometry
             FROM raw_kemidata r
-            LEFT JOIN stations s ON {join_clause}
+            LEFT JOIN station_lookup s ON {join_clause}
         """)
 
         # Filter to surface water only where possible
@@ -260,6 +429,15 @@ class KemidataSurfaceWaterSilver(BaseSource[KemidataSurfaceWaterSilverConfig], S
         self.log.info(f"Transformed: {total:,} rows, {with_geom:,} with geometry")
 
         return "kemidata_transformed"
+
+    @staticmethod
+    def _find_column(
+        columns: list[str], col_lower: dict[str, str], candidates: list[str]
+    ) -> str | None:
+        for candidate in candidates:
+            if candidate in columns or candidate.lower() in col_lower:
+                return col_lower.get(candidate.lower(), candidate)
+        return None
 
     @timed(name="Validating geometries")
     def _validate_geometries(self, table_name: str) -> None:

--- a/backend/pipelines/unified_pipeline/tests/gold/test_pmtiles_generator.py
+++ b/backend/pipelines/unified_pipeline/tests/gold/test_pmtiles_generator.py
@@ -1,5 +1,6 @@
 """Integration tests for PMTiles Generator."""
 
+import json
 import os
 import shutil
 import tempfile
@@ -16,6 +17,7 @@ from unified_pipeline.gold.pmtiles_generator.field_analysis_generator import (
 )
 from unified_pipeline.gold.pmtiles_generator.main import PMTilesGeneratorPipeline
 from unified_pipeline.gold.pmtiles_generator.uploader import CloudflareR2Uploader
+from unified_pipeline.gold.pmtiles_generator.utils import GeoJSONWriter
 from unified_pipeline.gold.pmtiles_generator.year_detector import DataSourceYearDetector
 
 
@@ -786,6 +788,43 @@ class TestPMTilesGeneratorPipeline:
         # Clear environment variables
         with patch.dict(os.environ, {}, clear=True):
             assert pipeline._should_upload() is False
+
+
+class TestGeoJSONWriter:
+    """Tests for GeoJSON export utility."""
+
+    @pytest.mark.asyncio
+    async def test_write_geojson_from_query_writes_valid_feature_collection(
+        self, duckdb_conn, tmp_path
+    ):
+        duckdb_conn.execute("""
+            CREATE TABLE geojson_rows AS
+            SELECT
+                'field-1' AS field_uuid,
+                2024 AS field_year,
+                '{"type":"Point","coordinates":[10.0,55.0]}' AS geometry
+            UNION ALL
+            SELECT
+                'field-2' AS field_uuid,
+                2024 AS field_year,
+                '{"type":"Point","coordinates":[11.0,56.0]}' AS geometry
+        """)
+        output_path = tmp_path / "fields.geojson"
+
+        success = await GeoJSONWriter.write_geojson_from_query(
+            duckdb_conn,
+            "SELECT field_uuid, field_year, geometry FROM geojson_rows ORDER BY field_uuid",
+            str(output_path),
+        )
+
+        assert success is True
+        data = json.loads(output_path.read_text(encoding="utf-8"))
+        assert data["type"] == "FeatureCollection"
+        assert [feature["properties"]["field_uuid"] for feature in data["features"]] == [
+            "field-1",
+            "field-2",
+        ]
+        assert data["features"][0]["geometry"]["coordinates"] == [10.0, 55.0]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## 🛠️ Issue Fix
Latest main Actions still failed for Kemidata silver, FVM WFS matrix enrichment, and PMTiles generation.

## 💡 Solution
This fixes Kemidata silver to read the live zipped semicolon export from storage without duplicating station-name rows, skips FVM subsidy `field_uuid` enrichment for legacy tables without CVR instead of doing ambiguous field-id-only joins, and streams PMTiles GeoJSON/tippecanoe output to reduce runner memory pressure.

## ✅ How to Do Self-Test
- `uv run --all-packages --group dev pytest` passed before final formatting: 1371 passed, 3 skipped.
- `uv run --all-packages --group dev pytest backend/pipelines/unified_pipeline/src/tests/silver/test_fvm_wfs_silver.py backend/pipelines/unified_pipeline/src/tests/silver/test_kemidata_surface_water_silver.py backend/pipelines/unified_pipeline/tests/gold/test_pmtiles_generator.py -q` passed after formatting: 41 passed.
- `cd frontend && npm run lint` passed with existing warnings.
- `cd frontend && npm test` was not green locally; after installing Playwright browsers it reached 356 passed before I interrupted it, with existing frontend-only failures in pesticidkort/rankings/search/visual tests unrelated to these backend pipeline files.

## 📷 Screenshots
Not applicable.

## 📝 Additional Notes
Live R2 smoke checks confirmed Kemidata now transforms 9,834/9,834 rows with geometry, and the FVM guard avoids writing wrong field UUIDs when legacy subsidy data lacks `cvr_number`.