### PR TITLE
fix(pipeline): paginate jordbrugsanalyser bronze WFS fetch

### DIFF
--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/jordbrugsanalyser.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/bronze/jordbrugsanalyser.py
@@ -37,9 +37,9 @@ class JordbrugsanalyserBronzeConfig(BaseJobConfig):
     and request configuration.
 
     Performance Note:
-    Testing showed that downloading the full dataset in single requests is
-    ~730x faster than chunking (5,837 vs 8 features/second). The WFS server
-    is optimized for large single requests rather than many small ones.
+    Large layers (575k+ features) are fetched in paginated STARTINDEX/COUNT
+    chunks (batch_size). Single unlimited requests now time out server-side
+    (~300s) and return truncated GML, so pagination is required for reliability.
 
     Attributes:
         name (str): Human-readable name of the data source
@@ -69,9 +69,12 @@ class JordbrugsanalyserBronzeConfig(BaseJobConfig):
     start_year: int = 2012
     end_year: int = 2024
 
-    # Request configuration - optimized for full dataset downloads
-    # Testing showed full downloads are ~730x faster than chunking
-    batch_size: int = 0  # 0 = unlimited, download full dataset in one request
+    # Request configuration.
+    # NOTE: single unlimited requests (batch_size=0) now time out server-side
+    # (~300s) for the large layers (575k+ features), returning truncated/invalid
+    # GML that fails parsing (ValueError) and leaves corrupt bronze. Paginate
+    # instead: chunked STARTINDEX/COUNT requests complete fast and reliably.
+    batch_size: int = 25000  # features per WFS page (0 would download full dataset)
     max_concurrent: int = 1  # Process one year at a time for stability
     request_timeout: int = 600  # Increased timeout for full dataset downloads
 


### PR DESCRIPTION
## Problem

The `jordbrugsanalyser` bronze stage fails to fetch data, which blocks the EjerNr CVR bridge (it needs `silver/jordbrugsanalyser_markers`). Root cause found in a real GH Actions run:

- The bronze downloads each year's **full dataset in one unlimited WFS request** (`batch_size=0`, 575k–609k features/year).
- Each request now **times out server-side at ~300s** and returns truncated/invalid GML → `ValueError` on parse.
- Tenacity retries 5× per year (~30 min/year), then fails → the bronze parquet is left **corrupt/empty** (`No magic bytes found at end of file`), which is why silver had nothing to read.

## Fix

Set `batch_size = 25000` so the (already-present) chunked path is used: sequential `STARTINDEX`/`COUNT` requests bounded by `request_semaphore`, each completing quickly and reliably (proven with `count≈30k` WFS probes).

No other changes needed — the bronze already stores the list of responses and the silver already parses **every** payload row, so multi-chunk years work end-to-end.

Unblocks materializing `silver/jordbrugsanalyser_markers` → the EjerNr CVR backfill (PR #1379).

🤖 Generated with [Claude Code](https://claude.com/claude-code)