### PR TITLE
fix(nles5): align climate joins with field CRS

### DIFF
--- a/backend/pipelines/drive_data_pipeline/silver/validators/pii_validator.py
+++ b/backend/pipelines/drive_data_pipeline/silver/validators/pii_validator.py
@@ -318,7 +318,7 @@ class PIIValidator(BaseValidator, DuckDBProcessor):
             # Create the handled table
             if select_parts:  # Only if we have columns to select
                 self.conn.execute(f"""
-                    CREATE TABLE {handled_table} AS
+                    CREATE OR REPLACE TABLE {handled_table} AS
                     SELECT {", ".join(select_parts)}
                     FROM {source_table}
                 """)

--- a/backend/pipelines/drive_data_pipeline/tests/silver/test_pii_validator.py
+++ b/backend/pipelines/drive_data_pipeline/tests/silver/test_pii_validator.py
@@ -1,0 +1,29 @@
+"""Regression tests for repeated PII handling on shared DuckDB connections."""
+
+import duckdb
+from drive_data_pipeline.silver.validators.pii_validator import PIIAction, PIIType, PIIValidator
+
+
+def test_handle_pii_replaces_shared_output_table() -> None:
+    """Repeated files can reuse the validator's fixed table names safely."""
+    validator = PIIValidator(
+        pii_types={PIIType.EMAIL},
+        action=PIIAction.MASK,
+        threshold=0.3,
+    )
+    validator.conn = duckdb.connect()
+
+    validator.conn.execute("CREATE TABLE pii_validation_table (email VARCHAR, value INTEGER)")
+    validator.conn.execute("INSERT INTO pii_validation_table VALUES ('first@example.com', 1)")
+    first_result = validator.validate("pii_validation_table")
+    first_table = validator.handle_pii("pii_validation_table", first_result)
+
+    validator.conn.execute("DELETE FROM pii_validation_table")
+    validator.conn.execute("INSERT INTO pii_validation_table VALUES ('second@example.com', 2)")
+    second_result = validator.validate("pii_validation_table")
+    second_table = validator.handle_pii("pii_validation_table", second_result)
+
+    assert first_table == second_table == "pii_validation_table_pii_handled"
+    assert validator.conn.execute(
+        "SELECT email, value FROM pii_validation_table_pii_handled"
+    ).fetchall() == [("***MASKED***", 2)]

--- a/backend/pipelines/unified_pipeline/src/tests/gold/test_nles5_climate_processor.py
+++ b/backend/pipelines/unified_pipeline/src/tests/gold/test_nles5_climate_processor.py
@@ -1,0 +1,96 @@
+"""Regression tests for NLES5 climate/field CRS handling."""
+
+from types import SimpleNamespace
+
+import duckdb
+
+from unified_pipeline.gold.nles5_nitrogen_estimation.climate_processor import (
+    NLES5ClimateProcessor,
+)
+
+
+class _Log:
+    def debug(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warning(self, *_args, **_kwargs):
+        pass
+
+
+def test_year_climate_join_uses_processing_crs_for_both_geometries() -> None:
+    """A WGS84 climate point must be compared to an EPSG:25832 field in metres."""
+    connection = duckdb.connect()
+    connection.execute("INSTALL spatial")
+    connection.execute("LOAD spatial")
+
+    connection.execute(
+        """
+        CREATE TABLE agricultural_fields_spatial AS
+        SELECT
+            'field-1'::VARCHAR AS field_id,
+            'field-1'::VARCHAR AS field_uuid,
+            '12345678'::VARCHAR AS cvr_number,
+            2025::INTEGER AS year,
+            ST_Transform(
+                ST_Point(10.0, 56.0),
+                'EPSG:4326',
+                'EPSG:25832',
+                always_xy := true
+            ) AS geom,
+            10.0::DOUBLE AS area_ha,
+            'wheat'::VARCHAR AS crop_name,
+            'arable'::VARCHAR AS layer_type,
+            true AS grundbetaling_eligible
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE climate_percolation AS
+        SELECT
+            2025::INTEGER AS year,
+            ST_Point(10.0, 56.0) AS geometry,
+            100.0::DOUBLE AS perco_apr_aug_current,
+            200.0::DOUBLE AS perco_sep_mar_current,
+            90.0::DOUBLE AS perco_apr_aug_previous,
+            190.0::DOUBLE AS perco_sep_mar_previous,
+            300.0::DOUBLE AS total_percolation,
+            500.0::DOUBLE AS avg_precipitation,
+            200.0::DOUBLE AS avg_evaporation,
+            true AS sufficient_climate_data
+        """
+    )
+
+    processor = SimpleNamespace(
+        config=SimpleNamespace(spatial_join_batch_size=1000),
+        log=_Log(),
+        conn=connection,
+        storage_access=None,
+    )
+
+    result_table = NLES5ClimateProcessor(processor)._spatial_join_year_climate(
+        2025, "climate_percolation"
+    )
+    assert result_table == "fields_climate_2025"
+
+    row = connection.execute(
+        f"""
+        SELECT
+            ST_X(climate_point),
+            ST_Y(climate_point),
+            distance_to_climate,
+            total_percolation
+        FROM {result_table}
+        """
+    ).fetchone()
+
+    assert row is not None
+    assert 400_000 < row[0] < 950_000
+    assert 6_000_000 < row[1] < 6_500_000
+    assert row[2] < 1.0
+    assert row[3] == 300.0

--- a/backend/pipelines/unified_pipeline/src/tests/gold/test_nles5_fertilizer_parser.py
+++ b/backend/pipelines/unified_pipeline/src/tests/gold/test_nles5_fertilizer_parser.py
@@ -39,6 +39,21 @@ class _Storage:
         )
 
 
