### PR TITLE
feat(nles5): parse in-depth fertilizer registers through 2025

### DIFF
--- a/backend/pipelines/drive_data_pipeline/silver/transformers/fertiliser_transformer.py
+++ b/backend/pipelines/drive_data_pipeline/silver/transformers/fertiliser_transformer.py
@@ -11,6 +11,7 @@ Refactored to use vanilla DuckDB instead of pandas.
 
 import contextlib
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -120,7 +121,9 @@ class FertiliserTransformer(BaseTransformer):
         main_match = any(pattern in filename for pattern in fertiliser_patterns)
 
         # In-depth patterns match (and in correct folder structure)
-        indepth_match = is_in_gr_folder and any(pattern in filename for pattern in indepth_patterns)
+        indepth_match = self._is_in_depth_register(filename) or (
+            is_in_gr_folder and any(pattern in filename for pattern in indepth_patterns)
+        )
 
         return main_match or indepth_match
 
@@ -158,6 +161,22 @@ class FertiliserTransformer(BaseTransformer):
                 self.conn.execute(f"""
                     CREATE TABLE {table_name} AS
                     SELECT * FROM read_parquet('{file_path}')
+                """)
+            elif file_suffix == ".csv":
+                # The GR 2024 release is a semicolon-delimited Latin-1 export.
+                # Keep every column as text so Danish decimal formatting is
+                # parsed later by the NLES5 loader without losing precision.
+                table_name = f"fertiliser_raw_{id(self)}"
+                self.conn.execute(f"""
+                    CREATE TABLE {table_name} AS
+                    SELECT * FROM read_csv(
+                        '{file_path}',
+                        delim=';',
+                        header=true,
+                        all_varchar=true,
+                        ignore_errors=true,
+                        encoding='latin-1'
+                    )
                 """)
             else:
                 return TransformResult(
@@ -232,8 +251,8 @@ class FertiliserTransformer(BaseTransformer):
     def _read_excel_to_table(self, file_path: Path) -> str | None:
         """Read Excel file into a DuckDB table.
 
-        Uses DuckDB's spatial extension for xlsx reading, with fallback to
-        temporary CSV conversion.
+        Uses DuckDB's spatial extension for Excel reading, with an ``xlrd``
+        fallback for the legacy binary XLS files used by the GR 2025 release.
 
         Args:
             file_path: Path to the Excel file
@@ -255,6 +274,74 @@ class FertiliserTransformer(BaseTransformer):
             return table_name
         except Exception as spatial_e:
             logger.debug(f"Spatial extension xlsx read failed: {spatial_e}")
+
+        # openpyxl intentionally does not read the legacy binary XLS format
+        # used by the GR 2025 release.  xlrd does, and is already a pipeline
+        # dependency for this purpose.
+        if file_path.suffix.lower() == ".xls":
+            try:
+                import xlrd
+
+                workbook = xlrd.open_workbook(file_path, on_demand=True)
+                all_data: list[dict[str, object]] = []
+                for sheet in workbook.sheets():
+                    if sheet.nrows == 0:
+                        continue
+                    headers = [
+                        str(value) if value is not None and str(value) else f"col_{index}"
+                        for index, value in enumerate(sheet.row_values(0))
+                    ]
+                    for row_index in range(1, sheet.nrows):
+                        values = sheet.row_values(row_index)
+                        row = {
+                            headers[index]: value if value != "" else None
+                            for index, value in enumerate(values)
+                        }
+                        row["source_sheet"] = sheet.name
+                        all_data.append(row)
+                workbook.release_resources()
+
+                if not all_data:
+                    logger.warning(f"No data found in XLS file: {file_path.name}")
+                    return None
+
+                all_columns = sorted({column for row in all_data for column in row})
+                column_types = {}
+                for column in all_columns:
+                    column_values = [row.get(column) for row in all_data]
+                    non_empty_values = [value for value in column_values if value is not None]
+                    column_types[column] = (
+                        "DOUBLE"
+                        if non_empty_values
+                        and all(
+                            isinstance(value, (int, float)) and not isinstance(value, bool)
+                            for value in non_empty_values
+                        )
+                        else "VARCHAR"
+                    )
+                columns_def = ", ".join(
+                    f'"{column.replace(chr(34), chr(34) * 2)}" {column_types[column]}'
+                    for column in all_columns
+                )
+                self.conn.execute(f"CREATE TABLE {table_name} ({columns_def})")
+                insert_values = [
+                    tuple(row.get(column) for column in all_columns) for row in all_data
+                ]
+                placeholders = ", ".join("?" for _ in all_columns)
+                self.conn.executemany(
+                    f"INSERT INTO {table_name} VALUES ({placeholders})", insert_values
+                )
+
+                logger.info(
+                    f"Read XLS file using xlrd fallback: {file_path.name} ({len(all_data)} rows)"
+                )
+                return table_name
+            except ImportError:
+                logger.error("xlrd not installed - cannot read legacy XLS files")
+                return None
+            except Exception as e:
+                logger.error(f"Failed to read XLS file {file_path.name}: {e}")
+                return None
 
         # Fallback: Use Python's openpyxl to read and convert to CSV, then load
         try:
@@ -356,6 +443,19 @@ class FertiliserTransformer(BaseTransformer):
                         CREATE TABLE {table_name} AS
                         SELECT * FROM read_parquet('{tmp_path}')
                     """)
+                elif file_suffix == ".csv":
+                    table_name = f"fertiliser_content_{id(self)}"
+                    self.conn.execute(f"""
+                        CREATE TABLE {table_name} AS
+                        SELECT * FROM read_csv(
+                            '{tmp_path}',
+                            delim=';',
+                            header=true,
+                            all_varchar=true,
+                            ignore_errors=true,
+                            encoding='latin-1'
+                        )
+                    """)
                 else:
                     logger.error(f"Unsupported file type for fertiliser transformer: {file_suffix}")
                     return None
@@ -425,6 +525,8 @@ class FertiliserTransformer(BaseTransformer):
 
             if "efterafgrøder" in filename_lower or "efterafgroeder" in filename_lower:
                 return self._process_efterafgroeder(table_name, filename)
