### PR TITLE
fix(nles5): load GKEA through storage access

### DIFF
--- a/backend/pipelines/unified_pipeline/src/tests/gold/test_nles5_fertilizer_parser.py
+++ b/backend/pipelines/unified_pipeline/src/tests/gold/test_nles5_fertilizer_parser.py
@@ -39,6 +39,21 @@ class _Storage:
         )
 
 
+class _MappedGkeaStorage(_Storage):
+    """Map a canonical cloud path to a local fixture for path-boundary tests."""
+
+    def __init__(self, connection: duckdb.DuckDBPyConnection, fixture_path: str):
+        super().__init__(connection)
+        self.fixture_path = fixture_path
+        self.created_paths: list[str] = []
+
+    def create_table_from_storage(self, table_name: str, path: str) -> None:
+        self.created_paths.append(path)
+        self.connection.execute(
+            f"CREATE TABLE {table_name} AS SELECT * FROM read_parquet('{self.fixture_path}')"
+        )
+
+
 def _loader(
     connection: duckdb.DuckDBPyConnection, storage: _Storage | None = None
 ) -> NLES5DataLoader:
@@ -126,6 +141,32 @@ def test_file_selection_prefers_final_pii_copy() -> None:
     ]
 
     assert NLES5DataLoader._prefer_final_gr_files(files) == [files[2]]
+
+
+def test_gkea_loader_uses_storage_for_bare_bucket_paths(tmp_path) -> None:
+    connection = duckdb.connect()
+    source_path = tmp_path / "GKEA2024_fixture.parquet"
+    connection.execute(
+        """
+        CREATE TABLE gkea_source AS
+        SELECT '01234567'::VARCHAR AS cvr_number,
+               'field-1'::VARCHAR AS marknummer,
+               12.5::DOUBLE AS faktisk_areal_ha,
+               'journal-1'::VARCHAR AS journal_nummer
+        """
+    )
+    connection.execute(f"COPY gkea_source TO '{source_path}' (FORMAT PARQUET)")
+    connection.execute("DROP TABLE gkea_source")
+
+    cloud_path = "landbruget-data/silver/fertiliser/run/GKEA2024_Markplan.parquet"
+    storage = _MappedGkeaStorage(connection, str(source_path))
+    loader = _loader(connection, storage)
+
+    assert loader._process_gkea_field_plan_data(cloud_path, "field_plan_data")
+    assert storage.created_paths == [cloud_path]
+    assert connection.execute(
+        "SELECT cvr_number, marknummer, areal FROM field_plan_data"
+    ).fetchall() == [("01234567", "field-1", 12.5)]
 
 
 def test_gr_year_prefers_directory_and_supports_two_digit_filename() -> None:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/data_loader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/data_loader.py
@@ -823,10 +823,12 @@ class NLES5DataLoader:
             gkea_year = int(year_match.group(1)) if year_match else 2024
 
             # First, load the data to check its structure
-            self.db.execute(f"""
-                CREATE OR REPLACE TABLE field_plan_temp AS
-                SELECT * FROM '{file_path}'
-            """)
+            # StorageAccess owns the cloud/local path boundary.  The paths
+            # returned by list_files are canonical bare bucket/key paths,
+            # which DuckDB would otherwise interpret as local files when the
+            # R2 scheme is omitted.
+            self.db.execute("DROP TABLE IF EXISTS field_plan_temp")
+            self.storage.create_table_from_storage("field_plan_temp", file_path)
 
             # Check the actual column names in the parquet file
             columns_info = self.db.execute("PRAGMA table_info(field_plan_temp)").fetchall()


### PR DESCRIPTION
## Summary
- load GKEA field-plan parquet through `StorageAccess` instead of handing bare bucket/key paths directly to DuckDB
- preserve replacement semantics for the temporary field-plan table
- add a regression test covering canonical R2-style paths

## Verification
- focused NLES5 fertilizer parser tests: 8 passed
- Ruff lint and format checks passed
- commit hooks passed

This fixes the observed failure where R2 contained GKEA files but NLES5 could not create `field_plan_data`.