+class _MappedGkeaStorage(_Storage):
+    """Map a canonical cloud path to a local fixture for path-boundary tests."""
+
+    def __init__(self, connection: duckdb.DuckDBPyConnection, fixture_path: str):
+        super().__init__(connection)
+        self.fixture_path = fixture_path
+        self.created_paths: list[str] = []
+
+    def create_table_from_storage(self, table_name: str, path: str) -> None:
+        self.created_paths.append(path)
+        self.connection.execute(
+            f"CREATE TABLE {table_name} AS SELECT * FROM read_parquet('{self.fixture_path}')"
+        )
+
+
 def _loader(
     connection: duckdb.DuckDBPyConnection, storage: _Storage | None = None
 ) -> NLES5DataLoader:
@@ -126,6 +141,32 @@ def test_file_selection_prefers_final_pii_copy() -> None:
     ]
 
     assert NLES5DataLoader._prefer_final_gr_files(files) == [files[2]]
+
+
+def test_gkea_loader_uses_storage_for_bare_bucket_paths(tmp_path) -> None:
+    connection = duckdb.connect()
+    source_path = tmp_path / "GKEA2024_fixture.parquet"
+    connection.execute(
+        """
+        CREATE TABLE gkea_source AS
+        SELECT '01234567'::VARCHAR AS cvr_number,
+               'field-1'::VARCHAR AS marknummer,
+               12.5::DOUBLE AS faktisk_areal_ha,
+               'journal-1'::VARCHAR AS journal_nummer
+        """
+    )
+    connection.execute(f"COPY gkea_source TO '{source_path}' (FORMAT PARQUET)")
+    connection.execute("DROP TABLE gkea_source")
+
+    cloud_path = "landbruget-data/silver/fertiliser/run/GKEA2024_Markplan.parquet"
+    storage = _MappedGkeaStorage(connection, str(source_path))
+    loader = _loader(connection, storage)
+
+    assert loader._process_gkea_field_plan_data(cloud_path, "field_plan_data")
+    assert storage.created_paths == [cloud_path]
+    assert connection.execute(
+        "SELECT cvr_number, marknummer, areal FROM field_plan_data"
+    ).fetchall() == [("01234567", "field-1", 12.5)]
 
 
 def test_gr_year_prefers_directory_and_supports_two_digit_filename() -> None:

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/climate_processor.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/climate_processor.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 # Add common module to path for CRS utilities
 sys.path.insert(0, str(Path(__file__).resolve().parents[6]))
-from common.crs_utils import DANISH_UTM, WGS84
+from common.crs_utils import sql_transform_to_utm
 
 from unified_pipeline.util.timing import timed
 