+            if self._is_in_depth_register(filename):
+                return self._process_in_depth_register(table_name, filename)
             if "gkea" in filename_lower:
                 return self._process_gkea(table_name, filename)
             if (
@@ -449,6 +551,86 @@ class FertiliserTransformer(BaseTransformer):
         if column_name in column_names:
             return f'"{column_name}"'
         return "NULL"
+
+    @staticmethod
+    def _is_in_depth_main_register(filename: str) -> bool:
+        """Identify the farm-level ``V_4061GR_*_ISKV*_6*`` export."""
+        name = Path(filename).name.lower()
+        if not re.match(r"v_4061gr_(?:\d{2}|20\d{2})_iskv\d+_6(?:[a-z]|_|\.|$)", name):
+            return False
+        return not any(token in name for token in ("_b_", "dyrerk", "aftrk", "feltdefinition"))
+
+    @staticmethod
+    def _is_in_depth_register(filename: str) -> bool:
+        """Identify any raw table in an in-depth GR release."""
+        name = Path(filename).name.lower()
+        return bool(
+            re.match(r"v_4061gr_(?:\d{2}|20\d{2})_iskv\d+_(?:6|b_)", name)
+            or name.startswith("b_")
+            or re.match(r"(?:v|lg)_company[ab]\.", name)
+        )
+
+    def _process_in_depth_register(self, table_name: str, filename: str) -> str:
+        """Preserve raw in-depth register fields for downstream parsing.
+
+        The generic Gødningsregnskab projection intentionally produced a
+        small common schema, but that projection dropped all ``F_*`` columns.
+        Main and detail exports are now kept losslessly, with only normalized
+        CVR and source-year metadata added where absent.
+        """
+        is_main = self._is_in_depth_main_register(filename)
+        logger.info(
+            f"Preserving in-depth {'main-register' if is_main else 'detail'} fields: {filename}"
+        )
+        output_table = f"harmonized_gr_{'main' if is_main else 'detail'}_{id(self)}"
+        columns = self.conn.execute(f"DESCRIBE {table_name}").fetchall()
+        column_names = [column[0] for column in columns]
+        lower_names = {column.lower() for column in column_names}
+        extras: list[str] = []
+
+        if "cvr_number" not in lower_names:
+            cvr_column = next(
+                (column for column in column_names if column.lower() in {"cvr", "cvr_number"}),
+                None,
+            )
+            if cvr_column:
+                reference = f'"{cvr_column.replace(chr(34), chr(34) * 2)}"'
+                value = f"TRIM(CAST({reference} AS VARCHAR))"
+                without_decimal = f"regexp_replace({value}, '[.]0+$', '')"
+                digits = f"regexp_replace({without_decimal}, '[^0-9]', '', 'g')"
+                extras.append(
+                    f"CASE WHEN length({digits}) BETWEEN 1 AND 8 "
+                    f"AND {digits} <> '00000000' THEN lpad({digits}, 8, '0') END AS cvr_number"
+                )
+
+        year_match = re.search(
+            r"(?:gødningsregnskaber|goedningsregnskaber)[ _-]*(20\d{2})", filename, re.I
+        )
+        if year_match:
+            year = int(year_match.group(1))
+        else:
+            short_match = re.search(r"4061gr_(\d{2})_", filename, re.I)
+            year = 2000 + int(short_match.group(1)) if short_match else None
+        if "source_year" not in lower_names:
+            extras.append(f"{year if year is not None else 'NULL'}::INTEGER AS source_year")
+
+        escaped_filename = filename.replace("'", "''")
+        if "data_source" not in lower_names:
+            data_source = "goedningsregnskaber_main" if is_main else "goedningsregnskaber_detail"
+            extras.append(f"'{data_source}' AS data_source")
+        if "data_type" not in lower_names:
+            data_type = "Gødningsregnskab main register" if is_main else "Gødningsregnskab detail"
+            extras.append(f"'{data_type}' AS data_type")
+        if "data_source_file" not in lower_names:
+            extras.append(f"'{escaped_filename}' AS data_source_file")
+
+        select_list = "*" + (", " + ", ".join(extras) if extras else "")
+        self.conn.execute(f"""
+            CREATE TABLE {output_table} AS
+            SELECT {select_list}
+            FROM {table_name}
+        """)
+        return output_table
 
     def _process_efterafgroeder(self, table_name: str, filename: str) -> str:
         """Process Efterafgrøder (cover crops) files using DuckDB."""

--- a/backend/pipelines/drive_data_pipeline/tests/silver/test_fertiliser_transformer.py
+++ b/backend/pipelines/drive_data_pipeline/tests/silver/test_fertiliser_transformer.py
@@ -1,0 +1,57 @@
+"""Regression tests for the in-depth GR Drive transformer."""
+
+from drive_data_pipeline.silver.transformers.fertiliser_transformer import FertiliserTransformer
+
+
+def test_csv_in_depth_main_register_preserves_form_codes(tmp_path) -> None:
+    transformer = FertiliserTransformer()
+    assert transformer.can_handle(tmp_path / "V_4061GR_24_ISKV1_6A.csv", {})
+    assert transformer.can_handle(tmp_path / "V_COMPANYA.xls", {})
+    assert transformer.can_handle(tmp_path / "B_AOGGOED_6B.xls", {})
+    content = ("CVR;F_901;F_706_1;F_308_1\n01234567;1.234,5;2.000,0;3.000,5\n").encode("latin-1")
+    source_path = tmp_path / "V_4061GR_24_ISKV1_6A.csv"
+    source_path.write_bytes(content)
+
+    result = transformer.transform(
+        source_path,
+        metadata=None,
+        output_dir=tmp_path / "out",
+    )
+
+    assert result.success
+    assert result.output_path is not None
+    columns = {
+        row[0]
+        for row in transformer.conn.execute(
+            f"DESCRIBE SELECT * FROM read_parquet('{result.output_path}')"
+        ).fetchall()
+    }
+    assert {"CVR", "F_901", "F_706_1", "F_308_1", "cvr_number"}.issubset(columns)
+    assert transformer.conn.execute(
+        f"SELECT CVR, F_901, source_year FROM read_parquet('{result.output_path}')"
+    ).fetchone() == ("01234567", "1.234,5", 2024)
+
+
+def test_detail_tables_are_preserved_for_downstream_animal_and_transfer_parsing() -> None:
+    transformer = FertiliserTransformer()
+    transformer.conn.execute(
+        """
+        CREATE TABLE raw_detail (
+            CVR VARCHAR,
+            C_155 VARCHAR,
+            C_197 VARCHAR,
+            C_2016 VARCHAR
+        )
+        """
+    )
+    transformer.conn.execute("INSERT INTO raw_detail VALUES ('01234567', '10,5', '2,0', '100,0')")
+
+    output_table = transformer._process_in_depth_register(
+        "raw_detail", "V_4061GR_25_ISKV1_B_DYRERK.xls"
+    )
+    columns = {row[0] for row in transformer.conn.execute(f"DESCRIBE {output_table}").fetchall()}
+
+    assert {"CVR", "C_155", "C_197", "C_2016", "cvr_number"}.issubset(columns)
+    assert transformer.conn.execute(
+        f"SELECT cvr_number, source_year, C_2016 FROM {output_table}"
+    ).fetchone() == ("01234567", 2025, "100,0")

--- a/backend/pipelines/unified_pipeline/src/tests/gold/test_nles5_fertilizer_parser.py
+++ b/backend/pipelines/unified_pipeline/src/tests/gold/test_nles5_fertilizer_parser.py
@@ -1,0 +1,264 @@
+"""Regression tests for in-depth Gødningsregnskab parsing."""
+
+from types import SimpleNamespace
+
+import duckdb
+import pytest
+
+from unified_pipeline.gold.nles5_nitrogen_estimation.data_loader import NLES5DataLoader
+from unified_pipeline.gold.nles5_nitrogen_estimation.fertilizer_distributor import (
+    NLES5FertilizerDistributor,
+)
+
+
+class _Log:
+    def debug(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warning(self, *_args, **_kwargs):
+        pass
+
+
+class _Storage:
+    def __init__(self, connection: duckdb.DuckDBPyConnection, paths: list[str] | None = None):
+        self.connection = connection
+        self.paths = paths or []
+
+    def list_files(self, _pattern: str) -> list[str]:
+        return self.paths
+
+    def create_table_from_storage(self, table_name: str, path: str) -> None:
+        self.connection.execute(
+            f"CREATE TABLE {table_name} AS SELECT * FROM read_parquet('{path}')"
+        )
+
+
+def _loader(
+    connection: duckdb.DuckDBPyConnection, storage: _Storage | None = None
+) -> NLES5DataLoader:
+    processor = SimpleNamespace(
+        config=SimpleNamespace(bucket="landbruget-data", fertilizer_dataset="fertiliser"),
+        log=_Log(),
+        storage_access=storage,
+        conn=connection,
+    )
+    return NLES5DataLoader(processor)
+
+
+def test_main_register_parts_are_aggregated_with_danish_number_format() -> None:
+    connection = duckdb.connect()
+    connection.execute(
+        """
+        CREATE TABLE raw_register (
+            CVR VARCHAR,
+            F_901 VARCHAR,
+            F_706_1 VARCHAR,
+            F_704_1 VARCHAR,
+            F_318_1 VARCHAR,
+            F_308_1 VARCHAR,
+            F_243 VARCHAR,
+            F_512 VARCHAR,
+            F_902 VARCHAR,
+            F_804_1 VARCHAR
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO raw_register VALUES
+            ('01234567', '1.234,5', '2.000,0', '120,0', '6,0', '3.000,5', '10,5', '4.000,0', '1.000,0', '12,0'),
+            ('01234567', '100,5', '200,0', '30,0', '2,0', '300,5', '1,5', '400,0', '100,0', '2,0'),
+            ('7654321', '50', '25', '5', '1', '10', '5', '40', '15', '1')
+        """
+    )
+
+    loader = _loader(connection)
+    loader._transform_gr_main_register("raw_register", "fertilizer_accounts", 2025, 2)
+
+    rows = connection.execute(
+        """
+        SELECT cvr_number, year, tn_t_ha, mineral_n_foraar, mineral_n_eft,
+               mineral_n_udb, organic_n_hus, mineral_n_total,
+               mineral_n_autumn_total_kg, grazing_n_total_kg,
+               harmoni_area_ha, total_n_consumption_kg,
+               niveau, mineral_n_allocation_method
+        FROM fertilizer_accounts
+        ORDER BY cvr_number
+        """
+    ).fetchall()
+
+    assert rows[0][:2] == ("01234567", 2025)
+    assert rows[0][2:12] == pytest.approx(
+        (0.11125, 0.0, 12.5, 2 / 3, 275.0833333333, 2200.0, 150.0, 8.0, 12.0, 1335.0)
+    )
+    assert rows[0][12:] == ("Detailed main register", "explicit_register_fields_only")
+    assert rows[1][:2] == ("07654321", 2025)
+    assert rows[1][2:12] == pytest.approx((0.01, 0.0, 1.0, 0.2, 2.0, 25.0, 5.0, 1.0, 5.0, 50.0))
+    assert rows[1][12:] == ("Detailed main register", "explicit_register_fields_only")
+
+
+def test_in_depth_file_selection_excludes_detail_tables() -> None:
+    assert NLES5DataLoader._is_in_depth_main_register_file(
+        "bucket/silver/gr 2025/20260912_120000/V_4061GR_25_ISKV1_6A_harmonized.parquet"
+    )
+    assert NLES5DataLoader._is_in_depth_main_register_file(
+        "bucket/silver/gr_2024/20260912_120000/V_4061GR_24_ISKV1_6B_pii_handled.parquet"
+    )
+    assert not NLES5DataLoader._is_in_depth_main_register_file(
+        "bucket/silver/gr 2025/20260912_120000/V_4061GR_25_ISKV1_B_DYRERK_harmonized.parquet"
+    )
+    assert not NLES5DataLoader._is_in_depth_main_register_file(
+        "bucket/silver/gr 2025/20260912_120000/V_4061GR_25_ISKV1_B_GOEDRK_6B.parquet"
+    )
+
+
+def test_file_selection_prefers_final_pii_copy() -> None:
+    files = [
+        "bucket/silver/gr 2025/20260912_120000/V_4061GR_25_ISKV1_6A_harmonized.parquet",
+        "bucket/silver/gr 2025/20260912_120000/V_4061GR_25_ISKV1_6A_harmonized_schema.parquet",
+        "bucket/silver/gr 2025/20260912_120000/V_4061GR_25_ISKV1_6A_harmonized_schema_pii_handled.parquet",
+    ]
+
+    assert NLES5DataLoader._prefer_final_gr_files(files) == [files[2]]
+
+
+def test_gr_year_prefers_directory_and_supports_two_digit_filename() -> None:
+    assert (
+        NLES5DataLoader._extract_godningsregnskab_year(
+            "silver/gr 2025/V_4061GR_25_ISKV1_6A.parquet", directory_year=2025
+        )
+        == 2025
+    )
+    assert (
+        NLES5DataLoader._extract_godningsregnskab_year(
+            "silver/fertiliser/V_4061GR_24_ISKV1_6A.parquet"
+        )
+        == 2024
+    )
+
+
+def test_loader_combines_multiple_years_and_all_parts(tmp_path) -> None:
+    connection = duckdb.connect()
+    storage = _Storage(connection)
+    paths: dict[int, list[str]] = {}
+
+    for year, cvr, total_n in ((2024, "01234567", "100,0"), (2025, "07654321", "200,0")):
+        table = f"source_{year}"
+        path = tmp_path / f"V_4061GR_{year % 100:02d}_ISKV1_6A.parquet"
+        connection.execute(
+            f"""
+            CREATE TABLE {table} AS
+            SELECT '{cvr}'::VARCHAR AS CVR,
+                   '{total_n}'::VARCHAR AS F_901,
+                   '10,0'::VARCHAR AS F_706_1,
+                   '20,0'::VARCHAR AS F_308_1,
+                   '10,0'::VARCHAR AS F_243
+            """
+        )
+        connection.execute(f"COPY {table} TO '{path}' (FORMAT PARQUET)")
+        connection.execute(f"DROP TABLE {table}")
+        paths[year] = [str(path)]
+
+    loader = _loader(connection, storage)
+    loader._get_fertilizer_accounts_file_paths = lambda year: paths.get(year, [])
+
+    assert loader._load_fertilizer_accounts_for_years([2024, 2025])
+    assert connection.execute(
+        "SELECT cvr_number, year, tn_t_ha FROM fertilizer_accounts ORDER BY year"
+    ).fetchall() == [("01234567", 2024, 0.01), ("07654321", 2025, 0.02)]
+
+
+def test_farm_loader_aggregates_detail_animal_rows_for_2025(tmp_path) -> None:
+    connection = duckdb.connect()
+    main_path = tmp_path / "V_4061GR_25_ISKV1_6A.parquet"
+    animal_path = tmp_path / "V_4061GR_25_ISKV1_B_DYRERK.parquet"
+    connection.execute(
+        """
+        CREATE TABLE main_source AS
+        SELECT '01234567'::VARCHAR AS CVR, '100,0'::VARCHAR AS F_901
+        """
+    )
+    connection.execute(f"COPY main_source TO '{main_path}' (FORMAT PARQUET)")
+    connection.execute(
+        """
+        CREATE TABLE animal_source AS
+        SELECT '01234567'::VARCHAR AS CVR,
+               '100,0'::VARCHAR AS C_2016,
+               '2'::VARCHAR AS C_2006,
+               '3'::VARCHAR AS C_2017
+        """
+    )
+    connection.execute(f"COPY animal_source TO '{animal_path}' (FORMAT PARQUET)")
+    connection.execute("DROP TABLE main_source")
+    connection.execute("DROP TABLE animal_source")
+
+    storage = _Storage(connection, [str(main_path), str(animal_path)])
+    loader = _loader(connection, storage)
+    farm_table = loader._load_farm_data_for_year(2025)
+
+    assert farm_table == "farm_data_2025"
+    assert connection.execute(
+        "SELECT cvr, organic_n_production, animal_count, animal_units FROM farm_data_2025"
+    ).fetchone() == ("01234567", 100.0, 2.0, 3.0)
+
+
+def test_fertilizer_distribution_keeps_reported_sources_separate() -> None:
+    connection = duckdb.connect()
+    connection.execute(
+        """
+        CREATE TABLE fertilizer_accounts (
+            cvr_number VARCHAR,
+            year INTEGER,
+            organic_n_hus DOUBLE,
+            mineral_n_foraar DOUBLE,
+            mineral_n_eft DOUBLE,
+            mineral_n_udb DOUBLE,
+            tn_t_ha DOUBLE,
+            harmoni_area_ha DOUBLE
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO fertilizer_accounts VALUES
+            ('01234567', 2025, 0.0, 3.0, 1.0, 0.5, 0.01, 10.0)
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE fields (
+            field_id VARCHAR,
+            cvr_number VARCHAR,
+            year INTEGER,
+            crop_name VARCHAR,
+            m_code VARCHAR,
+            area_ha DOUBLE
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO fields VALUES
+            ('field-1', '01234567', 2025, 'spring barley', 'M2', 5.0),
+            ('field-2', '01234567', 2025, 'spring barley', 'M2', 5.0)
+        """
+    )
+
+    distributor = NLES5FertilizerDistributor(connection, _Log())
+    result_table = distributor.apply_fertilizer_distribution_to_pipeline("fields")
+
+    rows = connection.execute(
+        f"""
+        SELECT mineral_n_foraar, mineral_n_eft, mineral_n_udb, tn_t_ha
+        FROM {result_table}
+        ORDER BY field_id
+        """
+    ).fetchall()
+
+    assert rows == pytest.approx([(3.0, 1.0, 0.5, 0.01)] * 2)

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/NLES5_Pipeline_Data_Flow.md
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/NLES5_Pipeline_Data_Flow.md
@@ -134,6 +134,15 @@ flowchart TD
 - **Purpose**: Replace estimated values with actual farm-specific data for enhanced accuracy
 - **Validation**: Comprehensive quality controls per N2023_62 Table 1 (21 validation rules)
 
+### In-depth GR 2024–2025 format
+- The Drive release is read from all `V_4061GR_{YY}_ISKV*_6*` main-register parts; `B_GOEDRK` is not used as a substitute when a main register exists.
+- The Drive Silver transformer accepts the 2024 semicolon/Latin-1 CSV export and 2025 Excel exports, preserving `F_*` and `C_*` columns.
+- Main-register fields are mapped as `F_901` → total N consumption, `F_706_1` → annual commercial N, `F_704_1` → explicit early-August/September commercial N, `F_318_1` → grazing-deposited manure N, `F_308_1` → manure N consumption, `F_804_1` → other organic N, `F_512` → corrected N quota, `F_902` → quota headroom, and `F_243` → harmoni area.
+- `F_706_1` is retained as an annual audit total. It is never assigned to spring or another season. The NLES5 spring input remains zero when the source does not report one; `F_704_1` populates only the autumn input, and `F_318_1` populates the grazing/`udb` input. `mineral_n_allocation_method` is `explicit_register_fields_only`.
+- Farm-to-field distribution keeps these reported sources separate and allocates each one using the same N-quota allocation method. It does not infer a seasonal split.
+- `F_901` remains the reported annual total used for `tn_t_ha`; it is allocated to fields independently of the seasonal inputs, so the annual total is not silently reduced to the subset of source components with explicit timing.
+- `B_DYRERK` detail rows are aggregated by CVR for animal-production fields, while Silver transform/schema/PII copies are de-duplicated before loading.
+
 ### Output Tables
 - **Intermediate**: `nles5_estimates_final_batched` (per batch/year with field_uuid)
 - **Final**: `nles5_nitrogen_estimates_gold` (consolidated results with field_uuid)
@@ -153,5 +162,3 @@ flowchart TD
 - **Validation**: Comprehensive quality controls ensure data integrity per Danish NLES5 methodology (N2023_62, Table 1).
 - Pipeline processes data in target-year batches for memory efficiency.
 - Final export table is `nles5_nitrogen_estimates_gold`.
-
-

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/config.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/config.py
@@ -51,14 +51,8 @@ class NLES5NitrogenEstimationGoldConfig(BaseJobConfig):
     # Note: farm_data_storage_path is no longer used - the pipeline now dynamically discovers
     # the latest timestamped directory for each year (e.g., silver/gr {year}/YYYYMMDD_HHMMSS/)
     enable_farm_data_integration: bool = True  # Enable farm data integration for enhanced accuracy
-    farm_data_years: ClassVar[list[int]] = [
-        2018,
-        2019,
-        2020,
-        2021,
-        2022,
-        2023,
-    ]  # Available farm data years (updated based on cloud storage tree)
+    farm_data_years: ClassVar[list[int]] = list(range(2018, 2026))
+    # Available farm data years, including the 2024 and 2025 in-depth releases.
     farm_data_cache_table: str = "farm_data_cache"  # DuckDB table name for cached farm data
 
     # Processing configuration - CHUNKED FOR STABILITY
@@ -99,9 +93,8 @@ class NLES5NitrogenEstimationGoldConfig(BaseJobConfig):
     # target_years: Optional[List[int]] = None
     # NOTE: Updated analysis shows 2023 agricultural fields data IS available
     # in cloud storage (fvm_marker_2023)
-    # TEMPORAL EXTENSION: Added 2023 support based on confirmed cloud storage data
-    # availability
-    target_years: ClassVar[list[int]] = [2021, 2022, 2023]
+    # The in-depth Gødningsregnskab releases now extend the target period through 2025.
+    target_years: ClassVar[list[int]] = [2021, 2022, 2023, 2024, 2025]
 
     # MEMORY OPTIMIZATION: Limits target calculation years (auto-discovery with memory management)
     # NLES5 requires 3-year windows: current + previous + year before previous

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/data_loader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/data_loader.py
@@ -284,124 +284,345 @@ class NLES5DataLoader:
             self.log.error(f"Fertilizer directory discovery failed: {e}")
             raise
 
-    def _get_fertilizer_accounts_file_path(self, target_year: int | None = None) -> str:
+    @staticmethod
+    def _is_in_depth_main_register_file(file_path: str) -> bool:
+        """Return whether a Silver file is a GR main-register ``_6*`` export.
+
+        The 2024 and 2025 Drive releases contain several related tables.  Only
+        the ``V_4061GR_*_ISKV*_6*`` tables contain the farm-level balance fields
+        consumed by NLES5.  ``B_GOEDRK`` is a block/subtable and must not be
+        selected as a replacement for the main register.
         """
-        Get the specific path to fertilizer accounts data file (Gødningsregnskab - GR).
+        filename = file_path.rsplit("/", 1)[-1].upper()
+        if not filename.endswith(".PARQUET") or "4061GR" not in filename:
+            return False
+        if "_B_" in filename or filename.startswith("B_"):
+            return False
+        if any(token in filename for token in ("DYRERK", "AFTRK", "FELTDEFINITION")):
+            return False
+        return bool(re.search(r"_ISKV\d+_6(?:[A-Z]|_|\.|$)", filename))
 
-        Looks for year-specific GR data in 'gr {year}/' directories first,
-        with correct file patterns:
-        - 2019: B_GOEDRK_6B.parquet
-        - 2023+: V_4061GR_{YY}_ISKV1_B_GOEDRK_6B.parquet
+    @staticmethod
+    def _extract_godningsregnskab_year(
+        file_path: str, directory_year: int | None = None
+    ) -> int | None:
+        """Resolve a GR year, preferring the directory over two-digit file codes."""
+        if directory_year is not None:
+            return directory_year
 
-        Falls back to 'fertiliser/' directory if year-specific not found.
+        filename = file_path.rsplit("/", 1)[-1]
+        full_year = re.search(r"(?:GR|GODNINGSREGNSKAB[^0-9]*)(20\d{2})", filename, re.I)
+        if full_year:
+            return int(full_year.group(1))
 
-        Args:
-            target_year: Optional target year to match
+        short_year = re.search(r"4061GR_(\d{2})_", filename, re.I)
+        if short_year:
+            return 2000 + int(short_year.group(1))
+        return None
 
-        Returns:
-            storage path to specific fertilizer accounts parquet file, or None if not found
+    def _latest_gr_files(self, files: list[str]) -> list[str]:
+        """Keep files from the newest Silver run when several runs are present."""
+        if not files:
+            return []
+
+        timestamp_dirs: dict[str, str] = {}
+        for file_path in files:
+            match = re.search(r"/(\d{8}_\d{6})/", file_path)
+            if match:
+                timestamp_dirs[match.group(1)] = match.group(1)
+
+        if not timestamp_dirs:
+            return sorted(set(files))
+
+        latest_timestamp = max(timestamp_dirs)
+        return sorted(file_path for file_path in set(files) if f"/{latest_timestamp}/" in file_path)
+
+    @staticmethod
+    def _prefer_final_gr_files(files: list[str]) -> list[str]:
+        """Avoid counting the transform, schema, and PII copies of one file."""
+        unique_files = sorted(set(files))
+        for marker in ("_pii_handled.parquet", "_schema.parquet"):
+            final_files = [file_path for file_path in unique_files if marker in file_path.lower()]
+            if final_files:
+                return final_files
+        return unique_files
+
+    def _get_fertilizer_accounts_file_paths(self, target_year: int | None = None) -> list[str]:
+        """Find every main-register parquet part for a GR year.
+
+        2024 is split across ``6A``/``6B`` CSV exports and 2025 is distributed
+        as one or more Excel exports.  The Drive Silver layer converts both to
+        parquet, so NLES5 must load all matching ``_6*`` parts and aggregate
+        them by CVR instead of selecting one legacy ``B_GOEDRK`` file.
         """
-        try:
-            # Strategy 1: Try year-specific GR directory first (e.g., "gr 2019/", "gr 2023/")
-            if target_year:
-                gr_dir_path = f"{self.config.bucket}/silver/gr {target_year}/"
+        if target_year is None:
+            return []
 
+        bucket = self.config.bucket
+        base_candidates = (
+            f"{bucket}/silver/gr {target_year}/",
+            f"{bucket}/silver/gr_{target_year}/",
+        )
+
+        for base_path in base_candidates:
+            files: list[str] = []
+            for pattern in (f"{base_path}*/*.parquet", f"{base_path}*.parquet"):
                 try:
-                    # Get latest timestamped directory within the gr year directory
-                    dirs = self.storage.list_files(f"{gr_dir_path}*/")
-                    if dirs:
-                        latest_dir = sorted([d for d in dirs if d.endswith("/")])[-1]
-                        self.log.info(f"🔍 Checking year-specific GR directory: {latest_dir}")
-
-                        # Define year-specific file patterns for Gødningsregnskab (GR) data
-                        # B_GOEDRK_6B = Bedrift Gødningsregnskab (company fertilizer accounts)
-                        file_patterns = [
-                            f"{latest_dir}B_GOEDRK_6B.parquet",  # 2019 pattern
-                            # 2021+ pattern (e.g., V_4061GR_21_...)
-                            f"{latest_dir}V_4061GR_{target_year % 100:02d}_ISKV1_B_GOEDRK_6B"
-                            ".parquet",
-                            # Alternative with full year
-                            f"{latest_dir}V_4061GR_{target_year}_ISKV1_B_GOEDRK_6B.parquet",
-                        ]
-
-                        # Try each pattern
-                        for pattern in file_patterns:
-                            files = self.storage.list_files(pattern)
-                            if files:
-                                selected_file = files[0]
-                                self.log.info(
-                                    f"✅ Found year-specific GR data for {target_year}: "
-                                    f"{selected_file}"
-                                )
-                                return selected_file
-
-                        # If exact patterns don't match, try wildcard search in the directory
-                        all_files = self.storage.list_files(f"{latest_dir}*.parquet")
-                        gr_files = [f for f in all_files if "GOEDRK" in f or "B_GOEDRK" in f]
-                        if gr_files:
-                            selected_file = gr_files[0]
-                            self.log.info(
-                                f"✅ Found GR file (wildcard match) for {target_year}: "
-                                f"{selected_file}"
-                            )
-                            return selected_file
-
-                        self.log.warning(f"⚠️ No GR fertilizer data found in {latest_dir}")
+                    files.extend(self.storage.list_files(pattern))
                 except Exception as e:
-                    self.log.info(f"Year-specific gr {target_year}/ directory not available: {e}")
-
-            # Strategy 2: Fall back to main fertiliser/ directory (legacy location)
-            self.log.info("⏭️ Falling back to main fertiliser/ directory")
-            fertilizer_dir = self._get_fertilizer_data_path(target_year)
-
-            # List all files in the directory to find fertilizer accounts files
-            pattern = f"{fertilizer_dir}*.parquet"
-            files = self.storage.list_files(pattern)
-
-            # Look for files that match fertilizer accounts pattern (Gødningsregnskaber)
-            fertilizer_accounts_files = []
-            for file_path in files:
-                if "Gødningsregnskaber" in file_path or "fertilizer" in file_path.lower():
-                    # Extract year from filename (look for 4 digits that are not part of timestamp)
-                    import re
-
-                    # Get just the filename, not the full path to avoid timestamp confusion
-                    filename = file_path.split("/")[-1]
-                    year_match = re.search(r"(\d{4})", filename)
-                    if year_match:
-                        file_year = int(year_match.group(1))
-                        fertilizer_accounts_files.append((file_year, file_path))
-                    else:
-                        # If no year found, use as fallback
-                        fertilizer_accounts_files.append((0, file_path))
-
-            if fertilizer_accounts_files:
-                # If target_year specified, prefer closest year match
-                if target_year:
-                    # Sort by proximity to target year
-                    fertilizer_accounts_files.sort(
-                        key=lambda x: abs(x[0] - target_year) if x[0] > 0 else 9999
-                    )
-                    selected_year, selected_file = fertilizer_accounts_files[0]
-                    if selected_year != target_year:
-                        self.log.warning(
-                            f"⚠️ Using {selected_year} fertilizer data as proxy for {target_year}"
-                        )
-                else:
-                    # Sort by year (descending) and get the most recent
-                    fertilizer_accounts_files.sort(reverse=True)
-                    selected_year, selected_file = fertilizer_accounts_files[0]
-
+                    self.log.debug(f"Could not list GR files with {pattern}: {e}")
+            selected = [
+                file_path for file_path in files if self._is_in_depth_main_register_file(file_path)
+            ]
+            if selected:
+                selected = self._prefer_final_gr_files(self._latest_gr_files(selected))
                 self.log.info(
-                    f"Found fertilizer accounts file: {selected_file} (year: {selected_year})"
+                    f"✅ Found {len(selected)} main-register file part(s) for GR {target_year}"
                 )
-                return selected_file
-            self.log.warning(f"❌ No fertilizer accounts files found in {fertilizer_dir}")
-            return None
+                return selected
 
-        except Exception as e:
-            self.log.error(f"Error finding fertilizer accounts file: {e}")
-            return None
+            # Preserve compatibility with the older archive, whose farm
+            # register was exported as B_GOEDRK_6B rather than a V_* _6* file.
+            legacy = [
+                file_path
+                for file_path in files
+                if "GOEDRK" in file_path.rsplit("/", 1)[-1].upper()
+                and not any(
+                    token in file_path.rsplit("/", 1)[-1].upper() for token in ("DYRERK", "AFTRK")
+                )
+            ]
+            if legacy:
+                selected = self._prefer_final_gr_files(self._latest_gr_files(legacy))
+                self.log.info(
+                    f"✅ Found {len(selected)} legacy B_GOEDRK file part(s) for GR {target_year}"
+                )
+                return selected
+
+        # The Drive pipeline can place files under ``silver/fertiliser`` when
+        # the original subfolder metadata is only ``Fertiliser``.  Search that
+        # tree as a compatibility fallback, but still require a year-matching
+        # main-register filename/path and never substitute another year.
+        files: list[str] = []
+        for pattern in (
+            f"{bucket}/silver/{self.config.fertilizer_dataset}/**/*.parquet",
+            f"{bucket}/silver/{self.config.fertilizer_dataset}/*/*.parquet",
+            f"{bucket}/silver/{self.config.fertilizer_dataset}/*/*/*.parquet",
+            f"{bucket}/silver/**/*.parquet",
+        ):
+            try:
+                files.extend(self.storage.list_files(pattern))
+            except Exception as e:
+                self.log.debug(f"Could not search fertiliser fallback tree with {pattern}: {e}")
+
+        year_code = f"{target_year % 100:02d}"
+        year_files = [
+            file_path
+            for file_path in files
+            if (
+                self._is_in_depth_main_register_file(file_path)
+                or "GOEDRK" in file_path.rsplit("/", 1)[-1].upper()
+            )
+            and (
+                f"gr {target_year}" in file_path.lower()
+                or f"gr_{target_year}" in file_path.lower()
+                or f"4061gr_{year_code}_" in file_path.lower()
+                or f"4061gr_{target_year}_" in file_path.lower()
+            )
+        ]
+        if year_files:
+            selected = self._prefer_final_gr_files(self._latest_gr_files(year_files))
+            self.log.info(
+                f"✅ Found {len(selected)} main-register file part(s) for GR {target_year} "
+                "under fertiliser/"
+            )
+            return selected
+
+        self.log.warning(f"❌ No in-depth main-register files found for GR {target_year}")
+        return []
+
+    def _get_fertilizer_accounts_file_path(self, target_year: int | None = None) -> str | None:
+        """Return the first main-register part for backwards compatibility."""
+        files = self._get_fertilizer_accounts_file_paths(target_year)
+        return files[0] if files else None
+
+    def _get_gr_column_map(self, table_name: str) -> dict[str, tuple[str, str]]:
+        """Return lower-case GR column names mapped to quoted name and DuckDB type."""
+        return {
+            column[0].lower(): (f'"{column[0].replace(chr(34), chr(34) * 2)}"', column[1])
+            for column in self.db.execute(f"DESCRIBE {table_name}").fetchall()
+        }
+
+    @staticmethod
+    def _gr_number_expression(column: tuple[str, str] | None) -> str:
+        """Parse both Excel numerics and Danish CSV number formatting.
+
+        The 2024 CSV release uses ``1.234,56`` while Excel-derived Silver
+        files are usually native numerics or strings such as ``1234.56``.
+        """
+        if column is None:
+            return "0.0"
+
+        reference = column[0]
+        if column[1].upper() not in {"VARCHAR", "TEXT", "STRING"}:
+            return f"COALESCE(TRY_CAST({reference} AS DOUBLE), 0.0)"
+
+        value = f"TRIM(CAST({reference} AS VARCHAR))"
+        return f"""
+            COALESCE(
+                CASE
+                    WHEN instr({value}, ',') > 0 THEN
+                        TRY_CAST(
+                            replace(replace(replace({value}, ' ', ''), '.', ''), ',', '.')
+                            AS DOUBLE
+                        )
+                    WHEN regexp_matches({value}, '^-?[0-9]{{1,3}}([.][0-9]{{3}})+$') THEN
+                        TRY_CAST(replace({value}, '.', '') AS DOUBLE)
+                    ELSE TRY_CAST(replace({value}, ' ', '') AS DOUBLE)
+                END,
+                0.0
+            )
+        """
+
+    @classmethod
+    def _gr_cvr_expression(cls, column: tuple[str, str] | None) -> str:
+        """Normalize CVR values without converting identifiers through BIGINT."""
+        if column is None:
+            return "NULL"
+
+        value = f"TRIM(CAST({column[0]} AS VARCHAR))"
+        # Excel can represent an identifier as ``12345678.0``.  Strip only
+        # that numeric suffix, then remove separators and pad short values.
+        without_decimal = f"regexp_replace({value}, '[.]0+$', '')"
+        digits = f"regexp_replace({without_decimal}, '[^0-9]', '', 'g')"
+        return f"""
+            CASE
+                WHEN length({digits}) BETWEEN 1 AND 8 AND {digits} <> '00000000'
+                THEN lpad({digits}, 8, '0')
+                ELSE NULL
+            END
+        """
+
+    @staticmethod
+    def _first_gr_number(columns: dict[str, tuple[str, str]], names: tuple[str, ...]) -> str:
+        """Use the first available form code, with compatibility aliases."""
+        for name in names:
+            column = columns.get(name.lower())
+            if column is not None:
+                return NLES5DataLoader._gr_number_expression(column)
+        return "0.0"
+
+    def _transform_gr_main_register(
+        self, raw_table: str, output_table: str, year: int, source_file_count: int
+    ) -> None:
+        """Project a raw in-depth main register to the NLES5 fertilizer schema."""
+        columns = self._get_gr_column_map(raw_table)
+        cvr_column = next(
+            (columns[name] for name in ("cvr", "cvr_number") if name in columns), None
+        )
+        cvr_expression = self._gr_cvr_expression(cvr_column)
+
+        total_n = self._first_gr_number(columns, ("f_901",))
+        mineral_n = self._first_gr_number(columns, ("f_706_1", "f_706"))
+        mineral_n_autumn = self._first_gr_number(columns, ("f_704_1", "f_704"))
+        grazing_n = self._first_gr_number(columns, ("f_318_1", "f_318"))
+        manure_n = self._first_gr_number(columns, ("f_308_1",))
+        other_organic_n = self._first_gr_number(columns, ("f_804_1",))
+        own_livestock_n = self._first_gr_number(columns, ("f_225_1",))
+        quota = self._first_gr_number(columns, ("f_512",))
+        remaining_quota = self._first_gr_number(columns, ("f_902",))
+        harmoni_area = self._first_gr_number(columns, ("f_243",))
+        area_total = f"NULLIF(SUM({harmoni_area}), 0)"
+        total_n_kg = f"SUM({total_n})"
+        mineral_n_kg = f"SUM({mineral_n})"
+        mineral_n_autumn_kg = f"SUM({mineral_n_autumn})"
+        grazing_n_kg = f"SUM({grazing_n})"
+        manure_n_kg = f"SUM({manure_n})"
+
+        # F_* fields are farm totals in kg N; NLES5 inputs are kg/ha. The GR
+        # main register does not contain a spring mineral-N total. F_704_1 is
+        # the explicit early-autumn consumption field, and F_318_1 is the
+        # explicit grazing-deposition field used by the NLES5 ``udb`` input.
+        # F_706_1 remains an annual audit total; it is never allocated to a
+        # season that the source does not report.
+        self.db.execute(f"""
+            CREATE OR REPLACE TABLE {output_table} AS
+            SELECT
+                {cvr_expression} AS cvr_number,
+                {year}::INTEGER AS year,
+                COALESCE({total_n_kg} / {area_total} / 1000.0, 0.0) AS tn_t_ha,
+                0.0::DOUBLE AS mineral_n_foraar,
+                COALESCE({mineral_n_autumn_kg} / {area_total}, 0.0) AS mineral_n_eft,
+                COALESCE({grazing_n_kg} / {area_total}, 0.0) AS mineral_n_udb,
+                COALESCE({manure_n_kg} / {area_total}, 0.0) AS organic_n_hus,
+                {mineral_n_kg} AS mineral_n_total,
+                {mineral_n_autumn_kg} AS mineral_n_autumn_total_kg,
+                {grazing_n_kg} AS grazing_n_total_kg,
+                COALESCE({manure_n_kg} / {area_total}, 0.0) AS organic_n_livestock,
+                SUM({other_organic_n}) AS organic_n_other,
+                SUM({own_livestock_n}) AS own_livestock_n,
+                SUM({quota}) AS n_quota,
+                SUM({remaining_quota}) AS remaining_n_quota,
+                SUM({harmoni_area}) AS harmoni_area_ha,
+                {total_n_kg} AS total_n_consumption_kg,
+                {manure_n_kg} AS organic_n_livestock_total_kg,
+                'Detailed main register' AS niveau,
+                'explicit_register_fields_only' AS mineral_n_allocation_method,
+                {source_file_count}::INTEGER AS source_file_count
+            FROM {raw_table}
+            WHERE {cvr_expression} IS NOT NULL
+            GROUP BY 1
+        """)
+
+    def _load_fertilizer_accounts_for_years(
+        self, years: list[int], table_name: str = "fertilizer_accounts"
+    ) -> bool:
+        """Load and aggregate all available GR main-register parts for ``years``."""
+        year_tables: list[str] = []
+        requested_years = sorted({int(year) for year in years})
+        self.db.execute(f"DROP TABLE IF EXISTS {table_name}")
+
+        for year in requested_years:
+            files = self._get_fertilizer_accounts_file_paths(year)
+            if not files:
+                self.log.warning(f"⚠️ Skipping fertilizer accounts for {year}: no main register")
+                continue
+
+            raw_tables: list[str] = []
+            for index, file_path in enumerate(files):
+                raw_table = f"gr_raw_{year}_{index}"
+                self.storage.create_table_from_storage(raw_table, file_path)
+                raw_tables.append(raw_table)
+
+            combined_raw = f"gr_raw_combined_{year}"
+            union_parts = [f"SELECT * FROM {raw_table}" for raw_table in raw_tables]
+            self.db.execute(
+                f"CREATE OR REPLACE TABLE {combined_raw} AS "
+                + " UNION ALL BY NAME ".join(union_parts)
+            )
+            for raw_table in raw_tables:
+                self.db.execute(f"DROP TABLE IF EXISTS {raw_table}")
+
+            year_table = f"fertilizer_accounts_{year}"
+            self._transform_gr_main_register(combined_raw, year_table, year, len(files))
+            self.db.execute(f"DROP TABLE IF EXISTS {combined_raw}")
+            year_tables.append(year_table)
+
+        if not year_tables:
+            return False
+
+        self.db.execute(
+            f"CREATE TABLE {table_name} AS "
+            + " UNION ALL BY NAME ".join(f"SELECT * FROM {table}" for table in year_tables)
+        )
+        for year_table in year_tables:
+            self.db.execute(f"DROP TABLE IF EXISTS {year_table}")
+
+        row_count = self.db.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]
+        self.log.info(
+            f"✅ Aggregated {row_count:,} farm fertilizer-account rows across "
+            f"{len(year_tables)} GR year(s)"
+        )
+        return row_count > 0
 
     def _get_field_plan_data_path(self, target_year: int | None = None) -> str:
         """
@@ -1104,8 +1325,9 @@ class NLES5DataLoader:
                             # the directory structure
                             try:
                                 if dataset_name == self.config.fertilizer_dataset:
-                                    test_path = self._get_fertilizer_accounts_file_path()
-                                    files = [test_path] if test_path else []
+                                    target_years = getattr(self.config, "target_years", [])
+                                    first_year = target_years[0] if target_years else None
+                                    files = self._get_fertilizer_accounts_file_paths(first_year)
                                 elif dataset_name == self.config.catch_crops_dataset:
                                     test_path = self._get_catch_crops_data_path()
                                     files = [test_path] if test_path else []
@@ -1131,60 +1353,33 @@ class NLES5DataLoader:
                             data_file = f"{latest_dir}data.parquet"
                             files = [data_file] if self.storage.file_exists(data_file) else []
 
+                        if dataset_name == self.config.fertilizer_dataset:
+                            try:
+                                target_years = getattr(self.config, "target_years", [])
+                                success = self._load_fertilizer_accounts_for_years(
+                                    target_years, table_name
+                                )
+                                if success:
+                                    loaded_tables[dataset_name] = table_name
+                                    self.log.info(
+                                        f"✅ Successfully loaded fertilizer data for years: "
+                                        f"{target_years}"
+                                    )
+                                else:
+                                    self.log.error(
+                                        f"❌ Failed to load fertilizer data {dataset_name}"
+                                    )
+                            except Exception as e:
+                                self.log.error(
+                                    f"❌ CRITICAL: Failed to load required fertilizer data: {e}"
+                                )
+                            continue
+
                         if files:
                             self.log.info(f"Found {dataset_name} in silver layer.")
 
-                            # Special handling for fertilizer data to get the latest 2024 data
-                            if dataset_name == self.config.fertilizer_dataset:
-                                try:
-                                    # Use the first target year as the reference for fertilizer data
-                                    target_year = (
-                                        self.config.target_years[0]
-                                        if getattr(self.config, "target_years", None)
-                                        and len(self.config.target_years) > 0
-                                        else None
-                                    )
-                                    fertilizer_file_path = self._get_fertilizer_accounts_file_path(
-                                        target_year
-                                    )
-                                    if fertilizer_file_path:
-                                        self.log.info(
-                                            f"Using fertilizer accounts file for year "
-                                            f"{target_year}: {fertilizer_file_path}"
-                                        )
-                                        success = self._read_silver_data_from_path(
-                                            dataset_name, fertilizer_file_path, table_name
-                                        )
-                                        if success:
-                                            # Add year column to fertilizer data
-                                            self._add_year_to_fertilizer_data(
-                                                fertilizer_file_path, table_name
-                                            )
-                                            # Transform raw fertilizer data to expected schema
-                                            self._transform_raw_fertilizer_data(table_name)
-                                            loaded_tables[dataset_name] = table_name
-                                            self.log.info(
-                                                f"✅ Successfully loaded fertilizer data: "
-                                                f"{dataset_name}"
-                                            )
-                                            continue
-                                        self.log.error(
-                                            f"❌ Failed to load fertilizer data {dataset_name}"
-                                        )
-                                        continue
-                                    self.log.error(
-                                        f"❌ No fertilizer accounts file found for year "
-                                        f"{target_year}"
-                                    )
-                                    continue
-                                except Exception as e:
-                                    self.log.error(
-                                        f"❌ CRITICAL: Failed to load required fertilizer data: {e}"
-                                    )
-                                    continue
-
                             # Special handling for catch crops data (optional)
-                            elif dataset_name == self.config.catch_crops_dataset:
+                            if dataset_name == self.config.catch_crops_dataset:
                                 try:
                                     target_year = (
                                         self.config.target_years[0]
@@ -1498,8 +1693,8 @@ class NLES5DataLoader:
         Load farm-level gødningsregnskab data for enhanced NLES5 calculations.
 
         Loads animal production data (C_2016, C_2006) and fertilizer application data
-        (F_901, F_902, F_512, F_703_1, F_706_1, F_308_1) to replace estimated values
-        with actual farm-specific data.
+        (F_901, F_902, F_512, F_704_1, F_706_1, F_318_1, F_308_1, F_804_1) to replace
+        estimated values with actual farm-specific data.
 
         Args:
             years: List of years to load farm data for
@@ -1570,6 +1765,51 @@ class NLES5DataLoader:
             self.log.error(f"❌ Failed to load farm data: {e}")
             return None
 
+    def _normalize_gr_cvr_table(self, table_name: str, output_table: str) -> None:
+        """Create a copy of a GR table with one normalized ``cvr`` column."""
+        columns = self._get_gr_column_map(table_name)
+        cvr_column = next(
+            (columns[name] for name in ("cvr", "cvr_number") if name in columns), None
+        )
+        if cvr_column is None:
+            raise ValueError(f"GR table {table_name} has no CVR column")
+
+        source_columns = [
+            column[0] for name, column in columns.items() if name not in {"cvr", "cvr_number"}
+        ]
+        select_parts = [*source_columns, f"{self._gr_cvr_expression(cvr_column)} AS cvr"]
+        self.db.execute(f"""
+            CREATE OR REPLACE TABLE {output_table} AS
+            SELECT {", ".join(select_parts)}
+            FROM {table_name}
+            WHERE {self._gr_cvr_expression(cvr_column)} IS NOT NULL
+        """)
+
+    def _summarize_gr_animal_table(self, table_name: str, output_table: str) -> None:
+        """Aggregate B_DYRERK's animal rows to one row per farm."""
+        columns = self._get_gr_column_map(table_name)
+        cvr_column = next(
+            (columns[name] for name in ("cvr", "cvr_number") if name in columns), None
+        )
+        if cvr_column is None:
+            raise ValueError(f"GR animal table {table_name} has no CVR column")
+
+        cvr_expression = self._gr_cvr_expression(cvr_column)
+        production_n = self._first_gr_number(columns, ("c_2016",))
+        animal_count = self._first_gr_number(columns, ("c_2006",))
+        animal_units = self._first_gr_number(columns, ("c_2017",))
+        self.db.execute(f"""
+            CREATE OR REPLACE TABLE {output_table} AS
+            SELECT
+                {cvr_expression} AS cvr,
+                SUM({production_n}) AS organic_n_production,
+                SUM({animal_count}) AS animal_count,
+                SUM({animal_units}) AS animal_units
+            FROM {table_name}
+            WHERE {cvr_expression} IS NOT NULL
+            GROUP BY 1
+        """)
+
     def _load_farm_data_for_year(self, year: int) -> str | None:
         """
         Load farm data for a specific year from storage bucket into DuckDB.
@@ -1581,26 +1821,49 @@ class NLES5DataLoader:
             Table name with farm data or None if not available
         """
         try:
-            # Load gødningsregnskab from storage bucket
-            # Dynamically find the latest timestamped directory for this year
-            base_path = f"{self.config.bucket}/silver/gr {year}/"
-            latest_dir = self._get_latest_timestamped_directory(base_path, f"farm data {year}")
-
-            if not latest_dir:
-                self.log.warning(f"No farm data found for year {year} in {base_path}")
-                return None
-
-            self.log.info(f"Loading farm data from: {latest_dir}")
-
-            # List available parquet files in the latest directory
-            pattern = f"{latest_dir}*.parquet"
-            files = self.storage.list_files(pattern)
+            # The Drive Silver processor may sanitize ``GR 2025`` to
+            # ``gr_2025`` and may use a Unix timestamp rather than the older
+            # YYYYMMDD_HHMMSS directory format.  Search both layouts and keep
+            # the newest timestamped run when that metadata is available.
+            files: list[str] = []
+            for base_path in (
+                f"{self.config.bucket}/silver/gr {year}/",
+                f"{self.config.bucket}/silver/gr_{year}/",
+            ):
+                for pattern in (f"{base_path}*/*.parquet", f"{base_path}*.parquet"):
+                    try:
+                        files.extend(self.storage.list_files(pattern))
+                    except Exception as e:
+                        self.log.debug(f"Could not list farm data with {pattern}: {e}")
+                if files:
+                    break
 
             if not files:
-                self.log.warning(
-                    f"No farm data files found for year {year} in cloud storage: {pattern}"
-                )
+                year_code = f"{year % 100:02d}"
+                try:
+                    all_silver_files = self.storage.list_files(
+                        f"{self.config.bucket}/silver/**/*.parquet"
+                    )
+                except Exception as e:
+                    self.log.debug(f"Could not search Silver fallback tree for GR {year}: {e}")
+                    all_silver_files = []
+                files = [
+                    file_path
+                    for file_path in all_silver_files
+                    if (
+                        f"gr {year}" in file_path.lower()
+                        or f"gr_{year}" in file_path.lower()
+                        or f"4061gr_{year_code}_" in file_path.lower()
+                        or f"4061gr_{year}_" in file_path.lower()
+                    )
+                ]
+
+            files = self._latest_gr_files(files)
+            if not files:
+                self.log.warning(f"No farm data found for year {year}")
                 return None
+
+            self.log.info(f"Loading farm data from {len(files)} GR file(s) for {year}")
 
             # Create temporary table name for this year
             main_table = f"farm_main_{year}"
@@ -1608,14 +1871,21 @@ class NLES5DataLoader:
             final_table = f"farm_data_{year}"
 
             # Find main data files (typically 4061GR files or Del1/Del2 files)
-            main_files = [
-                f
-                for f in files
-                if any(pattern in f for pattern in ["4061GR", "_Del1", "_Del2", "FELTDEFINITION"])
-            ]
+            main_files = [f for f in files if self._is_in_depth_main_register_file(f)]
+            if not main_files:
+                # Legacy GR releases used B_GOEDRK_6B instead of the V_4061GR
+                # main-register naming convention.
+                main_files = [
+                    f
+                    for f in files
+                    if "GOEDRK" in f.upper()
+                    and not any(token in f.upper() for token in ("DYRERK", "AFTRK"))
+                ]
+            main_files = self._prefer_final_gr_files(main_files)
             animal_files = [
-                f for f in files if any(pattern in f for pattern in ["DYRERK", "B_DYRERK"])
+                f for f in files if any(pattern in f.upper() for pattern in ["DYRERK", "B_DYRERK"])
             ]
+            animal_files = self._prefer_final_gr_files(animal_files)
 
             if not main_files:
                 self.log.warning(f"No main farm data files found for year {year}")
@@ -1634,12 +1904,22 @@ class NLES5DataLoader:
                     union_parts.append(f"SELECT * FROM {temp_table}")
 
                 # Create combined main table
-                union_sql = f"CREATE TABLE {main_table} AS {' UNION ALL '.join(union_parts)}"
+                union_sql = (
+                    f"CREATE TABLE {main_table} AS {' UNION ALL BY NAME '.join(union_parts)}"
+                )
                 self.db.execute(union_sql)
 
                 # Clean up temp tables
                 for i, _ in enumerate(main_files):
                     self.db.execute(f"DROP TABLE IF EXISTS farm_temp_main_{year}_{i}")
+
+            # Normalize CVR once so both raw ``CVR`` columns and the Drive
+            # transformer's ``cvr_number`` column join consistently and the
+            # cache's existing COUNT(DISTINCT cvr) check remains valid.
+            normalized_main_table = f"farm_main_normalized_{year}"
+            self._normalize_gr_cvr_table(main_table, normalized_main_table)
+            self.db.execute(f"DROP TABLE IF EXISTS {main_table}")
+            self.db.execute(f"ALTER TABLE {normalized_main_table} RENAME TO {main_table}")
 
             # Load animal data if available
             if animal_files:
@@ -1655,14 +1935,21 @@ class NLES5DataLoader:
                         union_parts.append(f"SELECT * FROM {temp_table}")
 
                     # Create combined animal table
-                    union_sql = f"CREATE TABLE {animal_table} AS {' UNION ALL '.join(union_parts)}"
+                    union_sql = (
+                        f"CREATE TABLE {animal_table} AS {' UNION ALL BY NAME '.join(union_parts)}"
+                    )
                     self.db.execute(union_sql)
 
                     # Clean up temp tables
                     for i, _ in enumerate(animal_files):
                         self.db.execute(f"DROP TABLE IF EXISTS farm_temp_animal_{year}_{i}")
 
-                # Merge main data with animal data (try to find CVR column in different formats)
+                animal_summary_table = f"farm_animal_summary_{year}"
+                self._summarize_gr_animal_table(animal_table, animal_summary_table)
+                self.db.execute(f"DROP TABLE IF EXISTS {animal_table}")
+                self.db.execute(f"ALTER TABLE {animal_summary_table} RENAME TO {animal_table}")
+
+                # Merge main data with the aggregated B_DYRERK animal data.
                 try:
                     self.db.execute(f"""
                         CREATE TABLE {final_table} AS
@@ -1671,7 +1958,7 @@ class NLES5DataLoader:
                                COALESCE(a.animal_count, 0) as animal_count,
                                COALESCE(a.animal_units, 0) as animal_units
                         FROM {main_table} m
-                        LEFT JOIN {animal_table} a ON m.CVR = a.CVR
+                        LEFT JOIN {animal_table} a ON m.cvr = a.cvr
                     """)
                 except Exception as e:
                     self.log.warning(f"Failed to join with animal data: {e}. Using main data only.")
@@ -2150,22 +2437,62 @@ class NLES5DataLoader:
     def _transform_fertilizer_accounting_data(
         self, table_name: str, column_names: list[str]
     ) -> None:
-        """Transform fertilizer accounting data with form codes (f_901, etc.)."""
+        """Transform legacy accounting tables using the same GR field mapping."""
         try:
-            # Map form codes to expected columns
+            columns = self._get_gr_column_map(table_name)
+            cvr_column = next(
+                (columns[name] for name in ("cvr", "cvr_number") if name in columns), None
+            )
+            year_column = columns.get("year")
+            if year_column is None:
+                raise ValueError(f"Legacy fertilizer table {table_name} has no year column")
+
+            cvr_expression = self._gr_cvr_expression(cvr_column)
+            total_n = self._first_gr_number(columns, ("f_901",))
+            mineral_n = self._first_gr_number(columns, ("f_706_1", "f_706"))
+            mineral_n_autumn = self._first_gr_number(columns, ("f_704_1", "f_704"))
+            grazing_n = self._first_gr_number(columns, ("f_318_1", "f_318"))
+            manure_n = self._first_gr_number(columns, ("f_308_1",))
+            other_organic_n = self._first_gr_number(columns, ("f_804_1",))
+            own_livestock_n = self._first_gr_number(columns, ("f_225_1",))
+            quota = self._first_gr_number(columns, ("f_512",))
+            remaining_quota = self._first_gr_number(columns, ("f_902",))
+            harmoni_area = self._first_gr_number(columns, ("f_243",))
+            year_expression = f"TRY_CAST({year_column[0]} AS INTEGER)"
+            area_total = f"NULLIF(SUM({harmoni_area}), 0)"
+            total_n_kg = f"SUM({total_n})"
+            mineral_n_kg = f"SUM({mineral_n})"
+            mineral_n_autumn_kg = f"SUM({mineral_n_autumn})"
+            grazing_n_kg = f"SUM({grazing_n})"
+            manure_n_kg = f"SUM({manure_n})"
+
             self.processor.conn.execute(f"""
                 CREATE OR REPLACE TABLE {table_name}_transformed AS
                 SELECT
-                    cvr_number,
-                    year,
-                    COALESCE(TRY_CAST(f_901 AS DOUBLE), 0.0) as tn_t_ha,
-                    COALESCE(TRY_CAST(f_185_2 AS DOUBLE), 0.0) as mineral_n_foraar,
-                    COALESCE(TRY_CAST(f_185_3 AS DOUBLE), 0.0) as mineral_n_eft,
-                    COALESCE(TRY_CAST(f_188_2 AS DOUBLE), 0.0) as mineral_n_udb,
-                    COALESCE(TRY_CAST(f_601_2 AS DOUBLE), 0.0) as organic_n_hus,
-                    'Standard' as niveau
+                    {cvr_expression} AS cvr_number,
+                    {year_expression} AS year,
+                    COALESCE({total_n_kg} / {area_total} / 1000.0, 0.0) AS tn_t_ha,
+                    0.0::DOUBLE AS mineral_n_foraar,
+                    COALESCE({mineral_n_autumn_kg} / {area_total}, 0.0) AS mineral_n_eft,
+                    COALESCE({grazing_n_kg} / {area_total}, 0.0) AS mineral_n_udb,
+                    COALESCE({manure_n_kg} / {area_total}, 0.0) AS organic_n_hus,
+                    {mineral_n_kg} AS mineral_n_total,
+                    {mineral_n_autumn_kg} AS mineral_n_autumn_total_kg,
+                    {grazing_n_kg} AS grazing_n_total_kg,
+                    COALESCE({manure_n_kg} / {area_total}, 0.0) AS organic_n_livestock,
+                    SUM({other_organic_n}) AS organic_n_other,
+                    SUM({own_livestock_n}) AS own_livestock_n,
+                    SUM({quota}) AS n_quota,
+                    SUM({remaining_quota}) AS remaining_n_quota,
+                    SUM({harmoni_area}) AS harmoni_area_ha,
+                    {total_n_kg} AS total_n_consumption_kg,
+                    {manure_n_kg} AS organic_n_livestock_total_kg,
+                    'Detailed main register' AS niveau,
+                    'explicit_register_fields_only' AS mineral_n_allocation_method,
+                    1::INTEGER AS source_file_count
                 FROM {table_name}
-                WHERE cvr_number IS NOT NULL
+                WHERE {cvr_expression} IS NOT NULL
+                GROUP BY 1, 2
             """)
 
             self.processor.conn.execute(f"DROP TABLE IF EXISTS {table_name}")

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/fertilizer_distributor.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/fertilizer_distributor.py
@@ -21,7 +21,9 @@ The algorithm follows the prioritized approach for organic fertilizer allocation
    - If organic fertilizer > 50% of total N-quota → distribute proportionally by N-quota
    - If organic fertilizer ≤ 50% of total N-quota → distribute up to 50% per crop by priority
 
-3. Mineral fertilizer distribution follows the same proportional allocation after organic.
+3. Reported fertilizer source components are allocated independently after organic:
+   commercial N reported for spring, commercial N reported for autumn, and grazing N.
+   No seasonal split is inferred from an annual commercial-N total.
 
 SOURCE:
 - N2023_62.md, Section 4.5 Gødningsfordeling, markniveau
@@ -71,6 +73,17 @@ class FieldFertilizerAllocation:
     organic_quota_fraction: float  # How much of N-quota comes from organic
     allocation_method: str  # 'proportional' or 'priority_based'
 
+    # Source-specific rates are kept separately so farm-level seasonal inputs
+    # are not replaced by an assumed split when they are joined back to fields.
+    grazing_n_allocated_kg: float = 0.0
+    mineral_n_spring_allocated_kg: float = 0.0
+    mineral_n_autumn_allocated_kg: float = 0.0
+    grazing_n_rate_kg_ha: float = 0.0
+    mineral_n_spring_rate_kg_ha: float = 0.0
+    mineral_n_autumn_rate_kg_ha: float = 0.0
+    reported_total_n_allocated_kg: float = 0.0
+    reported_total_n_rate_kg_ha: float = 0.0
+
 
 @dataclass
 class FarmFertilizerBudget:
@@ -81,6 +94,9 @@ class FarmFertilizerBudget:
     total_organic_n_kg: float
     total_mineral_n_kg: float
     total_n_kg: float
+    grazing_n_kg: float = 0.0
+    mineral_n_spring_kg: float = 0.0
+    mineral_n_autumn_kg: float = 0.0
 
 
 class NLES5FertilizerDistributor:
@@ -206,7 +222,8 @@ class NLES5FertilizerDistributor:
         self.log.debug(
             f"Distributing fertilizer for CVR {farm_budget.cvr_number}, "
             f"year {farm_budget.year}: {farm_budget.total_organic_n_kg:.1f} kg organic N, "
-            f"{farm_budget.total_mineral_n_kg:.1f} kg mineral N across {len(field_data)} fields"
+            f"{farm_budget.total_mineral_n_kg:.1f} kg mineral N and "
+            f"{farm_budget.grazing_n_kg:.1f} kg grazing N across {len(field_data)} fields"
         )
 
         # Step 1: Prepare field data with priorities and quotas
@@ -272,7 +289,11 @@ class NLES5FertilizerDistributor:
             organic_n_allocated = farm_budget.total_organic_n_kg * field_quota_fraction
 
             # Distribute mineral N proportionally
-            mineral_n_allocated = farm_budget.total_mineral_n_kg * field_quota_fraction
+            mineral_n_spring_allocated = farm_budget.mineral_n_spring_kg * field_quota_fraction
+            mineral_n_autumn_allocated = farm_budget.mineral_n_autumn_kg * field_quota_fraction
+            grazing_n_allocated = farm_budget.grazing_n_kg * field_quota_fraction
+            mineral_n_allocated = mineral_n_spring_allocated + mineral_n_autumn_allocated
+            reported_total_n_allocated = farm_budget.total_n_kg * field_quota_fraction
 
             allocation = FieldFertilizerAllocation(
                 field_id=field["field_id"],
@@ -285,7 +306,9 @@ class NLES5FertilizerDistributor:
                 total_n_quota_kg=field["n_quota_kg"],
                 organic_n_allocated_kg=organic_n_allocated,
                 mineral_n_allocated_kg=mineral_n_allocated,
-                total_n_allocated_kg=organic_n_allocated + mineral_n_allocated,
+                total_n_allocated_kg=organic_n_allocated
+                + mineral_n_allocated
+                + grazing_n_allocated,
                 organic_n_rate_kg_ha=organic_n_allocated / field["area_ha"]
                 if field["area_ha"] > 0
                 else 0,
@@ -296,6 +319,22 @@ class NLES5FertilizerDistributor:
                 if field["n_quota_kg"] > 0
                 else 0,
                 allocation_method="proportional",
+                grazing_n_allocated_kg=grazing_n_allocated,
+                mineral_n_spring_allocated_kg=mineral_n_spring_allocated,
+                mineral_n_autumn_allocated_kg=mineral_n_autumn_allocated,
+                grazing_n_rate_kg_ha=grazing_n_allocated / field["area_ha"]
+                if field["area_ha"] > 0
+                else 0,
+                mineral_n_spring_rate_kg_ha=mineral_n_spring_allocated / field["area_ha"]
+                if field["area_ha"] > 0
+                else 0,
+                mineral_n_autumn_rate_kg_ha=mineral_n_autumn_allocated / field["area_ha"]
+                if field["area_ha"] > 0
+                else 0,
+                reported_total_n_allocated_kg=reported_total_n_allocated,
+                reported_total_n_rate_kg_ha=reported_total_n_allocated / field["area_ha"]
+                if field["area_ha"] > 0
+                else 0,
             )
 
             allocations.append(allocation)
@@ -308,7 +347,9 @@ class NLES5FertilizerDistributor:
         """Distribute fertilizer by priority when organic ≤ 50%, up to 50% of each field's quota."""
         allocations = []
         remaining_organic_n = farm_budget.total_organic_n_kg
-        remaining_mineral_n = farm_budget.total_mineral_n_kg
+        remaining_mineral_n_spring = farm_budget.mineral_n_spring_kg
+        remaining_mineral_n_autumn = farm_budget.mineral_n_autumn_kg
+        remaining_grazing_n = farm_budget.grazing_n_kg
 
         # Initialize all fields with zero allocation
         for field in fields:
@@ -364,17 +405,27 @@ class NLES5FertilizerDistributor:
         total_remaining_quota = sum(
             field["n_quota_kg"] - field["organic_n_allocated"] for field in fields
         )
+        total_n_quota = sum(field["n_quota_kg"] for field in fields)
 
         for field in fields:
             if total_remaining_quota > 0:
                 remaining_quota_fraction = (
                     field["n_quota_kg"] - field["organic_n_allocated"]
                 ) / total_remaining_quota
-                mineral_allocated = remaining_mineral_n * remaining_quota_fraction
+                mineral_spring_allocated = remaining_mineral_n_spring * remaining_quota_fraction
+                mineral_autumn_allocated = remaining_mineral_n_autumn * remaining_quota_fraction
+                grazing_allocated = remaining_grazing_n * remaining_quota_fraction
             else:
-                mineral_allocated = 0
+                mineral_spring_allocated = 0
+                mineral_autumn_allocated = 0
+                grazing_allocated = 0
 
-            field["mineral_n_allocated"] = mineral_allocated
+            field["mineral_n_spring_allocated"] = mineral_spring_allocated
+            field["mineral_n_autumn_allocated"] = mineral_autumn_allocated
+            field["grazing_n_allocated"] = grazing_allocated
+            field["mineral_n_allocated"] = mineral_spring_allocated + mineral_autumn_allocated
+            field_quota_fraction = field["n_quota_kg"] / total_n_quota if total_n_quota > 0 else 0
+            field["reported_total_n_allocated"] = farm_budget.total_n_kg * field_quota_fraction
 
         # Step 4: Create allocation objects
         for field in fields:
@@ -389,7 +440,11 @@ class NLES5FertilizerDistributor:
                 total_n_quota_kg=field["n_quota_kg"],
                 organic_n_allocated_kg=field["organic_n_allocated"],
                 mineral_n_allocated_kg=field["mineral_n_allocated"],
-                total_n_allocated_kg=field["organic_n_allocated"] + field["mineral_n_allocated"],
+                total_n_allocated_kg=(
+                    field["organic_n_allocated"]
+                    + field["mineral_n_allocated"]
+                    + field["grazing_n_allocated"]
+                ),
                 organic_n_rate_kg_ha=field["organic_n_allocated"] / field["area_ha"]
                 if field["area_ha"] > 0
                 else 0,
@@ -400,6 +455,22 @@ class NLES5FertilizerDistributor:
                 if field["n_quota_kg"] > 0
                 else 0,
                 allocation_method="priority_based",
+                grazing_n_allocated_kg=field["grazing_n_allocated"],
+                mineral_n_spring_allocated_kg=field["mineral_n_spring_allocated"],
+                mineral_n_autumn_allocated_kg=field["mineral_n_autumn_allocated"],
+                grazing_n_rate_kg_ha=field["grazing_n_allocated"] / field["area_ha"]
+                if field["area_ha"] > 0
+                else 0,
+                mineral_n_spring_rate_kg_ha=field["mineral_n_spring_allocated"] / field["area_ha"]
+                if field["area_ha"] > 0
+                else 0,
+                mineral_n_autumn_rate_kg_ha=field["mineral_n_autumn_allocated"] / field["area_ha"]
+                if field["area_ha"] > 0
+                else 0,
+                reported_total_n_allocated_kg=field["reported_total_n_allocated"],
+                reported_total_n_rate_kg_ha=field["reported_total_n_allocated"] / field["area_ha"]
+                if field["area_ha"] > 0
+                else 0,
             )
 
             allocations.append(allocation)
