### PR TITLE
fix(drive): qualify R2 Silver paths

### DIFF
--- a/backend/pipelines/drive_data_pipeline/silver/processor.py
+++ b/backend/pipelines/drive_data_pipeline/silver/processor.py
@@ -816,10 +816,13 @@ class SilverProcessor:
                 # Use the persistent StorageAccess instance to avoid connection closure
                 storage_access = self._shared_storage_access
 
-                # Construct cloud storage path if needed
-                if not is_storage_path and using_cloud_storage:
+                # Construct the complete cloud storage path when using R2. The
+                # Silver manager returns paths relative to the bucket (e.g.
+                # ``gr_2025/<run>/<file>.parquet``), while StorageAccess
+                # requires ``<bucket>/silver/<path>``.
+                if using_cloud_storage:
                     bucket = getattr(self.storage_manager, "bucket_name", "landbruget-data")
-                    storage_path = f"{bucket}/silver/{output_path_str}"
+                    storage_path = self._get_cloud_storage_path(output_path_str, bucket)
                 else:
                     storage_path = output_path_str
 
@@ -871,6 +874,25 @@ class SilverProcessor:
             logger.warning(f"Failed to apply schema to {output_path}: {e!s}")
             return None
 
+    @staticmethod
+    def _get_cloud_storage_path(output_path: Path | str, bucket: str) -> str:
+        """Return a complete bucket/key path for a Silver or Bronze output.
+
+        Drive's R2 storage manager returns paths relative to the layer, while
+        ``StorageAccess`` accepts a bucket-qualified path. Preserve paths that
+        are already qualified so this helper is safe for both representations.
+        """
+        path = str(output_path).replace("\\", "/").lstrip("/")
+        bucket = bucket.strip("/")
+
+        if path.startswith(("r2://", "s3://")):
+            return path
+        if path == bucket or path.startswith(f"{bucket}/"):
+            return path
+        if path.startswith(("silver/", "bronze/")):
+            return f"{bucket}/{path}"
+        return f"{bucket}/silver/{path}"
+
     def _handle_pii_in_file(self, output_path: Path, silver_run_path: Path) -> Path | None:
         """Detect and handle PII in a processed file.
 
@@ -900,12 +922,11 @@ class SilverProcessor:
                 # Use the persistent StorageAccess instance to avoid connection closure
                 storage_access = self._shared_storage_access
 
-                # If we have a local path but are using cloud storage, construct the storage path
-                if not is_storage_path and using_cloud_storage:
-                    # Convert local path to cloud path using storage manager's bucket and base path
-                    # The output_path is relative to the silver base path
+                if using_cloud_storage:
+                    # Convert the Silver-relative output path to the complete
+                    # bucket-qualified key used by StorageAccess.
                     bucket = getattr(self.storage_manager, "bucket_name", "landbruget-data")
-                    storage_path = f"{bucket}/silver/{output_path_str}"
+                    storage_path = self._get_cloud_storage_path(output_path_str, bucket)
                 else:
                     storage_path = output_path_str
 

--- a/backend/pipelines/drive_data_pipeline/tests/silver/test_processor_storage_paths.py
+++ b/backend/pipelines/drive_data_pipeline/tests/silver/test_processor_storage_paths.py
@@ -1,0 +1,56 @@
+"""Tests for Silver processor cloud-storage path handling."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from drive_data_pipeline.silver.processor import SilverProcessor
+
+
+@pytest.mark.parametrize(
+    ("output_path", "expected"),
+    [
+        (
+            "gr_2025/20260912_131417/register.parquet",
+            "landbruget-data/silver/gr_2025/20260912_131417/register.parquet",
+        ),
+        (
+            "silver/gr_2025/20260912_131417/register.parquet",
+            "landbruget-data/silver/gr_2025/20260912_131417/register.parquet",
+        ),
+        (
+            "landbruget-data/silver/gr_2025/20260912_131417/register.parquet",
+            "landbruget-data/silver/gr_2025/20260912_131417/register.parquet",
+        ),
+        (
+            "r2://landbruget-data/silver/gr_2025/20260912_131417/register.parquet",
+            "r2://landbruget-data/silver/gr_2025/20260912_131417/register.parquet",
+        ),
+    ],
+)
+def test_get_cloud_storage_path(output_path: str, expected: str) -> None:
+    """Relative and already-qualified paths resolve to one canonical R2 path."""
+    assert SilverProcessor._get_cloud_storage_path(output_path, "landbruget-data") == expected
+
+
+def test_handle_pii_uses_bucket_qualified_relative_path() -> None:
+    """PII validation reads the same bucket/key that the R2 save operation writes."""
+    processor = object.__new__(SilverProcessor)
+    processor.storage_manager = SimpleNamespace(
+        storage_type="r2",
+        bucket_name="landbruget-data",
+    )
+    processor._shared_storage_access = MagicMock()
+    processor._shared_storage_access.query_parquet_native.return_value = "pii_validation_table"
+    processor.pii_validator = MagicMock()
+    processor.pii_validator.validate.return_value.is_valid = True
+
+    output_path = Path("gr_2025/20260912_131417/register.parquet")
+    assert processor._handle_pii_in_file(output_path, Path()) is None
+
+    processor._shared_storage_access.query_parquet_native.assert_called_once_with(
+        "landbruget-data/silver/gr_2025/20260912_131417/register.parquet",
+        "SELECT *",
+        "pii_validation_table",
+    )


### PR DESCRIPTION
## Summary
- qualify relative Silver/Bronze paths with the configured R2 bucket before native reads
- make schema and PII post-processing use the same bucket/key that the Drive storage manager writes
- preserve already-qualified `r2://`, `s3://`, and bucket-prefixed paths
- add regression coverage for path resolution and PII validation

## Verification
- `.venv/bin/python -m pytest backend/pipelines/drive_data_pipeline/tests/silver/test_processor_storage_paths.py backend/pipelines/drive_data_pipeline/tests/silver/test_fertiliser_transformer.py -q` (7 passed)
- Ruff check and format check passed

## Production evidence
The Fertiliser-only Drive run completed successfully for 237/237 files on `main` SHA `43fee427`, but logs showed `r2://gr_2025/...` during PII handling. This change maps that relative output to `<configured-bucket>/silver/gr_2025/...`.