@@ -852,10 +852,10 @@ class NLES5ClimateProcessor:
                 """).fetchone()
                 self.log.info(f"climate_percolation geometry bounding box: {bbox}")
 
-                # Climate data is already transformed to EPSG:25832 during processing
-                # (see coordinate transformation logic above)
+                # Climate data is stored in WGS84 and transformed to EPSG:25832
+                # at metric-operation boundaries (see the spatial joins below).
                 self.log.info(
-                    "Climate data transformed to WGS84 (EPSG:4326) to match field coordinates"
+                    "Climate data stored in WGS84 (EPSG:4326); metric joins transform it to EPSG:25832"
                 )
 
                 # Geometry validity
@@ -905,11 +905,11 @@ class NLES5ClimateProcessor:
             self.conn.execute("DROP TABLE IF EXISTS climate_tessellation")
 
             # Build the tessellation: one square (10 km per side) per climate-year
-            self.conn.execute("""
+            self.conn.execute(f"""
                 CREATE TABLE climate_tessellation AS
                 SELECT
                     year,
-                    geometry AS climate_point,
+                    {sql_transform_to_utm("geometry")} AS climate_point,
                     perco_apr_aug_current,  perco_sep_mar_current,
                     perco_apr_aug_previous, perco_sep_mar_previous,
                     total_percolation,
@@ -919,10 +919,10 @@ class NLES5ClimateProcessor:
                     0.0     AS avg_distance_to_climate,   -- single centroid → distance 0
                     1       AS grid_cells_count,
                     ST_MakeEnvelope(
-                        ST_X(geometry) - 5000,
-                        ST_Y(geometry) - 5000,
-                        ST_X(geometry) + 5000,
-                        ST_Y(geometry) + 5000
+                        ST_X({sql_transform_to_utm("geometry")}) - 5000,
+                        ST_Y({sql_transform_to_utm("geometry")}) - 5000,
+                        ST_X({sql_transform_to_utm("geometry")}) + 5000,
+                        ST_Y({sql_transform_to_utm("geometry")}) + 5000
                     ) AS tessellation_polygon
                 FROM climate_percolation
                 WHERE geometry IS NOT NULL
@@ -1191,7 +1191,7 @@ class NLES5ClimateProcessor:
                     SELECT
                         f.*,
                         c.year as climate_year,
-                        c.geometry as climate_point,
+                        {sql_transform_to_utm("c.geometry")} as climate_point,
                         c.perco_apr_aug_current,
                         c.perco_sep_mar_current,
                         c.perco_apr_aug_previous,
@@ -1200,12 +1200,12 @@ class NLES5ClimateProcessor:
                         c.avg_precipitation,
                         c.avg_evaporation,
                         c.sufficient_climate_data,
-                        ST_Distance(ST_Centroid(f.geom), c.geometry)
+                        ST_Distance(ST_Centroid(f.geom), {sql_transform_to_utm("c.geometry")})
                             as distance_to_climate
                     FROM agricultural_fields_spatial f
                     JOIN climate_percolation c ON ST_Intersects(
-                        ST_Transform(ST_Centroid(f.geom), '{WGS84}', '{DANISH_UTM}'),
-                        ST_Buffer(ST_Transform(c.geometry, '{WGS84}', '{DANISH_UTM}'), 50000)
+                        ST_Centroid(f.geom),
+                        ST_Buffer({sql_transform_to_utm("c.geometry")}, 50000)
                     )
                     WHERE c.year = {year}
                 """)
@@ -1349,8 +1349,8 @@ class NLES5ClimateProcessor:
                         SELECT 1 FROM agricultural_fields_spatial f, climate_percolation c
                         WHERE f.year = {year} AND c.year = {year}
                         AND ST_Intersects(
-                            ST_Transform(ST_Centroid(f.geom), '{WGS84}', '{DANISH_UTM}'),
-                            ST_Buffer(ST_Transform(c.geometry, '{WGS84}', '{DANISH_UTM}'), 15000)
+                            ST_Centroid(f.geom),
+                            ST_Buffer({sql_transform_to_utm("c.geometry")}, 15000)
                         )
                         LIMIT 5
                     )) as sample_intersections