@@ -427,11 +498,16 @@ class NLES5FertilizerDistributor:
             SELECT
                 cvr_number,
                 year,
-                SUM(organic_n_hus * area_ha) as total_organic_n_kg,
-                SUM((mineral_n_foraar + mineral_n_eft + mineral_n_udb) * area_ha)
+                -- ``mineral_n_udb`` is the legacy NLES5 column name for N
+                -- deposited by grazing animals, not a proxy for mineral N.
+                SUM(organic_n_hus * harmoni_area_ha) as total_organic_n_kg,
+                SUM((mineral_n_foraar + mineral_n_eft) * harmoni_area_ha)
                     as total_mineral_n_kg,
+                SUM(mineral_n_udb * harmoni_area_ha) as grazing_n_kg,
+                SUM(mineral_n_foraar * harmoni_area_ha) as mineral_n_spring_kg,
+                SUM(mineral_n_eft * harmoni_area_ha) as mineral_n_autumn_kg,
                 -- Convert tonnes to kg
-                SUM(tn_t_ha * area_ha * 1000) as total_n_kg
+                SUM(tn_t_ha * harmoni_area_ha * 1000) as total_n_kg
             FROM fertilizer_accounts fa
             WHERE cvr_number IS NOT NULL
             GROUP BY cvr_number, year