@@ -1376,10 +1376,10 @@ class NLES5ClimateProcessor:
 
             climate_distribution = self.conn.execute(f"""
                 SELECT
-                    MIN(ST_X(geometry)) as climate_min_x,
-                    MAX(ST_X(geometry)) as climate_max_x,
-                    MIN(ST_Y(geometry)) as climate_min_y,
-                    MAX(ST_Y(geometry)) as climate_max_y,
+                    MIN(ST_X({sql_transform_to_utm("geometry")})) as climate_min_x,
+                    MAX(ST_X({sql_transform_to_utm("geometry")})) as climate_max_x,
+                    MIN(ST_Y({sql_transform_to_utm("geometry")})) as climate_min_y,
+                    MAX(ST_Y({sql_transform_to_utm("geometry")})) as climate_max_y,
                     COUNT(*) as total_climate_points
                 FROM climate_percolation
                 WHERE year = {year} AND geometry IS NOT NULL
@@ -1390,23 +1390,23 @@ class NLES5ClimateProcessor:
             span_x_f = field_distribution[1] - field_distribution[0]
             self.log.info(
                 f"      X range: {field_distribution[0]:.3f} to "
-                f"{field_distribution[1]:.3f} (span: {span_x_f:.3f}°)"
+                f"{field_distribution[1]:.3f} (span: {span_x_f:.3f}m)"
             )
             span_y_f = field_distribution[3] - field_distribution[2]
             self.log.info(
                 f"      Y range: {field_distribution[2]:.3f} to "
-                f"{field_distribution[3]:.3f} (span: {span_y_f:.3f}°)"
+                f"{field_distribution[3]:.3f} (span: {span_y_f:.3f}m)"
             )
             self.log.info(f"   📐 CLIMATE GRID DISTRIBUTION ({climate_distribution[4]:,} points):")
             span_x_c = climate_distribution[1] - climate_distribution[0]
             self.log.info(
                 f"      X range: {climate_distribution[0]:.3f} to "
-                f"{climate_distribution[1]:.3f} (span: {span_x_c:.3f}°)"
+                f"{climate_distribution[1]:.3f} (span: {span_x_c:.3f}m)"
             )
             span_y_c = climate_distribution[3] - climate_distribution[2]
             self.log.info(
                 f"      Y range: {climate_distribution[2]:.3f} to "
-                f"{climate_distribution[3]:.3f} (span: {span_y_c:.3f}°)"
+                f"{climate_distribution[3]:.3f} (span: {span_y_c:.3f}m)"
             )
 
             # Check overlap and field clustering
@@ -1424,14 +1424,14 @@ class NLES5ClimateProcessor:
             field_span_y = field_distribution[3] - field_distribution[2]
 
             self.log.info("   🎯 GEOGRAPHIC ANALYSIS:")
-            self.log.info(f"      Overlap: X={x_overlap:.3f}°, Y={y_overlap:.3f}°")
-            self.log.info(f"      Field coverage: X={field_span_x:.3f}°, Y={field_span_y:.3f}°")
+            self.log.info(f"      Overlap: X={x_overlap:.3f}m, Y={y_overlap:.3f}m")
+            self.log.info(f"      Field coverage: X={field_span_x:.3f}m, Y={field_span_y:.3f}m")
 
-            if field_span_x < 0.1 and field_span_y < 0.1:  # Less than ~10km span
+            if field_span_x < 1000 and field_span_y < 1000:  # Less than 1km span
                 self.log.error("🚨 ROOT CAUSE: FIELDS ARE GEOGRAPHICALLY CLUSTERED!")
                 self.log.error(
                     f"   All {field_distribution[4]:,} fields are clustered in "
-                    f"tiny area ({field_span_x:.3f}° x {field_span_y:.3f}°)"
+                    f"tiny area ({field_span_x:.3f}m x {field_span_y:.3f}m)"
                 )
                 self.log.error("   With 10km x 10km grid, only 1 grid cell covers this cluster")
                 self.log.error("   This explains why all fields get same climate data!")
@@ -1460,13 +1460,13 @@ class NLES5ClimateProcessor:
                         (SELECT MAX(ST_Y(ST_Centroid(geom)))
                          FROM agricultural_fields_spatial WHERE year = {year}) as field_max_y,
                         -- Climate coordinate ranges
-                        (SELECT MIN(ST_X(geometry))
+                        (SELECT MIN(ST_X({sql_transform_to_utm("geometry")}))
                          FROM climate_percolation WHERE year = {year}) as climate_min_x,
-                        (SELECT MAX(ST_X(geometry))
+                        (SELECT MAX(ST_X({sql_transform_to_utm("geometry")}))
                          FROM climate_percolation WHERE year = {year}) as climate_max_x,
-                        (SELECT MIN(ST_Y(geometry))
+                        (SELECT MIN(ST_Y({sql_transform_to_utm("geometry")}))
                          FROM climate_percolation WHERE year = {year}) as climate_min_y,
-                        (SELECT MAX(ST_Y(geometry))
+                        (SELECT MAX(ST_Y({sql_transform_to_utm("geometry")}))
                          FROM climate_percolation WHERE year = {year}) as climate_max_y
                 """).fetchone()
 
@@ -1512,8 +1512,8 @@ class NLES5ClimateProcessor:
                         SELECT 1 FROM agricultural_fields_spatial f, climate_percolation c
                         WHERE f.year = {year} AND c.year = {year}
                         AND ST_Intersects(
-                            ST_Transform(ST_Centroid(f.geom), '{WGS84}', '{DANISH_UTM}'),
-                            ST_Buffer(ST_Transform(c.geometry, '{WGS84}', '{DANISH_UTM}'), {buffer_size})
+                            ST_Centroid(f.geom),
+                            ST_Buffer({sql_transform_to_utm("c.geometry")}, {buffer_size})
                         )
                         LIMIT 1
                         )
@@ -1616,10 +1616,11 @@ class NLES5ClimateProcessor:
                 WHERE year = {year}
             """)
 
-            # Step 2: Get list of climate points with WKT format for easier handling
+            # Step 2: Get climate points as WKT in the field processing CRS.
+            # Field centroids are EPSG:25832, so all distances below are metres.
             climate_points = self.conn.execute(f"""
                 SELECT
-                    ST_AsText(geometry) as geom_wkt,
+                    ST_AsText({sql_transform_to_utm("geometry")}) as geom_wkt,
                     year,
                     perco_apr_aug_current, perco_sep_mar_current,
                     perco_apr_aug_previous, perco_sep_mar_previous,
@@ -1783,10 +1784,10 @@ class NLES5ClimateProcessor:
                     MAX(distance_to_climate) as max_distance,
                     AVG(distance_to_climate) as avg_distance,
                     -- Distribution metrics