@@ -475,7 +551,13 @@ class NLES5FertilizerDistributor:
             # Get farm budget
             budget_row = self.conn.execute(
                 """
-                SELECT total_organic_n_kg, total_mineral_n_kg, total_n_kg
+                SELECT
+                    total_organic_n_kg,
+                    total_mineral_n_kg,
+                    total_n_kg,
+                    grazing_n_kg,
+                    mineral_n_spring_kg,
+                    mineral_n_autumn_kg
                 FROM farm_fertilizer_budgets
                 WHERE cvr_number = ? AND year = ?
             """,
@@ -489,6 +571,9 @@ class NLES5FertilizerDistributor:
                     total_organic_n_kg=budget_row[0] or 0,
                     total_mineral_n_kg=budget_row[1] or 0,
                     total_n_kg=budget_row[2] or 0,
+                    grazing_n_kg=budget_row[3] or 0,
+                    mineral_n_spring_kg=budget_row[4] or 0,
+                    mineral_n_autumn_kg=budget_row[5] or 0,
                 )
 
                 # Apply distribution algorithm
@@ -515,9 +600,17 @@ class NLES5FertilizerDistributor:
                 total_n_quota_kg DECIMAL(10,2),
                 organic_n_allocated_kg DECIMAL(10,2),
                 mineral_n_allocated_kg DECIMAL(10,2),