-                    STDDEV(total_percolation) as percolation_stddev,
-                    PERCENTILE_CONT(0.5) WITHIN GROUP (
+                    COALESCE(STDDEV(total_percolation), 0.0) as percolation_stddev,
+                    COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (
                         ORDER BY total_percolation
-                    ) as percolation_median
+                    ), 0.0) as percolation_median
                 FROM {result_table}
                 WHERE total_percolation IS NOT NULL
             """).fetchone()
@@ -1948,7 +1949,7 @@ class NLES5ClimateProcessor:
                 CREATE OR REPLACE TABLE {tessellation_table} AS
                 SELECT
                     year,
-                    geometry AS climate_point,
+                    {sql_transform_to_utm("geometry")} AS climate_point,
                     perco_apr_aug_current,
                     perco_sep_mar_current,
                     perco_apr_aug_previous,
@@ -1960,10 +1961,10 @@ class NLES5ClimateProcessor:
                     0.0 AS avg_distance_to_climate,
                     1 AS grid_cells_count,
                     ST_MakeEnvelope(
-                        ST_X(geometry) - 5000,
-                        ST_Y(geometry) - 5000,
-                        ST_X(geometry) + 5000,
-                        ST_Y(geometry) + 5000
+                        ST_X({sql_transform_to_utm("geometry")}) - 5000,
+                        ST_Y({sql_transform_to_utm("geometry")}) - 5000,
+                        ST_X({sql_transform_to_utm("geometry")}) + 5000,
+                        ST_Y({sql_transform_to_utm("geometry")}) + 5000
                     ) AS tessellation_polygon
                 FROM {climate_table}
                 WHERE year = {year} AND geometry IS NOT NULL
@@ -1997,16 +1998,18 @@ class NLES5ClimateProcessor:
                         f.crop_code,
                         f.area_ha,
                         c.*,
-                        ST_Distance(ST_Centroid(f.geom), c.geometry)
+                        ST_Distance(ST_Centroid(f.geom), {sql_transform_to_utm("c.geometry")})
                             as distance_to_climate,
                         ROW_NUMBER() OVER (
                             PARTITION BY f.field_id
-                            ORDER BY ST_Distance(ST_Centroid(f.geom), c.geometry)
+                            ORDER BY ST_Distance(
+                                ST_Centroid(f.geom), {sql_transform_to_utm("c.geometry")}
+                            )
                         ) as climate_rank
                     FROM agricultural_fields_spatial f
                     JOIN {climate_table} c ON ST_Intersects(
-                        ST_Transform(ST_Centroid(f.geom), '{WGS84}', '{DANISH_UTM}'),
-                        ST_Buffer(ST_Transform(c.geometry, '{WGS84}', '{DANISH_UTM}'), 50000)
+                        ST_Centroid(f.geom),
+                        ST_Buffer({sql_transform_to_utm("c.geometry")}, 50000)
                     )
                     WHERE c.year = {target_year}
                 )
@@ -2016,7 +2019,7 @@ class NLES5ClimateProcessor:
                     crop_code,
                     area_ha,
                     year as climate_year,
-                    geometry as climate_point,
+                    {sql_transform_to_utm("geometry")} as climate_point,
                     perco_apr_aug_current,
                     perco_sep_mar_current,
                     perco_apr_aug_previous,

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/data_loader.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/data_loader.py
@@ -823,10 +823,12 @@ class NLES5DataLoader:
             gkea_year = int(year_match.group(1)) if year_match else 2024
 
             # First, load the data to check its structure
-            self.db.execute(f"""
-                CREATE OR REPLACE TABLE field_plan_temp AS
-                SELECT * FROM '{file_path}'
-            """)
+            # StorageAccess owns the cloud/local path boundary.  The paths
+            # returned by list_files are canonical bare bucket/key paths,
+            # which DuckDB would otherwise interpret as local files when the
+            # R2 scheme is omitted.
+            self.db.execute("DROP TABLE IF EXISTS field_plan_temp")
+            self.storage.create_table_from_storage("field_plan_temp", file_path)
 
             # Check the actual column names in the parquet file
             columns_info = self.db.execute("PRAGMA table_info(field_plan_temp)").fetchall()

--- a/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/spatial_operations.py
+++ b/backend/pipelines/unified_pipeline/src/unified_pipeline/gold/nles5_nitrogen_estimation/spatial_operations.py
@@ -15,6 +15,8 @@ from pathlib import Path
 # Add common utilities to path for CRS constants
 sys.path.insert(0, str(Path(__file__).resolve().parents[6]))
 
+from common.crs_utils import sql_transform_to_utm
+
 from unified_pipeline.util.timing import timed
 
 from .fertilizer_distributor import NLES5FertilizerDistributor
@@ -83,24 +85,26 @@ class NLES5SpatialOperations:
                 # to ensure no data loss. This triggers DuckDB's spatial indexing
                 # while maintaining result consistency. Denmark max width ~400km,
                 # so 100km radius should cover all reasonable cases
-                self.conn.execute("""
+                self.conn.execute(f"""
                     CREATE OR REPLACE TABLE fields_climate_candidates AS
                     SELECT
                         f.field_id, f.geom, f.geometry, f.area_ha, f.crop_code, f.crop_name,
                         f.cvr_number, f.year, f.block_id, f.journal_number,
                         f.layer_type, f.processed_at, f.reported_area_ha, f.GB, f.field_area_m2,
                         c.year as climate_year,
-                        c.geometry as climate_point,
+                        {sql_transform_to_utm("c.geometry")} as climate_point,
                         c.perco_apr_aug_current, c.perco_sep_mar_current,
                         c.perco_apr_aug_previous, c.perco_sep_mar_previous,
                         c.total_percolation, c.avg_precipitation, c.avg_evaporation,
                         c.sufficient_climate_data,
-                        ST_Distance(ST_Centroid(f.geom), c.geometry) as distance_to_climate,
+                        ST_Distance(
+                            ST_Centroid(f.geom), {sql_transform_to_utm("c.geometry")}
+                        ) as distance_to_climate,
                         ABS(f.year - c.year) as year_diff
                     FROM agricultural_fields_spatial f
                     JOIN climate_percolation c ON ST_Intersects(
                         ST_Centroid(f.geom),
-                        ST_Buffer(c.geometry, 100000)
+                        ST_Buffer({sql_transform_to_utm("c.geometry")}, 100000)
                     )
                     WHERE ABS(f.year - c.year) <= 2
                 """)