+                grazing_n_allocated_kg DECIMAL(10,2),
+                mineral_n_spring_allocated_kg DECIMAL(10,2),
+                mineral_n_autumn_allocated_kg DECIMAL(10,2),
+                reported_total_n_allocated_kg DECIMAL(10,2),
                 total_n_allocated_kg DECIMAL(10,2),
                 organic_n_rate_kg_ha DECIMAL(8,2),
                 mineral_n_rate_kg_ha DECIMAL(8,2),
+                grazing_n_rate_kg_ha DECIMAL(8,2),
+                mineral_n_spring_rate_kg_ha DECIMAL(8,2),
+                mineral_n_autumn_rate_kg_ha DECIMAL(8,2),
+                reported_total_n_rate_kg_ha DECIMAL(8,2),
                 organic_quota_fraction DECIMAL(5,3),
                 allocation_method VARCHAR
             )
@@ -539,9 +632,17 @@ class NLES5FertilizerDistributor:
                     alloc.total_n_quota_kg,
                     alloc.organic_n_allocated_kg,
                     alloc.mineral_n_allocated_kg,
+                    alloc.grazing_n_allocated_kg,
+                    alloc.mineral_n_spring_allocated_kg,
+                    alloc.mineral_n_autumn_allocated_kg,
+                    alloc.reported_total_n_allocated_kg,
                     alloc.total_n_allocated_kg,
                     alloc.organic_n_rate_kg_ha,
                     alloc.mineral_n_rate_kg_ha,