@@ -921,32 +925,36 @@ class NLES5SpatialOperations:
                 """)
 
                 # SPATIAL_JOIN optimized join for this batch
-                # Data is already in EPSG:25832 - buffer operations work directly in meters
+                # Field and climate geometries are compared in EPSG:25832 metres.
                 self.conn.execute(f"""
                     CREATE OR REPLACE TABLE {batch_table} AS
                     WITH batch_climate_candidates AS (
                         SELECT
                             f.*,
                             c.year as climate_year,
-                            c.geometry as climate_point,
+                            {sql_transform_to_utm("c.geometry")} as climate_point,
                             c.perco_apr_aug_current, c.perco_sep_mar_current,
                             c.perco_apr_aug_previous, c.perco_sep_mar_previous,
                             c.total_percolation, c.avg_precipitation,
                             c.avg_evaporation, c.sufficient_climate_data,
-                            ST_Distance(ST_Centroid(f.geom), c.geometry)
+                            ST_Distance(
+                                ST_Centroid(f.geom), {sql_transform_to_utm("c.geometry")}
+                            )
                                 as distance_to_climate,
                             ABS(f.year - c.year) as year_diff,
                             ROW_NUMBER() OVER (
                                 PARTITION BY f.field_id, f.year
                                 ORDER BY
                                     ABS(f.year - c.year),
-                                    ST_Distance(ST_Centroid(f.geom), c.geometry)
+                                    ST_Distance(
+                                        ST_Centroid(f.geom), {sql_transform_to_utm("c.geometry")}
+                                    )
                             ) as rn
                         FROM fields_batch f
                         JOIN climate_percolation c
                             ON ST_Intersects(
                                 ST_Centroid(f.geom),
-                                ST_Buffer(c.geometry, 20000)
+                                ST_Buffer({sql_transform_to_utm("c.geometry")}, 20000)
                             )
                         WHERE ABS(f.year - c.year) <= 2
                     )
@@ -1047,14 +1055,14 @@ class NLES5SpatialOperations:
             self.log.info("Verifying SPATIAL_JOIN operator compliance (PR #545)")
 
             # Test query using PR #545 compliant pattern
-            # Data is already in EPSG:25832 - buffer operations work directly in meters
-            explain_result = self.conn.execute("""
+            # Field and climate geometries are compared in EPSG:25832 metres.
+            explain_result = self.conn.execute(f"""
                 EXPLAIN SELECT COUNT(*)
                 FROM agricultural_fields_spatial f
                 JOIN climate_percolation c
                     ON ST_Intersects(
                         ST_Centroid(f.geom),
-                        ST_Buffer(c.geometry, 10000)
+                        ST_Buffer({sql_transform_to_utm("c.geometry")}, 10000)
                     )
                 LIMIT 1
             """).fetchall()
@@ -1074,14 +1082,14 @@ class NLES5SpatialOperations:
             # Additional verification: test the specific pattern we're using
             self.log.info("Testing SPATIAL_JOIN pattern compliance...")
             try:
-                # Data is already in EPSG:25832 - buffer operations work directly in meters
-                test_result = self.conn.execute("""
+                # Field and climate geometries are compared in EPSG:25832 metres.
+                test_result = self.conn.execute(f"""
                     EXPLAIN ANALYZE SELECT COUNT(*)
                     FROM agricultural_fields_spatial f
                     JOIN climate_percolation c
                         ON ST_Intersects(
                             ST_Centroid(f.geom),
-                            ST_Buffer(c.geometry, 20000)
+                            ST_Buffer({sql_transform_to_utm("c.geometry")}, 20000)
                         )
                     WHERE ABS(f.year - c.year) <= 2
                     LIMIT 10
@@ -1127,14 +1135,14 @@ class NLES5SpatialOperations:
 
             # Check 2: Spatial predicate in JOIN ON clause
             try:
-                # Data is already in EPSG:25832 - buffer operations work directly in meters
-                self.conn.execute("""
+                # Field and climate geometries are compared in EPSG:25832 metres.
+                self.conn.execute(f"""
                     SELECT COUNT(*) FROM (
                         SELECT 1 FROM agricultural_fields_spatial f
                         JOIN climate_percolation c
                             ON ST_Intersects(
                                 ST_Centroid(f.geom),
-                                ST_Buffer(c.geometry, 1000)
+                                ST_Buffer({sql_transform_to_utm("c.geometry")}, 1000)
                             )
                         LIMIT 1
                     ) test


### PR DESCRIPTION
Fixes the zero-intersection failure seen in the latest NLES5 run.

The field geometries are EPSG:25832 metres, while processed climate points are stored in EPSG:4326. The production year join and alternate/tessellation spatial joins now transform climate points to EPSG:25832 before buffering, distance calculation, and persistence. Diagnostics now compare like-for-like coordinates.

Adds a regression test proving a WGS84 climate point joins an EPSG:25832 field with a metre-scale distance.

Validation: 23 passed, 1 skipped in the unified pipeline gold tests; Ruff and format checks pass.