+                    alloc.grazing_n_rate_kg_ha,
+                    alloc.mineral_n_spring_rate_kg_ha,
+                    alloc.mineral_n_autumn_rate_kg_ha,
+                    alloc.reported_total_n_rate_kg_ha,
                     alloc.organic_quota_fraction,
                     alloc.allocation_method,
                 )
@@ -551,7 +652,7 @@ class NLES5FertilizerDistributor:
             self.conn.executemany(
                 """
                 INSERT INTO distributed_fertilizer_data
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 values,
             )
@@ -564,15 +665,16 @@ class NLES5FertilizerDistributor:
             SELECT
                 f.*,
                 COALESCE(d.organic_n_rate_kg_ha, 0.0) as organic_n_hus,
-                -- Assume 40% spring
-                COALESCE(d.mineral_n_rate_kg_ha * 0.4, 0.0) as mineral_n_foraar,
-                -- Assume 10% autumn
-                COALESCE(d.mineral_n_rate_kg_ha * 0.1, 0.0) as mineral_n_eft,
-                -- Assume 50% growing season
-                COALESCE(d.mineral_n_rate_kg_ha * 0.5, 0.0) as mineral_n_udb,
-                -- Convert to tonnes/ha
+                COALESCE(d.mineral_n_spring_rate_kg_ha, 0.0) as mineral_n_foraar,
+                COALESCE(d.mineral_n_autumn_rate_kg_ha, 0.0) as mineral_n_eft,
+                COALESCE(d.grazing_n_rate_kg_ha, 0.0) as mineral_n_udb,
+                -- F_901 is the reported annual total. Its field allocation is
+                -- separate from the explicit seasonal components below and
+                -- must not be used to infer a season.
                 COALESCE(
-                    d.total_n_allocated_kg / NULLIF(f.area_ha, 0) / 1000, 0.0
+                    NULLIF(d.reported_total_n_rate_kg_ha, 0) / 1000,
+                    d.total_n_allocated_kg / NULLIF(f.area_ha, 0) / 1000,
+                    0.0
                 ) as tn_t_ha,
                 COALESCE(d.allocation_method, 'no_fertilizer_data')
                     as fertilizer_allocation_method,


### PR DESCRIPTION
## Summary

- Make the Drive fertiliser transformer read the semicolon/Latin-1 2024 CSV release and legacy `.xls` 2025 release, preserving the raw `F_*` and `C_*` fields needed downstream.
- Make NLES5 discover and aggregate every year-matching main-register part through 2025, normalize CVRs, exclude detail tables from fertilizer-account totals, and aggregate `B_DYRERK` animal rows for farm data.
- Remove the old hard-coded 40/10/50 seasonal proxy. Keep reported annual N (`F_901`), annual commercial N (`F_706_1`), explicit autumn N (`F_704_1`), grazing N (`F_318_1`), and manure N (`F_308_1`) as separate source components.
- Add regression coverage and document the source mappings.

## Verification

- Full unified NLES5 suite: 477 passed, 1 skipped.
- Focused NLES5 parser suite: 7 passed.
- Drive transformer suite: 2 passed.
- Ruff passed for both touched packages; commit hooks passed.
- Read-only local smoke run succeeded against the supplied 2024 6A/6B files and 2025 main/`B_DYRERK` files, with distinct-CVR checks and no duplicate rows in the main-register outputs.

## Scope note

The attached digestate/opland handover is retained as follow-up domain context. This PR only makes the existing Gødningsregnskab inputs parseable and correctly routed into NLES5; it does not invent digestate recipient/opland attribution or alter the future per-opland analysis.